### PR TITLE
fix: Correct adminAuthMiddleware import to resolve undefined handlers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -10,7 +10,7 @@ import crypto from 'crypto';
 import { sendWelcomeVerificationEmail } from './services/emailService.js';
 import { ZodError } from 'zod';
 import { normalizeFormSubmission } from './validators/formSchemas.js';
-import * as adminAuthMiddleware from './middleware/adminAuthMiddleware.js';
+import { adminAuthMiddleware } from './middleware/adminAuthMiddleware.js';
 import analyticsRouter from './routes/analytics.js';
 
 const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
### Overview
This PR resolves a critical bug where all admin routes (e.g., login, logout, dashboard management) were failing due to an improperly imported authentication middleware. The namespace mismatch was causing the `requireAdmin` handler to evaluate to `undefined`.

### Key Features Implemented
- **Corrected Import Destructuring**: Replaced the wildcard namespace import (`import * as adminAuthMiddleware`) with a named destructured import (`import { adminAuthMiddleware }`) in `server/index.js` to correctly map the exported object properties.

### Files Created & Modified
#### **Backend Changes**
- `server/index.js` (MODIFIED) - Fixed the import statement for `adminAuthMiddleware.js`.

### Setup Instructions
1. **Pull the latest changes** and switch to this branch.
2. Start the server using:
   ```bash
   npm run dev
   ```
3. Send a POST request to `/api/admin/login` or a GET request to `/api/admin/events` without credentials. It should now return a proper `401 Unauthorized` response instead of crashing or hanging due to an undefined handler.

### Testing Recommendations
1. **Server Integrity**: Ensure the backend starts up successfully.
2. **Admin Route Protection Check**: 
   - Verify that endpoints protected by `adminAuth` (such as `/api/admin/events`) correctly intercept requests and invoke the middleware logic.

### Related Issue
Closes #35  - [BUG] Broken Admin Authentication due to incorrect middleware import
