### PR TITLE
fix: Implement missing analytics route to prevent server startup crash (Issue #21)

### DIFF
--- a/server/routes/analytics.js
+++ b/server/routes/analytics.js
@@ -1,0 +1,96 @@
+import { Router } from 'express';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const CONTENT_FILE = path.join(__dirname, '..', 'data', 'content.json');
+
+const router = Router();
+
+/**
+ * Read stored content from the local JSON file.
+ * Returns the default structure if the file is missing or unreadable.
+ */
+async function readContentSafe() {
+  try {
+    const raw = await fs.readFile(CONTENT_FILE, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return { events: [], activityEvents: {}, coreTeam: [] };
+  }
+}
+
+/**
+ * GET /
+ * Returns a high-level summary of events, activity events, and core team members.
+ */
+router.get('/', async (_req, res) => {
+  try {
+    const content = await readContentSafe();
+
+    const events = content.events || [];
+    const activityEvents = content.activityEvents || {};
+    const coreTeam = content.coreTeam || [];
+
+    const upcomingEvents = events.filter(e => e.status === 'upcoming');
+    const completedEvents = events.filter(e => e.status === 'completed');
+
+    const activityEventCounts = {};
+    let totalActivityEvents = 0;
+    for (const [key, list] of Object.entries(activityEvents)) {
+      const count = Array.isArray(list) ? list.length : 0;
+      activityEventCounts[key] = count;
+      totalActivityEvents += count;
+    }
+
+    res.json({
+      overview: {
+        totalEvents: events.length,
+        upcomingEvents: upcomingEvents.length,
+        completedEvents: completedEvents.length,
+        totalActivityEvents,
+        totalCoreTeamMembers: coreTeam.length,
+      },
+      activityEventCounts,
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message || 'Failed to generate analytics' });
+  }
+});
+
+/**
+ * GET /events
+ * Returns detailed analytics for events including tag distribution.
+ */
+router.get('/events', async (_req, res) => {
+  try {
+    const content = await readContentSafe();
+    const events = content.events || [];
+
+    const tagFrequency = {};
+    for (const event of events) {
+      const tags = Array.isArray(event.tags) ? event.tags : [];
+      for (const tag of tags) {
+        tagFrequency[tag] = (tagFrequency[tag] || 0) + 1;
+      }
+    }
+
+    const statusBreakdown = {};
+    for (const event of events) {
+      const status = event.status || 'unknown';
+      statusBreakdown[status] = (statusBreakdown[status] || 0) + 1;
+    }
+
+    res.json({
+      total: events.length,
+      statusBreakdown,
+      tagFrequency,
+    });
+  } catch (error) {
+    res.status(500).json({ error: error.message || 'Failed to generate event analytics' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
### Overview
This PR resolves a critical issue where the Node.js server crashes immediately on startup due to a missing `analytics.js` module. It implements the necessary route handling to ensure smooth startup and provide basic analytics data for the admin dashboard.

### Key Features Implemented
- **Analytics Route Implementation**: Created the missing `server/routes/analytics.js` file.
- **Admin Dashboard Metrics**: Implemented logic to read from `content.json` and generate aggregate metrics for events, activity events, and core team members.
- **Safe Read Mechanism**: Added a fail-safe file read operation that gracefully returns empty data if the local storage file does not yet exist.

### Files Created & Modified
#### **Backend Changes**
- `server/routes/analytics.js` (NEW) - Provides the `/api/admin/analytics` endpoints.

### Setup Instructions
1. **Pull the latest changes** and switch to this branch.
2. Ensure you have run `npm install` inside the `server/` directory.
3. Start the server using:
   ```bash
   npm run dev
   ```
4. Verify that the server no longer throws `ERR_MODULE_NOT_FOUND` for `analytics.js`.

### Testing Recommendations
1. **Server Startup**: Simply run the server and ensure it does not crash during module resolution.
2. **Endpoint Validation (Admin only)**: 
   - Make a GET request to `/api/admin/analytics` (ensure you pass the appropriate Bearer token for admin authentication).
   - Verify it returns a JSON overview of the system's content metrics.

### Related Issue
Closes #21  - [BUG] Node.js server fails to start due to missing analytics route