### PR TITLE
fix: hide default cursor overlapping custom cursor

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -163,3 +163,6 @@ button, a { touch-action: manipulation; -webkit-tap-highlight-color: transparent
   #back-to-top { bottom: 18px; left: 18px; }
 }
 
+button, a, input, select, [role="button"] {
+    cursor: none !important;
+}


### PR DESCRIPTION
### Description
This PR fixes the UX bug in which the default cursor would appear above the custom red circle cursor when hovering over buttons.

### What was changed
* Added global CSS rules in `globals.css` such that: `cursor: none !important` on `button`, `a`, `input`, `select`, and elements with `role="button"`.

Closes #14