### PR TITLE
Fix hardcoded membership secret leaked in client-side bundle

### DIFF
--- a/admin-dashboard/.env.example
+++ b/admin-dashboard/.env.example
@@ -1,1 +1,4 @@
 VITE_API_BASE=https://nexasphere-api.up.railway.app
+
+# Note: Membership responses are now fetched through the server-side proxy.
+# Configure MEMBERSHIP_SCRIPT_URL and MEMBERSHIP_SECRET in the server .env file.

--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -251,19 +251,6 @@ export const api = {
   },
 
   membership: {
-    getAll: () => {
-      const scriptUrl = import.meta.env.VITE_MEMBERSHIP_SCRIPT_URL;
-      const secret = import.meta.env.VITE_MEMBERSHIP_SECRET || 'NEXA_SECRET_2026';
-
-      if (scriptUrl) {
-        // Fetch from Google Apps Script (production)
-        return fetch(`${scriptUrl}?token=${secret}`)
-          .then(r => r.json())
-          .catch(() => ({ responses: [] }));
-      }
-
-      // No Google Script configured — return empty (no Java endpoint for this)
-      return Promise.resolve({ responses: [] });
-    }
+    getAll: () => fetchWithAuth('/api/admin/membership'),
   },
 };

--- a/google-apps-script/Code.gs
+++ b/google-apps-script/Code.gs
@@ -9,24 +9,29 @@
  *   2.  Go to  Extensions → Apps Script
  *   3.  Your project should be named  "NexaSphere Membership"
  *   4.  Delete everything in Code.gs and paste THIS file.
- *   5.  Click  Deploy → New deployment → Web App
+ *   5.  Set the secret token:
+ *         File → Project properties → Script properties
+ *         Add key: MEMBERSHIP_SECRET  value: <your-strong-secret>
+ *   6.  Click  Deploy → New deployment → Web App
  *           Execute as  : Me
  *           Who can access : Anyone
- *   6.  Click  Authorise  when prompted (allow Spreadsheet access).
- *   7.  Copy the Web App URL that appears after deployment.
- *   8.  Paste that URL into  MembershipPage.jsx  at the top:
- *
- *           const MEMBERSHIP_SCRIPT_URL = 'https://script.google.com/macros/s/AKfy.../exec';
- *
- *       OR add it to your .env file:
- *           VITE_MEMBERSHIP_SCRIPT_URL=https://script.google.com/macros/s/AKfy.../exec
+ *   7.  Click  Authorise  when prompted (allow Spreadsheet access).
+ *   8.  Copy the Web App URL that appears after deployment.
+ *   9.  Add to your SERVER .env file (NOT client-side):
+ *         MEMBERSHIP_SCRIPT_URL=https://script.google.com/macros/s/AKfy.../exec
+ *         MEMBERSHIP_SECRET=<your-strong-secret>
  *
  * SHEET STRUCTURE:
  *   The script will automatically create a tab called "Membership" inside
  *   your spreadsheet with a styled, frozen header row the first time it runs.
  *   You do NOT need to create the tab manually.
  *
- * The spreadsheet is the one this script is BOUND to (opened from Extensions → Apps Script).
+ * SECURITY:
+ *   The secret token is stored in Script Properties (server-side only).
+ *   Admin requests must include the token in the POST body with action: 'getResponses'.
+ *   The secret is never exposed to client-side code.
+ *
+ * The spreadsheet is the one this script is bound to (opened from Extensions → Apps Script).
  */
 
 // ── CONFIG ────────────────────────────────────────────────────────────────────
@@ -93,16 +98,22 @@ function _styleHeader(sheet) {
   }
 }
 
-// ── POST handler (receives form submission from the website) ──────────────────
+// ── GET/POST handler — Fetch data for Admin Dashboard or health check ────────────────
+function doGet(e) {
+  return _respond({
+    ok: true,
+    service: 'NexaSphere Membership API',
+    version: '1.1',
+    sheet: SHEET_TAB_NAME,
+    status: 'Ready'
+  });
+}
+
 function doPost(e) {
   try {
-    // The website sends the payload as plain-text JSON (required for no-cors mode).
     var raw = '';
     if (e && e.postData && e.postData.contents) {
       raw = e.postData.contents;
-    } else if (e && e.parameter) {
-      // Fallback: form-encoded params
-      raw = JSON.stringify(e.parameter);
     }
 
     if (!raw) {
@@ -110,27 +121,63 @@ function doPost(e) {
     }
 
     var data = JSON.parse(raw);
-    var now  = new Date().toISOString();
 
+    // Handle admin requests (getResponses) with token verification
+    if (data.action === 'getResponses') {
+      var token = data.token;
+      var SECRET_TOKEN = PropertiesService.getScriptProperties().getProperty('MEMBERSHIP_SECRET');
+
+      if (!SECRET_TOKEN || token !== SECRET_TOKEN) {
+        return _respond({ ok: false, error: 'Unauthorized' });
+      }
+
+      try {
+        var sheet = getOrCreateSheet();
+        var rows = sheet.getDataRange().getValues();
+        var headers = rows[0];
+        var responses = [];
+
+        for (var i = 1; i < rows.length; i++) {
+          var obj = {};
+          for (var j = 0; j < headers.length; j++) {
+            var key = headers[j].toString().toLowerCase()
+              .replace(/[^a-z0-9]+(.)/g, (m, chr) => chr.toUpperCase())
+              .replace(/[^a-z0-9]/gi, '');
+            obj[key] = rows[i][j];
+          }
+          responses.push(obj);
+        }
+
+        return _respond({
+          ok: true,
+          count: responses.length,
+          responses: responses
+        });
+      } catch (err) {
+        return _respond({ ok: false, error: err.message });
+      }
+    }
+
+    // Handle form submissions (original behavior)
+    var now  = new Date().toISOString();
     var sheet = getOrCreateSheet();
 
     var row = [
-      now,                                                              // Timestamp (server)
-      data.fullName    || '',                                           // Full Name
-      data.collegeEmail|| '',                                           // College Email
-      data.rollNumber  || '',                                           // University Roll Number
-      data.course      || '',                                           // Course
-      data.branch      || '',                                           // Branch
-      data.section     || '',                                           // Section
-      data.semester    || '',                                           // Semester
-      data.whatsapp    || '',                                           // WhatsApp Number
-      // groups may be a pre-joined string from MembershipPage.jsx
+      now,
+      data.fullName    || '',
+      data.collegeEmail|| '',
+      data.rollNumber  || '',
+      data.course      || '',
+      data.branch      || '',
+      data.section     || '',
+      data.semester    || '',
+      data.whatsapp    || '',
       Array.isArray(data.groups)
         ? data.groups.join(', ')
-        : (data.groups || ''),                                          // Groups Selected
-      data.whyJoin     || '',                                           // Why Join NexaSphere
-      data.submittedAt || now,                                          // Submitted At (client)
-      data.userAgent   || '',                                           // User Agent
+        : (data.groups || ''),
+      data.whyJoin     || '',
+      data.submittedAt || now,
+      data.userAgent   || '',
     ];
 
     sheet.appendRow(row);
@@ -140,51 +187,6 @@ function doPost(e) {
   } catch (err) {
     return _respond({ ok: false, error: err.message });
   }
-}
-
-// ── GET handler — Fetch data for Admin Dashboard or health check ────────────────
-function doGet(e) {
-  var token = e.parameter.token;
-  var SECRET_TOKEN = 'NEXA_SECRET_2026'; // Match this in your Admin Dashboard .env
-
-  if (token === SECRET_TOKEN) {
-    try {
-      var sheet = getOrCreateSheet();
-      var rows = sheet.getDataRange().getValues();
-      var headers = rows[0];
-      var data = [];
-
-      // Skip header row and convert rows to objects
-      for (var i = 1; i < rows.length; i++) {
-        var obj = {};
-        for (var j = 0; j < headers.length; j++) {
-          // Create camelCase keys from headers (e.g. "Full Name" -> "fullName")
-          var key = headers[j].toString().toLowerCase()
-            .replace(/[^a-z0-9]+(.)/g, (m, chr) => chr.toUpperCase())
-            .replace(/[^a-z0-9]/gi, '');
-          obj[key] = rows[i][j];
-        }
-        data.push(obj);
-      }
-
-      return _respond({
-        ok: true,
-        count: data.length,
-        responses: data
-      });
-    } catch (err) {
-      return _respond({ ok: false, error: err.message });
-    }
-  }
-
-  // Default health check response
-  return _respond({
-    ok: true,
-    service: 'NexaSphere Membership API',
-    version: '1.1',
-    sheet: SHEET_TAB_NAME,
-    status: 'Ready'
-  });
 }
 
 // ── Helper ────────────────────────────────────────────────────────────────────

--- a/server/.env.example
+++ b/server/.env.example
@@ -34,3 +34,7 @@ GOOGLE_SHEET_TAB_NAME=Responses
 GOOGLE_MEMBERSHIP_TAB_NAME=MembershipResponses
 GOOGLE_RECRUITMENT_TAB_NAME=RecruitmentResponses
 GOOGLE_CORE_TEAM_TAB_NAME=CoreTeamResponses
+
+# Membership Google Apps Script (Server-side only — never expose to client)
+MEMBERSHIP_SCRIPT_URL=
+MEMBERSHIP_SECRET=

--- a/server/index.js
+++ b/server/index.js
@@ -680,6 +680,33 @@ app.delete('/api/admin/core-team/:id', adminAuth, async (req, res) => {
   }
 });
 
+app.get('/api/admin/membership', adminAuth, async (req, res) => {
+  const scriptUrl = process.env.MEMBERSHIP_SCRIPT_URL;
+  const secret = process.env.MEMBERSHIP_SECRET;
+
+  if (!scriptUrl || !secret) {
+    return res.json({ responses: [] });
+  }
+
+  try {
+    const response = await fetch(scriptUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action: 'getResponses', token: secret }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Google Apps Script returned ${response.status}`);
+    }
+
+    const data = await response.json();
+    return res.json({ responses: data.responses || [] });
+  } catch (err) {
+    console.error('[Membership] Failed to fetch responses:', err.message);
+    return res.status(500).json({ error: 'Failed to fetch membership responses' });
+  }
+});
+
 async function handleForm(formType, req, res) {
   try {
     const payload = normalizeFormSubmission(formType, req.body || {});


### PR DESCRIPTION
Closes #85

## Problem

The membership API secret was exposed in two ways:

1. **Client-side bundling** — `VITE_MEMBERSHIP_SECRET` in the admin dashboard gets inlined into the browser JS bundle (all `VITE_` vars are client-side in Vite)
2. **Hardcoded fallback** — `'NEXA_SECRET_2026'` was committed directly in source code as a fallback value
3. **URL query parameter** — Secret was passed as `?token=${secret}` which leaks into browser history, server logs, and proxy logs

## Solution

Moved the entire membership data fetch flow behind a server-side proxy:

### Server-side (`server/index.js`)
- Added `GET /api/admin/membership` endpoint protected by `adminAuth` middleware
- Server holds `MEMBERSHIP_SCRIPT_URL` and `MEMBERSHIP_SECRET` in environment variables
- Calls Google Apps Script via POST with token in request body (not URL)

### Admin Dashboard (`admin-dashboard/src/services/api.js`)
- Removed `VITE_MEMBERSHIP_SECRET` and hardcoded fallback entirely
- Membership responses now fetched through `/api/admin/membership` server proxy
- No secrets leave the server

### Google Apps Script (`google-apps-script/Code.gs`)
- Removed hardcoded `'NEXA_SECRET_2026'` from source
- Secret now stored in Google Script Properties (server-side config)
- Token verification moved from GET query param to POST body
- Updated deployment docs to use Script Properties for secret storage

## Files Changed
- `server/index.js` — Added membership proxy endpoint
- `server/.env.example` — Added `MEMBERSHIP_SCRIPT_URL` and `MEMBERSHIP_SECRET`
- `admin-dashboard/src/services/api.js` — Removed client-side secret handling
- `admin-dashboard/.env.example` — Added note about server-side config
- `google-apps-script/Code.gs` — Removed hardcoded secret, use Script Properties