### PR TITLE
🐛 fix: resolve UI elements overlapping and misalignment on multiple pages

### DIFF
--- a/src/pages/contact/ContactPage.css
+++ b/src/pages/contact/ContactPage.css
@@ -216,3 +216,27 @@
   .message-cta-box { padding: 24px 18px; }
   .contact-card { padding: 24px 18px 22px; }
 }
+
+/* ===== FIX #19: Contact page mobile fixes ===== */
+@media (max-width: 640px) {
+  .contact-hero {
+    padding: 48px 16px 36px !important;
+  }
+
+  .map-container {
+    aspect-ratio: 4/3 !important;
+  }
+
+  .message-cta-box {
+    padding: 20px 14px !important;
+  }
+
+  .name-input {
+    font-size: 1rem !important; /* prevents iOS zoom on focus */
+  }
+
+  .footer-info-box {
+    padding: 18px 14px !important;
+    margin-top: 36px !important;
+  }
+}

--- a/src/pages/home/HeroSection.css
+++ b/src/pages/home/HeroSection.css
@@ -235,3 +235,30 @@
   inset: 0;
   background-image: repeating-linear-gradient(0deg, transparent, transparent 2px, rgba(204, 17, 17, 0.005) 2px, rgba(204, 17, 17, 0.005) 4px);
 }
+/* ===== FIX #19: Hero section mobile fixes ===== */
+@media (max-width: 768px) {
+  .stats-bar {
+    max-width: 100% !important;
+    margin: 28px 16px 0 !important;
+  }
+
+  .scroll-indicator {
+    bottom: 8px !important;
+  }
+}
+
+@media (max-width: 480px) {
+  .hero-logo-wrap {
+    width: 200px !important;
+    height: 200px !important;
+  }
+
+  .hero-logo-img {
+    width: 160px !important;
+    height: 160px !important;
+  }
+
+  .data-streams {
+    display: none !important; /* hide on tiny screens to prevent layout shift */
+  }
+}

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -775,3 +775,194 @@
   .ns-nav-logo-full { display: block; }
 }
 [data-theme="light"] .ns-nav-logo-full { filter: drop-shadow(0 0 6px rgba(230,57,70,0.2)); }
+/* ===== FIX #19: UI Overlapping & Misalignment ===== */
+
+/* Mobile navbar top row - prevent logo/brand/toggle overlap */
+.ns-mobile-top {
+  display: flex !important;
+  align-items: center !important;
+  justify-content: space-between !important;
+  width: 100% !important;
+  padding: 0 14px 5px !important;
+  gap: 8px !important;
+  flex-wrap: nowrap !important;
+  overflow: hidden !important;
+}
+
+.ns-mobile-brand {
+  flex: 1 !important;
+  text-align: center !important;
+  min-width: 0 !important;
+  overflow: hidden !important;
+  text-overflow: ellipsis !important;
+  white-space: nowrap !important;
+}
+
+.ns-mobile-logo-ns {
+  flex-shrink: 0 !important;
+}
+
+.ns-theme-toggle {
+  flex-shrink: 0 !important;
+}
+
+/* Mobile tabs - prevent overflow clipping */
+.ns-mobile-tabs {
+  display: flex !important;
+  overflow-x: auto !important;
+  flex-wrap: nowrap !important;
+  width: 100% !important;
+  padding: 0 4px 2px !important;
+  gap: 0 !important;
+  -webkit-overflow-scrolling: touch !important;
+}
+
+/* Desktop navbar container grid fix */
+@media (max-width: 900px) {
+  .ns-navbar .container {
+    grid-template-columns: auto 1fr auto !important;
+    gap: 8px !important;
+  }
+
+  .ns-nav-tabs {
+    gap: 0 !important;
+    overflow-x: auto !important;
+    scrollbar-width: none !important;
+  }
+
+  .ns-nav-tabs::-webkit-scrollbar {
+    display: none !important;
+  }
+
+  .ns-nav-tab {
+    padding: 8px 10px !important;
+    font-size: 0.78rem !important;
+  }
+}
+
+/* Hero section - prevent CTA button overlap on small screens */
+@media (max-width: 480px) {
+  .hero-buttons-row {
+    flex-direction: column !important;
+    align-items: center !important;
+    width: 100% !important;
+  }
+
+  .hero-buttons-row .btn {
+    width: 100% !important;
+    max-width: 280px !important;
+    justify-content: center !important;
+  }
+
+  .apply-container {
+    padding: 12px 16px !important;
+    max-width: 100% !important;
+  }
+
+  .hero-content {
+    padding: 0 16px 80px !important;
+  }
+
+  .hero-title-text {
+    font-size: clamp(2rem, 8vw, 3.5rem) !important;
+    letter-spacing: 0.06em !important;
+  }
+
+  .hero-tagline {
+    font-size: 0.75rem !important;
+    letter-spacing: 0.1em !important;
+    word-break: break-word !important;
+  }
+}
+
+/* Stats bar - prevent overflow on tiny screens */
+@media (max-width: 400px) {
+  .stats-bar {
+    flex-wrap: wrap !important;
+    border-radius: 12px !important;
+  }
+
+  .stats-item {
+    flex: 1 1 45% !important;
+    min-width: 0 !important;
+  }
+}
+
+/* Activity grid - prevent card overflow */
+@media (max-width: 640px) {
+  .activity-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .activity-card {
+    overflow: hidden !important;
+    width: 100% !important;
+  }
+}
+
+/* Team grid - prevent card overflow on mobile */
+@media (max-width: 480px) {
+  .team-grid {
+    grid-template-columns: repeat(2, 1fr) !important;
+    gap: 10px !important;
+  }
+}
+
+/* Timeline - already has mobile fix but ensure no overflow */
+@media (max-width: 640px) {
+  .timeline-card {
+    width: 100% !important;
+    overflow: hidden !important;
+  }
+}
+
+/* Contact cards - fix grid overflow */
+@media (max-width: 480px) {
+  .contact-cards-grid {
+    grid-template-columns: 1fr !important;
+  }
+
+  .contact-card {
+    padding: 20px 16px !important;
+  }
+
+  .contact-card-value {
+    word-break: break-word !important;
+    overflow-wrap: anywhere !important;
+  }
+}
+
+/* Modal - fix overlap on very small screens */
+@media (max-width: 380px) {
+  .modal-box {
+    padding: 22px 14px !important;
+    max-height: 95vh !important;
+  }
+
+  .modal-social {
+    gap: 6px !important;
+  }
+
+  .modal-social-btn {
+    padding: 6px 10px !important;
+    font-size: 0.68rem !important;
+  }
+}
+
+/* Footer logos - prevent overlap */
+.ns-footer-inner {
+  overflow: hidden !important;
+  width: 100% !important;
+}
+
+/* General container safety */
+.container {
+  max-width: 1240px !important;
+  overflow: visible !important;
+}
+
+@media (max-width: 768px) {
+  body {
+    overflow-x: hidden !important;
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,5 +1,9 @@
 @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700;900&family=Rajdhani:wght@300;400;500;600;700&family=Space+Mono:wght@400;700&family=Inter:wght@400;500;600&display=swap');
 
+/* ===== FIX: Box sizing global reset ===== */
+*, *::before, *::after {
+  box-sizing: border-box;
+}
 html { 
   scroll-behavior: smooth; 
   -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
## 🐛 Bug Fix — UI Elements Overlapping / Misaligned on Multiple Pages
Closes #19

---

## 📋 Problem
Several UI components across NexaSphere were visually broken — elements 
overlapping each other or appearing misaligned, especially on smaller 
screen sizes (375px–768px).

| Page / Section | Issue Fixed |
|---|---|
| Navbar (Mobile) | Logo, brand name, theme toggle overlapping |
| Navbar (Desktop) | Nav tabs overflowing on medium screens |
| Hero Section | CTA buttons stacking/overlapping on small screens |
| Activity Cards | Cards overflowing containers on mobile |
| Team Grid | Cards misaligned on small screens |
| Contact Page | Cards and input fields overflowing |
| Modal | Content clipping on very small screens (<380px) |
| Footer | Logos and text misaligned on mobile |

---

## ✅ Changes Made

### `src/styles/globals.css`
- Added global `box-sizing: border-box` reset to prevent width overflow

### `src/styles/components.css`
- Fixed `.ns-mobile-top` — flex layout so logo/brand/toggle never overlap
- Fixed `.ns-mobile-tabs` — proper scroll behavior without clipping
- Fixed desktop navbar grid at <900px breakpoint
- Fixed hero buttons stacking correctly on <480px
- Fixed activity grid to single column on <640px
- Fixed team grid to 2-column on <480px
- Fixed contact cards to single column on <480px
- Fixed modal padding and social buttons on <380px
- Added `overflow-x: hidden` on body for mobile

### `src/pages/contact/ContactPage.css`
- Fixed contact hero padding on mobile
- Fixed map aspect ratio on small screens
- Fixed input `font-size: 1rem` to prevent iOS zoom bug

### `src/pages/home/HeroSection.css`
- Fixed stats bar width on mobile
- Fixed hero logo size on very small screens
- Hidden data streams on tiny screens to prevent layout shift

---

## 📸 Screenshots

### Before

<img width="959" height="449" alt="Screenshot 2026-05-17 115202" src="https://github.com/user-attachments/assets/21860958-ded7-4982-bc0b-8f28a780954d" />


### After  

<img width="959" height="445" alt="Screenshot 2026-05-17 131515" src="https://github.com/user-attachments/assets/da5a385d-b253-4474-b9f7-1fcc7b62230d" />

<img width="959" height="449" alt="Screenshot 2026-05-17 131532" src="https://github.com/user-attachments/assets/a8a66d45-a383-4f26-9ac0-620e83e4bf6f" />

<img width="959" height="448" alt="Screenshot 2026-05-17 131545" src="https://github.com/user-attachments/assets/438375a1-4316-4444-b8e1-a7d8f9b15a75" />


<img width="959" height="454" alt="Screenshot 2026-05-17 131615" src="https://github.com/user-attachments/assets/a08caf8e-01b6-40b8-8ed8-062101dc226a" />


<img width="959" height="451" alt="Screenshot 2026-05-17 131647" src="https://github.com/user-attachments/assets/6464faf1-1698-4bef-b889-2cd4afd85074" />



<img width="959" height="443" alt="Screenshot 2026-05-17 131705" src="https://github.com/user-attachments/assets/098bb53f-fea6-48fa-b9dc-e71f003f9038" />


<img width="959" height="452" alt="Screenshot 2026-05-17 131749" src="https://github.com/user-attachments/assets/f948821d-c542-43c8-80ce-1369bdb1ec39" />


<img width="959" height="446" alt="Screenshot 2026-05-17 131803" src="https://github.com/user-attachments/assets/76733f15-6540-4b4f-8f30-fdc36ff5ced9" />

<img width="959" height="449" alt="Screenshot 2026-05-17 131822" src="https://github.com/user-attachments/assets/74b2dfc0-5ebc-454c-88ee-814fafb9addb" />



> 📱 Test at 375px width using Chrome DevTools (F12 → Toggle Device Toolbar)

---

## 🧪 Tested On
- [x] Chrome — 375px (mobile)
- [x] Chrome — 768px (tablet)
- [x] Chrome — 1024px (laptop)
- [x] Chrome — 1440px (desktop)
- [x] `npm run dev` — no errors
- [x] `npm run build` — builds successfully
- [x] Dark mode ✅
- [x] Light mode ✅

---

## 🔗 Related Issue
Closes #19