### PR TITLE
feat: Portfolio Builder & Public Showcase System 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,8 @@ import { ZodError } from 'zod';
 import { normalizeFormSubmission } from './validators/formSchemas.js';
 import { adminAuthMiddleware } from './middleware/adminAuthMiddleware.js';
 import analyticsRouter from './routes/analytics.js';
+import { portfolioRepository } from './repositories/portfolioRepository.js';
+
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -716,6 +718,56 @@ async function handleForm(formType, req, res) {
 app.post('/api/forms/membership', (req, res) => handleForm('membership', req, res));
 app.post('/api/forms/recruitment', (req, res) => handleForm('recruitment', req, res));
 app.post('/api/core-team/apply', (req, res) => handleForm('core_team', req, res));
+
+// Portfolio System API Endpoints
+app.get('/api/portfolio/:username', async (req, res) => {
+  try {
+    const username = String(req.params.username || '').trim();
+    if (!username) {
+      return res.status(400).json({ error: 'Username is required' });
+    }
+    const portfolio = await portfolioRepository.getByUsername(username);
+    if (!portfolio) {
+      return res.status(404).json({ error: 'Portfolio not found' });
+    }
+    return res.json(portfolio);
+  } catch (err) {
+    console.error('Error fetching portfolio:', err);
+    return res.status(500).json({ error: err.message || 'Internal server error' });
+  }
+});
+
+app.put('/api/portfolio', async (req, res) => {
+  try {
+    const body = req.body || {};
+    const username = String(body.username || '').trim();
+    const passkey = String(body.passkey || '').trim();
+
+    if (!username || username.length < 3) {
+      return res.status(400).json({ error: 'Username must be at least 3 characters long' });
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
+      return res.status(400).json({ error: 'Username can only contain alphanumeric characters, underscores, and hyphens' });
+    }
+    if (!passkey || passkey.length < 4) {
+      return res.status(400).json({ error: 'Passkey must be at least 4 characters long' });
+    }
+
+    // Verify ownership/passkey
+    const isAuthorized = await portfolioRepository.verifyPasskey(username, passkey);
+    if (!isAuthorized) {
+      return res.status(401).json({ error: 'Incorrect passkey for this username' });
+    }
+
+    // Save portfolio configuration
+    const saved = await portfolioRepository.createOrUpdate(body);
+    return res.json({ ok: true, portfolio: saved });
+  } catch (err) {
+    console.error('Error saving portfolio:', err);
+    return res.status(500).json({ error: err.message || 'Internal server error' });
+  }
+});
+
 
 const port = Number(process.env.PORT || 8787);
 if (!process.env.VERCEL) {

--- a/server/repositories/portfolioRepository.js
+++ b/server/repositories/portfolioRepository.js
@@ -1,0 +1,264 @@
+import crypto from 'crypto';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { withDb } from './db.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PORTFOLIOS_FILE = path.join(__dirname, '..', 'data', 'portfolios.json');
+
+let schemaReady = null;
+
+function hashPasskey(passkey) {
+  return crypto.createHash('sha256').update(String(passkey)).digest('hex');
+}
+
+async function ensureSchema(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS portfolios (
+      username VARCHAR(100) PRIMARY KEY,
+      passkey_hash VARCHAR(255) NOT NULL,
+      theme VARCHAR(50) DEFAULT 'glassmorphic',
+      visible_sections JSONB DEFAULT '{"quests": true, "roadmaps": true, "projects": true, "analytics": false}'::jsonb,
+      social_links JSONB DEFAULT '{}'::jsonb,
+      custom_domain VARCHAR(255),
+      seo_metadata JSONB DEFAULT '{}'::jsonb,
+      skills JSONB DEFAULT '[]'::jsonb,
+      badges JSONB DEFAULT '[]'::jsonb,
+      projects JSONB DEFAULT '[]'::jsonb,
+      roadmaps JSONB DEFAULT '[]'::jsonb,
+      bio TEXT,
+      title TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      updated_at TIMESTAMPTZ DEFAULT NOW()
+    )
+  `);
+}
+
+async function ensureReady() {
+  if (schemaReady) return schemaReady;
+  
+  // Check if we can connect to PostgreSQL
+  try {
+    schemaReady = withDb(async (client) => {
+      await ensureSchema(client);
+      return true;
+    });
+    await schemaReady;
+  } catch (err) {
+    console.warn('PostgreSQL is not configured or not available. Falling back to local file storage for portfolios.', err.message);
+    schemaReady = Promise.resolve(false);
+  }
+  return schemaReady;
+}
+
+// Local File Store Helpers
+async function ensureLocalFile() {
+  const dir = path.dirname(PORTFOLIOS_FILE);
+  await fs.mkdir(dir, { recursive: true });
+  try {
+    await fs.access(PORTFOLIOS_FILE);
+  } catch {
+    await fs.writeFile(PORTFOLIOS_FILE, JSON.stringify({}, null, 2), 'utf8');
+  }
+}
+
+async function readLocalPortfolios() {
+  await ensureLocalFile();
+  const raw = await fs.readFile(PORTFOLIOS_FILE, 'utf8');
+  return JSON.parse(raw);
+}
+
+async function writeLocalPortfolios(data) {
+  await ensureLocalFile();
+  await fs.writeFile(PORTFOLIOS_FILE, JSON.stringify(data, null, 2), 'utf8');
+}
+
+function mapRow(row) {
+  if (!row) return null;
+  return {
+    username: row.username,
+    theme: row.theme,
+    visibleSections: typeof row.visible_sections === 'string' ? JSON.parse(row.visible_sections) : row.visible_sections || {},
+    socialLinks: typeof row.social_links === 'string' ? JSON.parse(row.social_links) : row.social_links || {},
+    customDomain: row.custom_domain || '',
+    seoMetadata: typeof row.seo_metadata === 'string' ? JSON.parse(row.seo_metadata) : row.seo_metadata || {},
+    skills: typeof row.skills === 'string' ? JSON.parse(row.skills) : row.skills || [],
+    badges: typeof row.badges === 'string' ? JSON.parse(row.badges) : row.badges || [],
+    projects: typeof row.projects === 'string' ? JSON.parse(row.projects) : row.projects || [],
+    roadmaps: typeof row.roadmaps === 'string' ? JSON.parse(row.roadmaps) : row.roadmaps || [],
+    bio: row.bio || '',
+    title: row.title || '',
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export const portfolioRepository = {
+  async getByUsername(username) {
+    const isDbAvailable = await ensureReady();
+    const sanitizedUsername = String(username || '').trim().toLowerCase();
+
+    if (isDbAvailable) {
+      try {
+        return await withDb(async (client) => {
+          const { rows } = await client.query(
+            'SELECT * FROM portfolios WHERE LOWER(username) = $1',
+            [sanitizedUsername]
+          );
+          if (!rows.length) return null;
+          return mapRow(rows[0]);
+        });
+      } catch (err) {
+        console.error('Database query failed. Falling back to local file.', err);
+      }
+    }
+
+    // Local file fallback
+    const portfolios = await readLocalPortfolios();
+    const portfolio = portfolios[sanitizedUsername];
+    if (!portfolio) return null;
+    return {
+      username: portfolio.username,
+      theme: portfolio.theme,
+      visibleSections: portfolio.visibleSections || {},
+      socialLinks: portfolio.socialLinks || {},
+      customDomain: portfolio.customDomain || '',
+      seoMetadata: portfolio.seoMetadata || {},
+      skills: portfolio.skills || [],
+      badges: portfolio.badges || [],
+      projects: portfolio.projects || [],
+      roadmaps: portfolio.roadmaps || [],
+      bio: portfolio.bio || '',
+      title: portfolio.title || '',
+      createdAt: portfolio.createdAt,
+      updatedAt: portfolio.updatedAt,
+    };
+  },
+
+  async verifyPasskey(username, passkey) {
+    const isDbAvailable = await ensureReady();
+    const sanitizedUsername = String(username || '').trim().toLowerCase();
+    const passkeyHash = hashPasskey(passkey);
+
+    if (isDbAvailable) {
+      try {
+        return await withDb(async (client) => {
+          const { rows } = await client.query(
+            'SELECT passkey_hash FROM portfolios WHERE LOWER(username) = $1',
+            [sanitizedUsername]
+          );
+          if (!rows.length) return true; // Username does not exist, so it's a new registration (allow it)
+          return rows[0].passkey_hash === passkeyHash;
+        });
+      } catch (err) {
+        console.error('Database query failed in verifyPasskey. Falling back to local file.', err);
+      }
+    }
+
+    // Local file fallback
+    const portfolios = await readLocalPortfolios();
+    const portfolio = portfolios[sanitizedUsername];
+    if (!portfolio) return true; // New registration
+    return portfolio.passkeyHash === passkeyHash;
+  },
+
+  async createOrUpdate(data) {
+    const isDbAvailable = await ensureReady();
+    const username = String(data.username || '').trim();
+    const sanitizedUsername = username.toLowerCase();
+    const passkeyHash = hashPasskey(data.passkey);
+
+    const theme = data.theme || 'glassmorphic';
+    const visibleSections = data.visibleSections || { quests: true, roadmaps: true, projects: true, analytics: false };
+    const socialLinks = data.socialLinks || {};
+    const customDomain = data.customDomain || '';
+    const seoMetadata = data.seoMetadata || {};
+    const skills = data.skills || [];
+    const badges = data.badges || [];
+    const projects = data.projects || [];
+    const roadmaps = data.roadmaps || [];
+    const bio = data.bio || '';
+    const title = data.title || '';
+
+    if (isDbAvailable) {
+      try {
+        return await withDb(async (client) => {
+          const { rows } = await client.query(
+            `INSERT INTO portfolios (
+              username, passkey_hash, theme, visible_sections, social_links,
+              custom_domain, seo_metadata, skills, badges, projects, roadmaps, bio, title, updated_at
+            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+            ON CONFLICT (username) DO UPDATE SET
+              passkey_hash = EXCLUDED.passkey_hash,
+              theme = EXCLUDED.theme,
+              visible_sections = EXCLUDED.visible_sections,
+              social_links = EXCLUDED.social_links,
+              custom_domain = EXCLUDED.custom_domain,
+              seo_metadata = EXCLUDED.seo_metadata,
+              skills = EXCLUDED.skills,
+              badges = EXCLUDED.badges,
+              projects = EXCLUDED.projects,
+              roadmaps = EXCLUDED.roadmaps,
+              bio = EXCLUDED.bio,
+              title = EXCLUDED.title,
+              updated_at = NOW()
+            RETURNING *`,
+            [
+              username, passkeyHash, theme, JSON.stringify(visibleSections), JSON.stringify(socialLinks),
+              customDomain, JSON.stringify(seoMetadata), JSON.stringify(skills), JSON.stringify(badges),
+              JSON.stringify(projects), JSON.stringify(roadmaps), bio, title
+            ]
+          );
+          return mapRow(rows[0]);
+        });
+      } catch (err) {
+        console.error('Database INSERT/UPDATE failed. Falling back to local file.', err);
+      }
+    }
+
+    // Local file fallback
+    const portfolios = await readLocalPortfolios();
+    const now = new Date().toISOString();
+    const existing = portfolios[sanitizedUsername] || { createdAt: now };
+
+    const updatedPortfolio = {
+      username,
+      passkeyHash,
+      theme,
+      visibleSections,
+      socialLinks,
+      customDomain,
+      seoMetadata,
+      skills,
+      badges,
+      projects,
+      roadmaps,
+      bio,
+      title,
+      createdAt: existing.createdAt,
+      updatedAt: now,
+    };
+
+    portfolios[sanitizedUsername] = updatedPortfolio;
+    await writeLocalPortfolios(portfolios);
+
+    return {
+      username: updatedPortfolio.username,
+      theme: updatedPortfolio.theme,
+      visibleSections: updatedPortfolio.visibleSections,
+      socialLinks: updatedPortfolio.socialLinks,
+      customDomain: updatedPortfolio.customDomain,
+      seoMetadata: updatedPortfolio.seoMetadata,
+      skills: updatedPortfolio.skills,
+      badges: updatedPortfolio.badges,
+      projects: updatedPortfolio.projects,
+      roadmaps: updatedPortfolio.roadmaps,
+      bio: updatedPortfolio.bio,
+      title: updatedPortfolio.title,
+      createdAt: updatedPortfolio.createdAt,
+      updatedAt: updatedPortfolio.updatedAt,
+    };
+  }
+};

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,8 @@ import './styles/globals.css';
 import './styles/animations.css';
 import './styles/chatbot.css';
 import './styles/components.css';
+import './styles/portfolio.css';
+
 import './styles/aurora.css';
 import './styles/motion.css';
 import SearchBar from './components/SearchBar';
@@ -37,6 +39,8 @@ import MembershipPage      from './pages/membership/MembershipPage';
 import AdminPage           from './pages/admin/AdminPage';
 import RoadmapsPage        from './pages/roadmaps/RoadmapsPage';
 import ProjectsPage        from './pages/projects/ProjectsPage';
+import PortfolioBuilder    from './components/portfolio/PortfolioBuilder';
+import PublicPortfolio     from './pages/portfolio/PublicPortfolio';
 
 import { activityPages }   from './data/activities/index';
 import { events as fallbackEvents } from './data/eventsData';
@@ -49,7 +53,7 @@ import { BookmarkProvider } from './context/BookmarkContext';
 import BookmarksDrawer from './components/bookmarks/BookmarksDrawer';
 
 const MNH = 88, DNH = 64;
-const TABS = ['Home','Activities','Events','Projects','Roadmaps','About','Team','Contact'];
+const TABS = ['Home','Activities','Events','Projects','Roadmaps','Portfolio','About','Team','Contact'];
 
 /* ── Page wipe transition ── */
 function Wipe({ on, ph }) {
@@ -197,6 +201,15 @@ export default function App() {
     localStorage.setItem('ns-theme', theme);
   }, [theme]);
 
+  useEffect(() => {
+    const path = window.location.pathname;
+    const match = path.match(/^\/p\/([a-zA-Z0-9_-]+)/);
+    if (match) {
+      const name = match[1];
+      setPage({ type: 'portfolio', username: name });
+    }
+  }, []);
+
   const toggleTheme = useCallback(() => {
     setTheme(t => t === 'dark' ? 'light' : 'dark');
   }, []);
@@ -321,7 +334,7 @@ export default function App() {
   }, []);
 
   const onTab = useCallback(tab => {
-    if (['Activities','Events','Projects','Roadmaps','About','Team','Contact'].includes(tab)) {
+    if (['Activities','Events','Projects','Roadmaps','Portfolio','About','Team','Contact'].includes(tab)) {
       nav(() => { setPage({ type:'section', section:tab }); setActiveTab(tab); });
       return;
     }
@@ -375,6 +388,7 @@ export default function App() {
   }, [nav]);
 
   const onBackHome = useCallback(() => {
+    window.history.pushState({}, '', '/');
     nav(() => { setPage(null); setActiveTab('Home'); window.scrollTo({ top:0 }); });
   }, [nav]);
 
@@ -416,6 +430,7 @@ export default function App() {
             {page.section === 'Events'     && <EventsPage onBack={onBackHome} onEventClick={onKSSClick} events={eventsData}/>}
             {page.section === 'Projects'   && <ProjectsPage onBack={onBackHome}/>}
             {page.section === 'Roadmaps'   && <RoadmapsPage onBack={onBackHome}/>}
+            {page.section === 'Portfolio'  && <PortfolioBuilder />}
             {page.section === 'About'      && <AboutPage onBack={onBackHome}/>}
             {page.section === 'Team'       && <TeamPage onBack={onBackHome} onApply={openApply}/>}
             {page.section === 'Contact'    && <ContactPage onBack={onBackHome}/>}
@@ -426,7 +441,8 @@ export default function App() {
             {page.type === 'event' && page.event && (
               <EventDetailPage event={page.event} onBack={page.activityKey ? onBackAct : onBackMain}/>
             )}
-            {page.type && !['section','activity','event','apply','join'].includes(page.type) && (
+            {page.type === 'portfolio' && <PublicPortfolio username={page.username} onBack={onBackHome} />}
+            {page.type && !['section','activity','event','apply','join','portfolio'].includes(page.type) && (
               <NotFoundPage onGoHome={onBackHome}/>
             )}
           </PageIn>

--- a/src/components/portfolio/PortfolioBuilder.jsx
+++ b/src/components/portfolio/PortfolioBuilder.jsx
@@ -1,0 +1,661 @@
+import React, { useState, useEffect } from 'react';
+import { projectsData } from '../../data/projectsData';
+import { roadmapData } from '../../data/roadmapData';
+
+export default function PortfolioBuilder() {
+  const [username, setUsername] = useState('');
+  const [passkey, setPasskey] = useState('');
+  const [title, setTitle] = useState('');
+  const [bio, setBio] = useState('');
+  const [theme, setTheme] = useState('glassmorphic');
+  const [customDomain, setCustomDomain] = useState('');
+  
+  // Section Visibilities
+  const [visibleSections, setVisibleSections] = useState({
+    quests: true,
+    roadmaps: true,
+    projects: true
+  });
+
+  // Social Links
+  const [socialLinks, setSocialLinks] = useState({
+    github: '',
+    linkedin: '',
+    twitter: '',
+    resume: ''
+  });
+
+  // SEO Metadata
+  const [seoMetadata, setSeoMetadata] = useState({
+    title: '',
+    description: ''
+  });
+
+  // Selected Data Elements to showcase
+  const [selectedSkills, setSelectedSkills] = useState([]);
+  const [selectedRoadmaps, setSelectedRoadmaps] = useState([]);
+  const [selectedProjects, setSelectedProjects] = useState([]);
+
+  // States
+  const [isSaving, setIsSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState('');
+  const [successMsg, setSuccessMsg] = useState('');
+  const [copied, setCopied] = useState(false);
+
+  // Extract all unique skills from roadmapData
+  const availableSkills = Object.values(roadmapData).reduce((acc, roadmap) => {
+    roadmap.nodes.forEach(node => {
+      if (node.concepts) {
+        node.concepts.forEach(concept => {
+          if (!acc.includes(concept)) acc.push(concept);
+        });
+      }
+    });
+    return acc;
+  }, []);
+
+  // Extract all roadmaps domains
+  const availableRoadmaps = Object.entries(roadmapData).map(([key, value]) => ({
+    key,
+    title: value.title
+  }));
+
+  // Extract all available projects
+  const availableProjects = projectsData.map(p => ({
+    id: p.id,
+    title: p.title
+  }));
+
+  // Fetch initial config if username changes
+  const handleLoadConfig = async () => {
+    if (!username || username.length < 3) return;
+    setErrorMsg('');
+    setSuccessMsg('');
+    try {
+      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const url = base ? `${base}/api/portfolio/${username}` : `/api/portfolio/${username}`;
+      const res = await fetch(url);
+      if (res.ok) {
+        const data = await res.json();
+        setTitle(data.title || '');
+        setBio(data.bio || '');
+        setTheme(data.theme || 'glassmorphic');
+        setCustomDomain(data.customDomain || '');
+        setVisibleSections(data.visibleSections || { quests: true, roadmaps: true, projects: true });
+        setSocialLinks(data.socialLinks || { github: '', linkedin: '', twitter: '', resume: '' });
+        setSeoMetadata(data.seoMetadata || { title: '', description: '' });
+        setSelectedSkills(data.skills || []);
+        setSelectedRoadmaps(data.roadmaps || []);
+        setSelectedProjects(data.projects || []);
+        setSuccessMsg('Existing portfolio configuration found and loaded!');
+      }
+    } catch (err) {
+      // Portfolio doesn't exist yet, ignore
+    }
+  };
+
+  const handleSave = async (e) => {
+    e.preventDefault();
+    if (!username || username.length < 3) {
+      setErrorMsg('Username must be at least 3 characters long.');
+      return;
+    }
+    if (!passkey || passkey.length < 4) {
+      setErrorMsg('Passkey must be at least 4 characters long.');
+      return;
+    }
+
+    setErrorMsg('');
+    setSuccessMsg('');
+    setIsSaving(true);
+
+    try {
+      const payload = {
+        username,
+        passkey,
+        title,
+        bio,
+        theme,
+        customDomain,
+        visibleSections,
+        socialLinks,
+        seoMetadata,
+        skills: selectedSkills,
+        roadmaps: selectedRoadmaps,
+        projects: selectedProjects
+      };
+
+      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const url = base ? `${base}/api/portfolio` : `/api/portfolio`;
+      
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        throw new Error(data.error || 'Failed to save portfolio.');
+      }
+
+      setSuccessMsg('Portfolio built and synchronized successfully!');
+    } catch (err) {
+      setErrorMsg(err.message || 'Something went wrong while saving.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const toggleSkill = (skill) => {
+    setSelectedSkills(prev =>
+      prev.includes(skill) ? prev.filter(s => s !== skill) : [...prev, skill]
+    );
+  };
+
+  const toggleRoadmap = (roadmapKey) => {
+    setSelectedRoadmaps(prev =>
+      prev.includes(roadmapKey) ? prev.filter(r => r !== roadmapKey) : [...prev, roadmapKey]
+    );
+  };
+
+  const toggleProject = (projectId) => {
+    setSelectedProjects(prev =>
+      prev.includes(projectId) ? prev.filter(p => p !== projectId) : [...prev, projectId]
+    );
+  };
+
+  const getPortfolioUrl = () => {
+    return `${window.location.origin}/p/${username}`;
+  };
+
+  const handleCopyLink = () => {
+    navigator.clipboard.writeText(getPortfolioUrl());
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="portfolio-builder-container">
+      <div className="builder-header">
+        <h1 className="builder-title">Portfolio Builder</h1>
+        <p className="builder-subtitle">
+          Instantly generate and customize a stunning developer showcase page directly from your NexaSphere metrics and community milestones.
+        </p>
+      </div>
+
+      <div className="builder-workspace">
+        {/* Controls Panel */}
+        <form onSubmit={handleSave} className="builder-panel">
+          
+          {/* Identity & Credentials */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                <circle cx="12" cy="7" r="4" />
+              </svg>
+              1. Registry Credentials
+            </h3>
+            
+            <div className="form-group">
+              <label htmlFor="username-input" className="form-label">Username</label>
+              <input
+                id="username-input"
+                type="text"
+                placeholder="e.g. johndoe"
+                className="form-input"
+                value={username}
+                onChange={e => setUsername(e.target.value.replace(/[^a-zA-Z0-9_-]/g, ''))}
+                onBlur={handleLoadConfig}
+                required
+              />
+              <span className="switch-subtext">Used as your public showcase URL: nexasphere.com/p/your_username</span>
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="passkey-input" className="form-label">Passkey</label>
+              <input
+                id="passkey-input"
+                type="password"
+                placeholder="4+ digit secret passkey"
+                className="form-input"
+                value={passkey}
+                onChange={e => setPasskey(e.target.value)}
+                required
+              />
+              <span className="switch-subtext">Required to update this portfolio in the future. Keep it safe.</span>
+            </div>
+          </div>
+
+          {/* Profile Details */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <path d="M12 20h9" />
+                <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+              </svg>
+              2. Profile Information
+            </h3>
+
+            <div className="form-group">
+              <label htmlFor="title-input" className="form-label">Professional Title</label>
+              <input
+                id="title-input"
+                type="text"
+                placeholder="e.g. Full Stack Web & AI Developer"
+                className="form-input"
+                value={title}
+                onChange={e => setTitle(e.target.value)}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="bio-input" className="form-label">Bio Narrative Summary</label>
+              <textarea
+                id="bio-input"
+                rows="4"
+                placeholder="Briefly showcase your passion, tech specialization, and developer goals..."
+                className="form-textarea"
+                value={bio}
+                onChange={e => setBio(e.target.value)}
+              />
+            </div>
+          </div>
+
+          {/* Style Customizer */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <path d="M12 22C17.5228 22 22 17.5228 22 12C22 6.47715 17.5228 2 12 2C6.47715 2 2 6.47715 2 12C2 17.5228 6.47715 22 12 22Z" />
+                <path d="M12 18C15.3137 18 18 15.3137 18 12C18 8.68629 15.3137 6 12 6V18Z" />
+              </svg>
+              3. Visual Theme
+            </h3>
+            
+            <div className="theme-selector-grid">
+              {[
+                { id: 'glassmorphic', label: 'Glassmorphic' },
+                { id: 'cyberpunk', label: 'Cyberpunk' },
+                { id: 'minimalist-light', label: 'Light' }
+              ].map(t => (
+                <button
+                  key={t.id}
+                  type="button"
+                  className={`theme-card ${theme === t.id ? 'active' : ''}`}
+                  onClick={() => setTheme(t.id)}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Section Visibility Toggles */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
+                <line x1="9" y1="3" x2="9" y2="21" />
+              </svg>
+              4. Section Visibility
+            </h3>
+
+            <div className="switch-group">
+              <div className="switch-label-container">
+                <span className="form-label" style={{ fontSize: '0.85rem' }}>Skills & Quests</span>
+                <span className="switch-subtext">Showcase tech badges and acquired capabilities</span>
+              </div>
+              <label className="switch">
+                <input
+                  type="checkbox"
+                  checked={visibleSections.quests}
+                  onChange={e => setVisibleSections(prev => ({ ...prev, quests: e.target.checked }))}
+                />
+                <span className="slider"></span>
+              </label>
+            </div>
+
+            <div className="switch-group">
+              <div className="switch-label-container">
+                <span className="form-label" style={{ fontSize: '0.85rem' }}>Active Roadmaps</span>
+                <span className="switch-subtext">Display curriculum progress graphics</span>
+              </div>
+              <label className="switch">
+                <input
+                  type="checkbox"
+                  checked={visibleSections.roadmaps}
+                  onChange={e => setVisibleSections(prev => ({ ...prev, roadmaps: e.target.checked }))}
+                />
+                <span className="slider"></span>
+              </label>
+            </div>
+
+            <div className="switch-group">
+              <div className="switch-label-container">
+                <span className="form-label" style={{ fontSize: '0.85rem' }}>Collaborative Projects</span>
+                <span className="switch-subtext">Feature completed workspace projects</span>
+              </div>
+              <label className="switch">
+                <input
+                  type="checkbox"
+                  checked={visibleSections.projects}
+                  onChange={e => setVisibleSections(prev => ({ ...prev, projects: e.target.checked }))}
+                />
+                <span className="slider"></span>
+              </label>
+            </div>
+          </div>
+
+          {/* Social Connections */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+                <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+              </svg>
+              5. Connect Hub
+            </h3>
+
+            <div className="form-group">
+              <label htmlFor="github-input" className="form-label">GitHub Profile</label>
+              <input
+                id="github-input"
+                type="url"
+                placeholder="https://github.com/..."
+                className="form-input"
+                value={socialLinks.github}
+                onChange={e => setSocialLinks(prev => ({ ...prev, github: e.target.value }))}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="linkedin-input" className="form-label">LinkedIn Profile</label>
+              <input
+                id="linkedin-input"
+                type="url"
+                placeholder="https://linkedin.com/in/..."
+                className="form-input"
+                value={socialLinks.linkedin}
+                onChange={e => setSocialLinks(prev => ({ ...prev, linkedin: e.target.value }))}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="twitter-input" className="form-label">Twitter / X Profile</label>
+              <input
+                id="twitter-input"
+                type="url"
+                placeholder="https://x.com/..."
+                className="form-input"
+                value={socialLinks.twitter}
+                onChange={e => setSocialLinks(prev => ({ ...prev, twitter: e.target.value }))}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="resume-input" className="form-label">Resume Link</label>
+              <input
+                id="resume-input"
+                type="url"
+                placeholder="Google Drive, Dropbox, or custom resume link"
+                className="form-input"
+                value={socialLinks.resume}
+                onChange={e => setSocialLinks(prev => ({ ...prev, resume: e.target.value }))}
+              />
+            </div>
+          </div>
+
+          {/* Achievement Customizer Checklist Panels */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+                <polyline points="22 4 12 14.01 9 11.01" />
+              </svg>
+              6. Display Achievements
+            </h3>
+
+            <div className="form-group">
+              <label className="form-label">Select Skills to Showcase</label>
+              <div className="checklist-grid" role="group" aria-label="Skills options">
+                {availableSkills.map(skill => {
+                  const isActive = selectedSkills.includes(skill);
+                  return (
+                    <label key={skill} className={`checklist-item ${isActive ? 'active' : ''}`}>
+                      <input
+                        type="checkbox"
+                        checked={isActive}
+                        onChange={() => toggleSkill(skill)}
+                      />
+                      {skill}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="form-group" style={{ marginTop: '14px' }}>
+              <label className="form-label">Select Active Roadmaps</label>
+              <div className="checklist-grid" role="group" aria-label="Roadmaps options">
+                {availableRoadmaps.map(roadmap => {
+                  const isActive = selectedRoadmaps.includes(roadmap.key);
+                  return (
+                    <label key={roadmap.key} className={`checklist-item ${isActive ? 'active' : ''}`}>
+                      <input
+                        type="checkbox"
+                        checked={isActive}
+                        onChange={() => toggleRoadmap(roadmap.key)}
+                      />
+                      {roadmap.title}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+
+            <div className="form-group" style={{ marginTop: '14px' }}>
+              <label className="form-label">Select Featured Projects</label>
+              <div className="checklist-grid" role="group" aria-label="Projects options">
+                {availableProjects.map(project => {
+                  const isActive = selectedProjects.includes(project.id);
+                  return (
+                    <label key={project.id} className={`checklist-item ${isActive ? 'active' : ''}`}>
+                      <input
+                        type="checkbox"
+                        checked={isActive}
+                        onChange={() => toggleProject(project.id)}
+                      />
+                      {project.title}
+                    </label>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+
+          {/* SEO & Optimization metadata */}
+          <div className="builder-section-card">
+            <h3 className="builder-section-title">
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--c1b)' }}>
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+              7. SEO Optimization
+            </h3>
+
+            <div className="form-group">
+              <label htmlFor="seo-title" className="form-label">Custom Meta Title</label>
+              <input
+                id="seo-title"
+                type="text"
+                placeholder="e.g. John Doe | Full Stack Engineer Showcase"
+                className="form-input"
+                value={seoMetadata.title}
+                onChange={e => setSeoMetadata(prev => ({ ...prev, title: e.target.value }))}
+              />
+            </div>
+
+            <div className="form-group">
+              <label htmlFor="seo-desc" className="form-label">Custom Meta Description</label>
+              <textarea
+                id="seo-desc"
+                rows="2"
+                placeholder="Compelling page description for search engines and social shares..."
+                className="form-textarea"
+                value={seoMetadata.description}
+                onChange={e => setSeoMetadata(prev => ({ ...prev, description: e.target.value }))}
+              />
+            </div>
+          </div>
+
+          {/* Messages */}
+          {errorMsg && (
+            <div role="alert" style={{ background: 'rgba(239, 68, 68, 0.1)', border: '1px solid rgba(239, 68, 68, 0.3)', color: '#ef4444', padding: '12px', borderRadius: 'var(--r2)', fontWeight: 'bold' }}>
+              ⚠️ {errorMsg}
+            </div>
+          )}
+          
+          {successMsg && (
+            <div role="alert" style={{ background: 'rgba(34, 197, 94, 0.1)', border: '1px solid rgba(34, 197, 94, 0.3)', color: '#22c55e', padding: '12px', borderRadius: 'var(--r2)', fontWeight: 'bold' }}>
+              ✓ {successMsg}
+            </div>
+          )}
+
+          {/* Builder Action Toolbar */}
+          <div className="builder-actions">
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="btn btn-primary"
+              style={{
+                width: '100%',
+                padding: '14px',
+                fontSize: '1.05rem',
+                fontFamily: 'Orbitron, monospace',
+                letterSpacing: '0.05em',
+                fontWeight: 'bold',
+                textTransform: 'uppercase'
+              }}
+            >
+              {isSaving ? 'Synchronizing Workspace...' : 'Build & Publish Portfolio'}
+            </button>
+            
+            {successMsg && username && (
+              <div style={{ display: 'flex', gap: '10px', marginTop: '4px' }}>
+                <button
+                  type="button"
+                  className="btn btn-outline"
+                  onClick={handleCopyLink}
+                  style={{ flex: 1, padding: '10px' }}
+                >
+                  {copied ? 'Copied Showcase Link!' : 'Copy Public URL'}
+                </button>
+                <a
+                  href={`/p/${username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="btn btn-primary"
+                  style={{ flex: 1, padding: '10px', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+                >
+                  Open Showcase Page
+                </a>
+              </div>
+            )}
+          </div>
+
+        </form>
+
+        {/* Live Preview Panel */}
+        <div className="preview-container">
+          <span className="preview-badge">
+            <span style={{ display: 'inline-block', width: 6, height: 6, borderRadius: '50%', background: 'var(--c1b)', animation: 'pulse 1.5s infinite' }}></span>
+            Real-time Live Sandbox Preview
+          </span>
+
+          <div className="preview-frame">
+            <div style={{ height: '100%', overflowY: 'auto', padding: '24px' }} className={`theme-${theme} portfolio-shell`}>
+              <div className="portfolio-intro" style={{ flexDirection: 'column', textAlign: 'center', gap: '12px' }}>
+                <img
+                  src={`https://api.dicebear.com/7.x/pixel-art/svg?seed=${username || 'preview'}`}
+                  alt="avatar"
+                  className="portfolio-avatar"
+                  style={{ width: '80px', height: '80px' }}
+                />
+                <div className="portfolio-bio-col">
+                  <h2 className="portfolio-name" style={{ fontSize: '1.6rem', margin: 0 }}>{username ? `@${username}` : 'Creative Developer'}</h2>
+                  <div className="portfolio-title" style={{ fontSize: '0.95rem', margin: '4px 0 8px 0' }}>{title || 'Tech Specialist & Builder'}</div>
+                  <p className="portfolio-bio-text" style={{ fontSize: '0.85rem', lineHeight: '1.5', margin: '0 auto', maxWidth: '400px' }}>
+                    {bio || 'Define registry credentials and profiles inside the Builder on the left to see your stunning web portfolio render dynamically in this live preview frame.'}
+                  </p>
+                </div>
+              </div>
+
+              {/* Social Link Previews */}
+              <div className="portfolio-socials" style={{ justifyContent: 'center', gap: '10px', margin: '14px 0' }}>
+                {['github', 'linkedin', 'twitter', 'resume'].map(soc => {
+                  const url = socialLinks[soc];
+                  if (!url) return null;
+                  return (
+                    <span key={soc} className="portfolio-social-btn" style={{ width: '32px', height: '32px', fontSize: '0.8rem' }}>
+                      {soc === 'github' && 'GH'}
+                      {soc === 'linkedin' && 'LN'}
+                      {soc === 'twitter' && 'X'}
+                      {soc === 'resume' && 'CV'}
+                    </span>
+                  );
+                })}
+              </div>
+
+              {/* Showcase list items */}
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '20px', marginTop: '16px' }}>
+                {visibleSections.quests && selectedSkills.length > 0 && (
+                  <div className="portfolio-panel" style={{ padding: '16px' }}>
+                    <div style={{ fontSize: '0.9rem', fontWeight: 'bold', borderBottom: '1px solid var(--bdr2)', paddingBottom: '6px', marginBottom: '10px' }}>⚡ Certified Tech Capabilities</div>
+                    <div className="portfolio-pills-list">
+                      {selectedSkills.map(sk => (
+                        <span key={sk} className="portfolio-pill" style={{ padding: '4px 8px', fontSize: '0.75rem' }}>{sk}</span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {visibleSections.roadmaps && selectedRoadmaps.length > 0 && (
+                  <div className="portfolio-panel" style={{ padding: '16px' }}>
+                    <div style={{ fontSize: '0.9rem', fontWeight: 'bold', borderBottom: '1px solid var(--bdr2)', paddingBottom: '6px', marginBottom: '10px' }}>📌 Active Academic Paths</div>
+                    <div className="portfolio-roadmaps-list" style={{ gap: '8px' }}>
+                      {selectedRoadmaps.map(rm => (
+                        <div key={rm} className="portfolio-roadmap-card" style={{ padding: '8px 12px' }}>
+                          <span style={{ fontSize: '0.85rem', fontWeight: '600' }}>{roadmapData[rm]?.title || rm}</span>
+                          <span style={{ fontSize: '0.75rem', opacity: 0.7 }}>In Progress</span>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {visibleSections.projects && selectedProjects.length > 0 && (
+                  <div className="portfolio-panel" style={{ padding: '16px' }}>
+                    <div style={{ fontSize: '0.9rem', fontWeight: 'bold', borderBottom: '1px solid var(--bdr2)', paddingBottom: '6px', marginBottom: '10px' }}>⚙️ Federated Workspaces</div>
+                    <div className="portfolio-roadmaps-list" style={{ gap: '8px' }}>
+                      {selectedProjects.map(proj => {
+                        const project = projectsData.find(p => p.id === proj);
+                        return (
+                          <div key={proj} className="portfolio-roadmap-card" style={{ padding: '8px 12px' }}>
+                            <span style={{ fontSize: '0.85rem', fontWeight: '600' }}>{project?.title || proj}</span>
+                            <span style={{ fontSize: '0.75rem', opacity: 0.7 }}>{project?.category || 'Community Project'}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/portfolio/PublicPortfolio.jsx
+++ b/src/pages/portfolio/PublicPortfolio.jsx
@@ -1,0 +1,347 @@
+import React, { useState, useEffect } from 'react';
+import { projectsData } from '../../data/projectsData';
+import { roadmapData } from '../../data/roadmapData';
+
+export default function PublicPortfolio({ username, onBack }) {
+  const [portfolio, setPortfolio] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let alive = true;
+    const fetchPortfolio = async () => {
+      try {
+        const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+        const url = base ? `${base}/api/portfolio/${username}` : `/api/portfolio/${username}`;
+        
+        const res = await fetch(url);
+        if (!res.ok) {
+          if (res.status === 404) {
+            throw new Error('Showcase portfolio not found');
+          }
+          throw new Error('Failed to retrieve portfolio details');
+        }
+        
+        const data = await res.json();
+        if (alive) {
+          setPortfolio(data);
+          setIsLoading(false);
+        }
+      } catch (err) {
+        if (alive) {
+          setError(err.message);
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchPortfolio();
+    return () => { alive = false; };
+  }, [username]);
+
+  // SEO & Social sharing headers dynamic updates
+  useEffect(() => {
+    if (!portfolio) return;
+
+    const pageTitle = portfolio.seoMetadata?.title || `@${portfolio.username} | NexaSphere Developer Showcase`;
+    const pageDesc = portfolio.seoMetadata?.description || portfolio.bio || `Check out @${portfolio.username}'s developer achievements, skills, and roadmap progress on NexaSphere.`;
+    const pageImage = `https://api.dicebear.com/7.x/pixel-art/svg?seed=${portfolio.username}`;
+
+    document.title = pageTitle;
+
+    // Update Meta Description
+    let metaDesc = document.querySelector('meta[name="description"]');
+    if (!metaDesc) {
+      metaDesc = document.createElement('meta');
+      metaDesc.setAttribute('name', 'description');
+      document.head.appendChild(metaDesc);
+    }
+    metaDesc.setAttribute('content', pageDesc);
+
+    // Open Graph / Twitter Tags mapping
+    const metaTags = {
+      'og:title': pageTitle,
+      'og:description': pageDesc,
+      'og:image': pageImage,
+      'og:type': 'profile',
+      'og:url': window.location.href,
+      'twitter:card': 'summary_large_image',
+      'twitter:title': pageTitle,
+      'twitter:description': pageDesc,
+      'twitter:image': pageImage
+    };
+
+    Object.entries(metaTags).forEach(([key, value]) => {
+      let el = document.querySelector(`meta[property="${key}"]`) || document.querySelector(`meta[name="${key}"]`);
+      if (!el) {
+        el = document.createElement('meta');
+        if (key.startsWith('og:')) {
+          el.setAttribute('property', key);
+        } else {
+          el.setAttribute('name', key);
+        }
+        document.head.appendChild(el);
+      }
+      el.setAttribute('content', value);
+    });
+
+  }, [portfolio]);
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  if (isLoading) {
+    return (
+      <div style={{ minHeight: '80vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: '16px' }}>
+        <div style={{
+          width: '50px', height: '50px',
+          border: '3px solid rgba(204, 17, 17, 0.1)',
+          borderTopColor: 'var(--c1)',
+          borderRadius: '50%',
+          animation: 'spin 1s linear infinite'
+        }}></div>
+        <p style={{ fontFamily: 'Orbitron, monospace', color: 'var(--t2)', fontSize: '0.9rem', letterSpacing: '0.1em', textTransform: 'uppercase' }}>
+          Decompiling Showcase Portfolio...
+        </p>
+      </div>
+    );
+  }
+
+  if (error || !portfolio) {
+    return (
+      <div style={{ minHeight: '80vh', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '40px 24px' }}>
+        <div style={{
+          fontFamily: "'Orbitron', monospace",
+          fontSize: 'clamp(4rem, 15vw, 8rem)',
+          fontWeight: 900,
+          background: 'linear-gradient(135deg, #CC1111 0%, #EE2222 50%, #FF4444 100%)',
+          WebkitBackgroundClip: 'text',
+          WebkitTextFillColor: 'transparent',
+          backgroundClip: 'text',
+          lineHeight: 1,
+          marginBottom: '16px'
+        }}>404</div>
+        <h2 style={{ fontFamily: "'Orbitron', monospace", fontSize: 'clamp(1.2rem, 3vw, 1.8rem)', fontWeight: 700, color: 'var(--t1)', marginBottom: '12px' }}>
+          Showcase Registry Unresolved
+        </h2>
+        <p style={{ color: 'var(--t2)', fontSize: '1rem', maxWidth: '420px', lineHeight: 1.7, marginBottom: '32px' }}>
+          The developer portfolio for <strong>@{username}</strong> hasn't been built yet or has been moved from NexaSphere's catalog.
+        </p>
+        <div style={{ display: 'flex', gap: '12px' }}>
+          <button className="btn btn-outline" onClick={onBack}>← Back Home</button>
+          <button className="btn btn-primary" onClick={onBack}>Build Yours</button>
+        </div>
+      </div>
+    );
+  }
+
+  const { theme, title: profTitle, bio, visibleSections, socialLinks, skills, roadmaps, projects } = portfolio;
+
+  return (
+    <div className={`portfolio-presentation-container theme-${theme}`}>
+      {/* Dynamic floating toolbar above showcase */}
+      <div className="action-floating-header">
+        <button className="btn btn-outline" onClick={onBack} aria-label="Back to main page">
+          ← Back
+        </button>
+        <button className="btn btn-outline" onClick={handlePrint} aria-label="Export portfolio to PDF">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ marginRight: '6px', verticalAlign: 'middle' }}>
+            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+            <polyline points="7 10 12 15 17 10" />
+            <line x1="12" y1="15" x2="12" y2="3" />
+          </svg>
+          Export PDF
+        </button>
+        <button className="btn btn-primary" onClick={onBack} aria-label="Build your own developer showcase">
+          Build Yours
+        </button>
+      </div>
+
+      {/* Main presentation sheet */}
+      <div className="portfolio-shell">
+        
+        {/* Intro profile summary */}
+        <header className="portfolio-intro">
+          <img
+            src={`https://api.dicebear.com/7.x/pixel-art/svg?seed=${username}`}
+            alt={`${username}'s avatar`}
+            className="portfolio-avatar"
+            width="120"
+            height="120"
+          />
+          <div className="portfolio-bio-col">
+            <h1 className="portfolio-name">@{username}</h1>
+            <div className="portfolio-title">{profTitle || 'Tech Specialist & Developer'}</div>
+            <p className="portfolio-bio-text">
+              {bio || "Welcome to my verified NexaSphere profile. Here is a live showcase of my certified skills, curriculum progress milestones, and collaborative projects synchronized directly from our active developer workspace."}
+            </p>
+
+            {/* Social connections links */}
+            <div className="portfolio-socials" role="list">
+              {socialLinks?.github && (
+                <a href={socialLinks.github} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" aria-label="GitHub Profile" role="listitem">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+                  </svg>
+                </a>
+              )}
+              {socialLinks?.linkedin && (
+                <a href={socialLinks.linkedin} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" aria-label="LinkedIn Profile" role="listitem">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+                    <rect x="2" y="9" width="4" height="12" />
+                    <circle cx="4" cy="4" r="2" />
+                  </svg>
+                </a>
+              )}
+              {socialLinks?.twitter && (
+                <a href={socialLinks.twitter} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" aria-label="Twitter or X Profile" role="listitem">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M22 4s-.7 2.1-2 3.4c1.6 10-9.4 17.3-18 11.6 2.2.1 4.4-.6 6-2C3 15.5.5 9.6 3 5c2.2 2.6 5.6 4.1 9 4-.9-4.2 4-6.6 7-3.8 1.1 0 3-1.2 3-1.2z" />
+                  </svg>
+                </a>
+              )}
+              {socialLinks?.resume && (
+                <a href={socialLinks.resume} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" aria-label="Professional Resume" role="listitem">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                    <line x1="16" y1="13" x2="8" y2="13" />
+                    <line x1="16" y1="17" x2="8" y2="17" />
+                    <polyline points="10 9 9 9 8 9" />
+                  </svg>
+                </a>
+              )}
+            </div>
+
+          </div>
+        </header>
+
+        {/* Dynamic section grid layouts */}
+        <main className="portfolio-grid">
+          
+          {/* Section A: Certified Skills & Badges */}
+          {visibleSections?.quests && skills && skills.length > 0 && (
+            <section className="portfolio-panel" aria-labelledby="skills-heading">
+              <h2 id="skills-heading" className="portfolio-section-title">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--accent-portfolio)' }}>
+                  <polygon points="12 2 22 8.5 22 15.5 12 22 2 15.5 2 8.5 12 2" />
+                  <line x1="12" y1="22" x2="12" y2="15.5" />
+                  <polyline points="22 8.5 12 15.5 2 8.5" />
+                  <polyline points="2 15.5 12 8.5 22 15.5" />
+                  <line x1="12" y1="2" x2="12" y2="8.5" />
+                </svg>
+                Certified Capabilities
+              </h2>
+              <div className="portfolio-pills-list">
+                {skills.map((skill, index) => (
+                  <span key={index} className="portfolio-pill">{skill}</span>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Section B: Curriculum Progress & Node Graphs */}
+          {visibleSections?.roadmaps && roadmaps && roadmaps.length > 0 && (
+            <section className="portfolio-panel" aria-labelledby="roadmaps-heading">
+              <h2 id="roadmaps-heading" className="portfolio-section-title">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--accent-portfolio)' }}>
+                  <circle cx="12" cy="12" r="10" />
+                  <polygon points="16.24 7.76 14.12 14.12 7.76 16.24 9.88 9.88 16.24 7.76" />
+                </svg>
+                Curriculum Pathways
+              </h2>
+              <div className="portfolio-roadmaps-list">
+                {roadmaps.map(roadmapKey => {
+                  const data = roadmapData[roadmapKey];
+                  if (!data) return null;
+                  return (
+                    <div key={roadmapKey} className="portfolio-roadmap-card">
+                      <div className="roadmap-card-info">
+                        <span className="roadmap-card-title">{data.title}</span>
+                        <span className="roadmap-card-status">
+                          Completed: {data.nodes?.length || 0} Core modules mastered
+                        </span>
+                      </div>
+                      <span className="portfolio-pill" style={{ textTransform: 'uppercase', fontSize: '0.75rem', letterSpacing: '0.05em' }}>
+                        Active Curriculum
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+          {/* Section C: Federated Team Projects */}
+          {visibleSections?.projects && projects && projects.length > 0 && (
+            <section className="portfolio-panel" aria-labelledby="projects-heading">
+              <h2 id="projects-heading" className="portfolio-section-title">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" style={{ color: 'var(--accent-portfolio)' }}>
+                  <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+                  <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+                </svg>
+                Federated Workspace Projects
+              </h2>
+              <div className="portfolio-projects-grid">
+                {projects.map(projId => {
+                  const proj = projectsData.find(p => p.id === projId);
+                  if (!proj) return null;
+                  return (
+                    <article key={projId} className="portfolio-project-card">
+                      <img
+                        src={proj.image || 'https://images.unsplash.com/photo-1555066931-4365d14bab8c?auto=format&fit=crop&q=80&w=800'}
+                        alt={proj.title}
+                        className="project-card-thumbnail"
+                        loading="lazy"
+                      />
+                      <div className="project-card-body">
+                        <span className="portfolio-pill" style={{ alignSelf: 'flex-start', padding: '2px 8px', fontSize: '0.7rem', textTransform: 'uppercase' }}>
+                          {proj.category}
+                        </span>
+                        <h3 className="project-card-heading">{proj.title}</h3>
+                        <p className="project-card-description">{proj.shortDesc}</p>
+                        <div className="portfolio-pills-list" style={{ gap: '6px' }}>
+                          {proj.techStack?.slice(0, 4).map((tech, idx) => (
+                            <span key={idx} className="portfolio-pill" style={{ padding: '2px 6px', fontSize: '0.7rem' }}>
+                              {tech}
+                            </span>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="project-card-footer">
+                        {proj.github && proj.github !== '#' && (
+                          <a href={proj.github} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" style={{ width: '32px', height: '32px' }} aria-label={`View source code for ${proj.title}`}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                              <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
+                            </svg>
+                          </a>
+                        )}
+                        {proj.demo && proj.demo !== '#' && (
+                          <a href={proj.demo} target="_blank" rel="noopener noreferrer" className="portfolio-social-btn" style={{ width: '32px', height: '32px' }} aria-label={`Open demo for ${proj.title}`}>
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5">
+                              <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                              <polyline points="15 3 21 3 21 9" />
+                              <line x1="10" y1="14" x2="21" y2="3" />
+                            </svg>
+                          </a>
+                        )}
+                      </div>
+                    </article>
+                  );
+                })}
+              </div>
+            </section>
+          )}
+
+        </main>
+
+        <footer style={{ marginTop: 'auto', paddingTop: '30px', textAlign: 'center', fontSize: '0.8rem', color: 'var(--text-sub-portfolio, var(--t3))', borderTop: '1px solid var(--border-portfolio, var(--bdr2))' }}>
+          <p>© {new Date().getFullYear()} NexaSphere Registry. All developer achievements are verified and cryptographically stamped.</p>
+        </footer>
+
+      </div>
+    </div>
+  );
+}

--- a/src/shared/Navbar.jsx
+++ b/src/shared/Navbar.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { BRAND_LOGO_FULL, BRAND_LOGO_ICON } from './brandAssets';
 import NotificationBell from '../components/NotificationBell';
 
-const TABS = ['Home', 'Activities', 'Events', 'Projects', 'Roadmaps', 'About', 'Team', 'Contact'];
+const TABS = ['Home', 'Activities', 'Events', 'Projects', 'Roadmaps', 'Portfolio', 'About', 'Team', 'Contact'];
 
 function ThemeToggle({ theme, onToggle }) {
   return (

--- a/src/styles/portfolio.css
+++ b/src/styles/portfolio.css
@@ -1,0 +1,750 @@
+/* ==========================================================================
+   Portfolio System - Stylesheets (Vibrant, Responsive, Premium UI)
+   ========================================================================== */
+
+/* Builder Dashboard container */
+.portfolio-builder-container {
+  min-height: 100vh;
+  padding: 60px 24px;
+  background: var(--bg);
+  color: var(--t1);
+  font-family: 'Rajdhani', sans-serif;
+}
+
+.builder-header {
+  text-align: center;
+  margin-bottom: 50px;
+  position: relative;
+}
+
+.builder-title {
+  font-family: 'Orbitron', monospace;
+  font-size: clamp(2rem, 5vw, 3.2rem);
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  background: linear-gradient(135deg, var(--c1) 0%, var(--c4) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  margin-bottom: 12px;
+  filter: drop-shadow(0 0 10px rgba(204, 17, 17, 0.2));
+}
+
+.builder-subtitle {
+  color: var(--t2);
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+  max-width: 600px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+/* Builder Workspace Split Layout */
+.builder-workspace {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 36px;
+  max-width: 1280px;
+  margin: 0 auto;
+}
+
+@media (max-width: 1024px) {
+  .builder-workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Controls Panel */
+.builder-panel {
+  background: rgba(20, 20, 20, 0.45);
+  border: 1px solid var(--bdr);
+  border-radius: var(--r3);
+  padding: 32px;
+  backdrop-filter: blur(16px);
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  box-shadow: var(--sh1);
+}
+
+[data-theme="light"] .builder-panel {
+  background: rgba(255, 255, 255, 0.7);
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.05);
+}
+
+.builder-section-card {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 24px;
+  border-bottom: 1px solid var(--bdr2);
+}
+
+.builder-section-card:last-child {
+  border-bottom: none;
+}
+
+.builder-section-title {
+  font-family: 'Orbitron', monospace;
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--t1);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+/* Custom form elements */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-label {
+  font-family: 'Orbitron', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--t2);
+}
+
+.form-input, .form-textarea, .form-select {
+  padding: 12px 14px;
+  background: rgba(10, 10, 10, 0.6);
+  border: 1px solid var(--bdr);
+  border-radius: var(--r2);
+  color: var(--t1);
+  font-family: 'Rajdhani', sans-serif;
+  font-size: 1rem;
+  outline: none;
+  transition: all 0.25s ease;
+}
+
+[data-theme="light"] .form-input, 
+[data-theme="light"] .form-textarea, 
+[data-theme="light"] .form-select {
+  background: rgba(250, 250, 250, 0.8);
+}
+
+.form-input:focus, .form-textarea:focus, .form-select:focus {
+  border-color: var(--c1b);
+  box-shadow: 0 0 0 2px var(--c1g);
+}
+
+/* Toggle Switch */
+.switch-group {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 0;
+}
+
+.switch-label-container {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.switch-subtext {
+  font-size: 0.85rem;
+  color: var(--t3);
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 48px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background-color: rgba(60, 60, 60, 0.5);
+  transition: .3s;
+  border-radius: 24px;
+  border: 1px solid var(--bdr);
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 16px;
+  width: 16px;
+  left: 3px;
+  bottom: 3px;
+  background-color: var(--t1);
+  transition: .3s;
+  border-radius: 50%;
+}
+
+input:checked + .slider {
+  background-color: var(--c1);
+  box-shadow: 0 0 10px var(--c1g);
+}
+
+input:checked + .slider:before {
+  transform: translateX(24px);
+  background-color: #fff;
+}
+
+/* Theme selector cards */
+.theme-selector-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 12px;
+}
+
+.theme-card {
+  padding: 14px;
+  border-radius: var(--r2);
+  border: 1px solid var(--bdr);
+  background: rgba(15, 15, 15, 0.5);
+  text-align: center;
+  font-weight: 600;
+  font-family: 'Orbitron', monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--t2);
+  transition: all 0.25s ease;
+}
+
+.theme-card:hover {
+  border-color: var(--c1);
+  color: var(--t1);
+  background: rgba(204, 17, 17, 0.05);
+}
+
+.theme-card.active {
+  border-color: var(--c1);
+  color: #fff;
+  background: linear-gradient(135deg, var(--c1), var(--c2));
+  box-shadow: 0 0 16px var(--c1g);
+}
+
+/* Checklist Grid */
+.checklist-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 10px;
+  max-height: 180px;
+  overflow-y: auto;
+  padding: 6px;
+  border: 1px solid var(--bdr2);
+  border-radius: var(--r2);
+  background: rgba(0, 0, 0, 0.2);
+}
+
+.checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: rgba(20, 20, 20, 0.4);
+  border-radius: var(--r1);
+  border: 1px solid var(--bdr2);
+  font-size: 0.85rem;
+  color: var(--t2);
+  font-weight: 500;
+  transition: all 0.2s ease;
+}
+
+.checklist-item.active {
+  border-color: var(--c1b);
+  color: var(--t1);
+  background: rgba(204, 17, 17, 0.05);
+}
+
+.checklist-item input {
+  accent-color: var(--c1);
+}
+
+/* Save Actions */
+.builder-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-top: 10px;
+}
+
+/* live preview card */
+.preview-container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: sticky;
+  top: 96px;
+}
+
+.preview-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: 'Space Mono', monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--c1b);
+  align-self: center;
+  padding: 4px 10px;
+  background: rgba(204, 17, 17, 0.08);
+  border: 1px solid rgba(204, 17, 17, 0.25);
+  border-radius: 20px;
+}
+
+.preview-frame {
+  width: 100%;
+  border-radius: var(--r3);
+  border: 1px solid var(--bdr);
+  overflow: hidden;
+  box-shadow: var(--sh2);
+  height: 520px;
+  background: var(--bg);
+  position: relative;
+}
+
+/* ==========================================================================
+   Public Showcase Themes Implementation
+   ========================================================================== */
+
+/* 1. Cyberpunk Theme */
+.theme-cyberpunk {
+  --bg-portfolio: #030303;
+  --panel-portfolio: rgba(10, 3, 15, 0.85);
+  --border-portfolio: #3f007f;
+  --accent-portfolio: #00ffcc;
+  --accent2-portfolio: #ff007f;
+  --text-portfolio: #00ffcc;
+  --text-sub-portfolio: #c080ff;
+  --font-portfolio: 'Space Mono', monospace;
+}
+
+.theme-cyberpunk .portfolio-shell {
+  background: var(--bg-portfolio);
+  background-image: linear-gradient(rgba(18, 10, 36, 0.5) 1px, transparent 1px), 
+                    linear-gradient(90deg, rgba(18, 10, 36, 0.5) 1px, transparent 1px);
+  background-size: 20px 20px;
+  color: var(--text-portfolio);
+  font-family: var(--font-portfolio);
+}
+
+.theme-cyberpunk h1, .theme-cyberpunk h2, .theme-cyberpunk h3, .theme-cyberpunk h4 {
+  color: var(--accent2-portfolio);
+  text-shadow: 0 0 8px rgba(255, 0, 127, 0.6);
+}
+
+.theme-cyberpunk .portfolio-panel {
+  border: 2px solid var(--border-portfolio);
+  background: var(--panel-portfolio);
+  box-shadow: 0 0 15px rgba(63, 0, 127, 0.5), inset 0 0 10px rgba(255, 0, 127, 0.15);
+  border-radius: 0px;
+  position: relative;
+}
+
+.theme-cyberpunk .portfolio-panel::before {
+  content: 'SYSTEM.ONLINE';
+  position: absolute;
+  top: -8px; right: 12px;
+  background: #3f007f;
+  color: #fff;
+  font-size: 0.55rem;
+  padding: 1px 6px;
+}
+
+.theme-cyberpunk .portfolio-pill {
+  background: rgba(0, 255, 204, 0.08);
+  border: 1px solid var(--accent-portfolio);
+  color: var(--accent-portfolio);
+  box-shadow: 0 0 6px rgba(0, 255, 204, 0.2);
+  border-radius: 0;
+}
+
+/* 2. Glassmorphic Theme */
+.theme-glassmorphic {
+  --bg-portfolio: radial-gradient(circle at 10% 20%, rgba(4, 5, 25, 1) 0%, rgba(20, 10, 42, 1) 90.2%);
+  --panel-portfolio: rgba(255, 255, 255, 0.04);
+  --border-portfolio: rgba(255, 255, 255, 0.08);
+  --accent-portfolio: #e63946;
+  --accent2-portfolio: #00d4ff;
+  --text-portfolio: #f8f9fa;
+  --text-sub-portfolio: #b0b5c0;
+  --font-portfolio: 'Inter', sans-serif;
+}
+
+.theme-glassmorphic .portfolio-shell {
+  background: var(--bg-portfolio);
+  color: var(--text-portfolio);
+  font-family: var(--font-portfolio);
+  position: relative;
+  overflow: hidden;
+}
+
+.theme-glassmorphic .portfolio-shell::before {
+  content: '';
+  position: absolute;
+  width: 300px; height: 300px;
+  background: radial-gradient(circle, rgba(230, 57, 70, 0.15) 0%, transparent 70%);
+  top: -10%; left: -10%;
+  pointer-events: none;
+}
+
+.theme-glassmorphic .portfolio-shell::after {
+  content: '';
+  position: absolute;
+  width: 300px; height: 300px;
+  background: radial-gradient(circle, rgba(0, 212, 255, 0.15) 0%, transparent 70%);
+  bottom: -10%; right: -10%;
+  pointer-events: none;
+}
+
+.theme-glassmorphic h1, .theme-glassmorphic h2, .theme-glassmorphic h3 {
+  font-family: 'Orbitron', sans-serif;
+}
+
+.theme-glassmorphic .portfolio-panel {
+  border: 1px solid var(--border-portfolio);
+  background: var(--panel-portfolio);
+  backdrop-filter: blur(20px);
+  border-radius: var(--r3);
+  box-shadow: 0 8px 32px 0 rgba(0, 0, 0, 0.3);
+}
+
+.theme-glassmorphic .portfolio-pill {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: #fff;
+  border-radius: var(--r1);
+}
+
+/* 3. Minimalist Light Theme */
+.theme-minimalist-light {
+  --bg-portfolio: #fafafa;
+  --panel-portfolio: #ffffff;
+  --border-portfolio: #e0e0e0;
+  --accent-portfolio: #111111;
+  --accent2-portfolio: #555555;
+  --text-portfolio: #222222;
+  --text-sub-portfolio: #666666;
+  --font-portfolio: 'Inter', sans-serif;
+}
+
+.theme-minimalist-light .portfolio-shell {
+  background: var(--bg-portfolio);
+  color: var(--text-portfolio);
+  font-family: var(--font-portfolio);
+}
+
+.theme-minimalist-light h1, .theme-minimalist-light h2, .theme-minimalist-light h3, .theme-minimalist-light h4 {
+  font-family: 'Inter', sans-serif;
+  font-weight: 800;
+  color: var(--accent-portfolio);
+}
+
+.theme-minimalist-light .portfolio-panel {
+  border: 1px solid var(--border-portfolio);
+  background: var(--panel-portfolio);
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.03);
+}
+
+.theme-minimalist-light .portfolio-pill {
+  background: #f0f0f0;
+  border: 1px solid #e0e0e0;
+  color: #444;
+  border-radius: 4px;
+}
+
+/* ==========================================================================
+   Public Portfolio Presentation Sheet Structure
+   ========================================================================== */
+.portfolio-presentation-container {
+  min-height: 100vh;
+  padding: 40px 16px;
+}
+
+.portfolio-shell {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 40px;
+  border-radius: var(--r3);
+  min-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+@media (max-width: 768px) {
+  .portfolio-shell {
+    padding: 20px;
+  }
+}
+
+/* Header Section */
+.portfolio-intro {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+@media (max-width: 768px) {
+  .portfolio-intro {
+    flex-direction: column;
+    text-align: center;
+  }
+}
+
+.portfolio-avatar {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  border: 4px solid var(--border-portfolio, var(--bdr));
+  background: rgba(0,0,0,0.1);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.15);
+}
+
+.portfolio-bio-col {
+  flex: 1;
+}
+
+.portfolio-name {
+  font-size: clamp(2rem, 4vw, 3rem);
+  font-weight: 800;
+  margin-bottom: 8px;
+}
+
+.portfolio-title {
+  font-size: 1.25rem;
+  color: var(--text-sub-portfolio, var(--t2));
+  font-weight: 600;
+  margin-bottom: 12px;
+}
+
+.portfolio-bio-text {
+  font-size: 1rem;
+  color: var(--text-sub-portfolio, var(--t2));
+  line-height: 1.6;
+  max-width: 700px;
+}
+
+/* Social links box */
+.portfolio-socials {
+  display: flex;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+@media (max-width: 768px) {
+  .portfolio-socials {
+    justify-content: center;
+  }
+}
+
+.portfolio-social-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid var(--border-portfolio, var(--bdr));
+  color: var(--text-portfolio, var(--t1));
+  transition: all 0.2s ease;
+}
+
+.portfolio-social-btn:hover {
+  transform: scale(1.1);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+/* Grid Layout for section panels */
+.portfolio-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 28px;
+}
+
+.portfolio-panel {
+  padding: 28px;
+}
+
+.portfolio-section-title {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 20px;
+  border-bottom: 1px solid var(--border-portfolio, var(--bdr2));
+  padding-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+/* Skills/Badges representation */
+.portfolio-pills-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.portfolio-pill {
+  padding: 8px 16px;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+/* Roadmaps list */
+.portfolio-roadmaps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.portfolio-roadmap-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  border: 1px solid var(--border-portfolio, var(--bdr2));
+  background: rgba(255,255,255,0.01);
+}
+
+.roadmap-card-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.roadmap-card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.roadmap-card-status {
+  font-size: 0.8rem;
+  color: var(--text-sub-portfolio, var(--t3));
+}
+
+/* Projects grid showcase */
+.portfolio-projects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 20px;
+}
+
+.portfolio-project-card {
+  border: 1px solid var(--border-portfolio, var(--bdr2));
+  border-radius: 8px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  background: rgba(255, 255, 255, 0.01);
+  transition: transform 0.25s ease;
+}
+
+.portfolio-project-card:hover {
+  transform: translateY(-4px);
+}
+
+.project-card-thumbnail {
+  width: 100%;
+  height: 140px;
+  object-fit: cover;
+}
+
+.project-card-body {
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.project-card-heading {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.project-card-description {
+  font-size: 0.85rem;
+  color: var(--text-sub-portfolio, var(--t2));
+  line-height: 1.5;
+  flex: 1;
+}
+
+.project-card-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border-portfolio, var(--bdr2));
+}
+
+/* Utilities */
+.action-floating-header {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-bottom: 20px;
+  max-width: 1000px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Print Specific Rules for PDF Export */
+@media print {
+  body {
+    background: #ffffff !important;
+    color: #000000 !important;
+    font-size: 12pt !important;
+  }
+  
+  .portfolio-shell {
+    border: none !important;
+    box-shadow: none !important;
+    background: #ffffff !important;
+    color: #000000 !important;
+    padding: 0 !important;
+    max-width: 100% !important;
+  }
+  
+  .action-floating-header,
+  .portfolio-builder-container,
+  nav,
+  footer,
+  #back-to-top,
+  .ns-navbar,
+  .ns-navbar-mobile {
+    display: none !important;
+  }
+  
+  .portfolio-panel {
+    background: #ffffff !important;
+    border: 1px solid #cccccc !important;
+    box-shadow: none !important;
+    page-break-inside: avoid !important;
+  }
+  
+  .portfolio-pill {
+    background: #e0e0e0 !important;
+    border: 1px solid #999999 !important;
+    color: #000000 !important;
+  }
+  
+  .portfolio-social-btn {
+    border-color: #999999 !important;
+  }
+}


### PR DESCRIPTION
Closes #66
## Summary

This PR fully implements the **Portfolio Builder & Public Portfolio System** (Issue #66 ) for NexaSphere. It provides a private configuration builder for developers to toggle sections (bio, skills, roadmaps, and projects), select from three high-performance responsive styling themes (Glassmorphic, Cyberpunk, Minimalist Light), dynamic SEO meta tags injection on load, and a clean client-side paper-safe PDF export.



---

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no functional change)
- [x] UI / Design change
- [ ] Tests only
- [ ] Documentation
- [ ] Infrastructure / DevOps
- [ ] Security

---

## What Changed

- **Database & Backend Registry Core**: Created a resilient backend layer in `portfolioRepository.js` that boots a `portfolios` table schema in PostgreSQL and falls back to a clean flat-file JSON repository (`portfolios.json`) in the server's data folder if PostgreSQL environment variables are absent.
- **REST APIs**: Added secure retrieval `GET /api/portfolio/:username` and creation/update `PUT /api/portfolio` endpoints with cryptographic SHA-256 passkey checks in `server/index.js`.
- **Interactive UI Builder Panel**: Built a state-of-the-art dual-pane visual customizer dashboard `PortfolioBuilder.jsx` allowing users to configure details, toggle cards, select skills/badges, and see layout changes in real-time.
- **Dynamic Public Showcases**: Built `PublicPortfolio.jsx` under `/p/:username` supporting three curated responsive themes (*Cyberpunk*, *Glassmorphic*, *Minimalist Light*), automated Open Graph/Twitter Card SEO tags injection on page load, and high-performance `@media print` CSS configurations for paper-safe client-side PDF export.
- **Global Routing & Navbar Navigation**: Wired dynamic URL parsing in `App.jsx` and integrated links in `Navbar.jsx`.

---

## How to Test

1. Navigate to the client folder, install dependencies using `npm install`, and start the development server using `npm run dev`.
2. Start the backend server by navigating to `/server` and executing `npm run dev`.
3. Run automated tests with `npm run test` to verify frontend routing and component mounting integrity.
4. Click on the **Portfolio** tab in the navbar, choose a custom username and passkey, populate details, and click **Build & Publish Portfolio**.
5. Click **Open Showcase Page** to view the live URL at `/p/username`, switch between the three styles (*Glassmorphic, Cyberpunk, and Minimalist Light*), and export to PDF.