### PR TITLE
perf: implement lazy loading for below-the-fold images

### DIFF
--- a/src/pages/contact/ContactPage.jsx
+++ b/src/pages/contact/ContactPage.jsx
@@ -487,7 +487,7 @@ export default function ContactPage({ onBack }) {
           borderRadius: 'var(--r3)', position: 'relative',
         }}>
           <div className="corner-tl"/><div className="corner-br"/>
-          <img src={glbajajLogo} alt="GL Bajaj" style={{
+          <img src={glbajajLogo} alt="GL Bajaj" loading="lazy" style={{
             height: 38, margin: '0 auto 12px',
             background: 'rgba(255,255,255,.88)',
             padding: '3px 8px', borderRadius: 6,

--- a/src/pages/team/TeamMemberCard.jsx
+++ b/src/pages/team/TeamMemberCard.jsx
@@ -33,6 +33,7 @@ export default function TeamMemberCard({ member, onClick, extraClass = '', style
           src={imgError ? 'https://api.dicebear.com/7.x/initials/svg?seed=' + encodeURIComponent(member.name) + '&backgroundColor=CC1111&textColor=ffffff' : member.photo} 
           alt={member.name} 
           className="team-card-photo"
+          loading="lazy"
           onError={() => setImgError(true)}
         />
       </div>

--- a/src/pages/team/TeamMemberModal.jsx
+++ b/src/pages/team/TeamMemberModal.jsx
@@ -66,7 +66,7 @@ function ModalContent({ member, onClose }) {
         <button className="modal-close" onClick={onClose} aria-label="Close">✕</button>
 
         {/* Photo */}
-        <img src={member.photo} alt={member.name} className="modal-photo" />
+        <img src={member.photo} alt={member.name} className="modal-photo" loading="lazy" />
 
         {/* Name & Role */}
         <div className="modal-name">{member.name}</div>

--- a/src/pages/team/TeamPage.jsx
+++ b/src/pages/team/TeamPage.jsx
@@ -49,6 +49,7 @@ function MemberCard({ member, idx, onClick }) {
         src={imgError ? 'https://api.dicebear.com/7.x/initials/svg?seed=' + encodeURIComponent(member.name) + '&backgroundColor=CC1111&textColor=ffffff' : member.photo} 
         alt={member.name} 
         className="team-card-photo"
+        loading="lazy"
         onError={() => setImgError(true)}
       />
       </div>

--- a/src/pages/team/TeamSection.jsx
+++ b/src/pages/team/TeamSection.jsx
@@ -41,7 +41,7 @@ function MemberCard({ member, idx, onClick }) {
       onKeyDown={e => { if (e.key === 'Enter' || e.key === ' ') click(); }}
     >
       <div className="team-card-photo-wrap">
-        <img src={member.photo} alt={member.name} className="team-card-photo" />
+        <img src={member.photo} alt={member.name} className="team-card-photo" loading="lazy" />
       </div>
       <div className="team-card-name">{member.name}</div>
       <div className="team-card-role">{member.role}</div>

--- a/src/shared/Footer.jsx
+++ b/src/shared/Footer.jsx
@@ -10,10 +10,10 @@ export default function Footer({ onAdmin }) {
         <div className="ns-footer-inner">
           <div className="ns-footer-divider"/>
           <div className="ns-footer-logos">
-            <img src={BRAND_LOGO_ICON} alt="NexaSphere" className="ns-footer-logo-ns ns-footer-logo-mobile"/>
-            <img src={BRAND_LOGO_FULL} alt="NexaSphere" className="ns-nav-logo-ns ns-nav-logo-icon"/>
+            <img src={BRAND_LOGO_ICON} alt="NexaSphere" className="ns-footer-logo-ns ns-footer-logo-mobile" loading="lazy"/>
+            <img src={BRAND_LOGO_FULL} alt="NexaSphere" className="ns-nav-logo-ns ns-nav-logo-icon" loading="lazy"/>
             <div style={{width:1,height:24,background:'var(--bdr2)'}}/>
-            <img src={GL_BAJAJ_LOGO} alt="GL Bajaj" className="ns-footer-logo-gl"/>
+            <img src={GL_BAJAJ_LOGO} alt="GL Bajaj" className="ns-footer-logo-gl" loading="lazy"/>
           </div>
           <p className="ns-footer-text">© {new Date().getFullYear()} <span>NexaSphere</span> — GL Bajaj Group of Institutions, Mathura</p>
           <p className="ns-footer-text">


### PR DESCRIPTION
Closes #8

## Summary
Implements native HTML lazy loading (`loading="lazy"`) for all below-the-fold images to improve initial page load performance.

## Changes
- `TeamMemberCard.jsx` — lazy load member card photo
- `TeamSection.jsx` — lazy load member card photos in the home section
- `TeamPage.jsx` — lazy load member card photos on the dedicated team page
- `TeamMemberModal.jsx` — lazy load modal profile photo (only renders on user click)
- `Footer.jsx` — lazy load all three logo images (NexaSphere icon, NexaSphere full, GL Bajaj)
- `ContactPage.jsx` — lazy load GL Bajaj logo in the address card at the bottom

## What was NOT changed
- `HeroSection.jsx` — above the fold, must load eagerly
- `CinematicOpening.jsx` — critical first paint asset
- `Navbar.jsx` — logo is above the fold

## Testing
- ✅ No React warnings or errors
- ✅ Vite build passes (2517 modules transformed)
- ✅ All existing styling and functionality preserved
- ✅ Only relevant files modified
