### PR TITLE
Add offline mode warning banner for mock auth fallback

### DIFF
--- a/admin-dashboard/src/App.jsx
+++ b/admin-dashboard/src/App.jsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom
 import { auth } from './services/auth';
 import { Sidebar } from './components/Sidebar';
 import { Toast } from './components/Toast';
+import { OfflineBanner } from './components/OfflineBanner';
 import { LoginPage } from './pages/LoginPage';
 import { DashboardHome } from './pages/DashboardHome';
 import { EventsManager } from './pages/EventsManager';
@@ -17,6 +18,7 @@ function RequireAuth() {
 function DashboardLayout() {
   return (
     <div className="app-layout">
+      <OfflineBanner />
       <Sidebar />
       <main className="main-content">
         <Outlet />

--- a/admin-dashboard/src/components/OfflineBanner.jsx
+++ b/admin-dashboard/src/components/OfflineBanner.jsx
@@ -1,0 +1,27 @@
+import { useState, useEffect } from 'react';
+import { auth } from '../services/auth';
+
+export function OfflineBanner() {
+  const [isOffline, setIsOffline] = useState(false);
+
+  useEffect(() => {
+    setIsOffline(auth.isOfflineMode());
+
+    const checkInterval = setInterval(() => {
+      setIsOffline(auth.isOfflineMode());
+    }, 2000);
+
+    return () => clearInterval(checkInterval);
+  }, []);
+
+  if (!isOffline) return null;
+
+  return (
+    <div className="offline-banner">
+      <span className="offline-icon">&#9888;</span>
+      <span>
+        <strong>Offline Mode</strong> — Changes are saved locally and will not sync to the server.
+      </span>
+    </div>
+  );
+}

--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -75,8 +75,7 @@ const getDb = (key, defaultVal) => {
 const setDb = (key, val) => localStorage.setItem(`ns_db_${key}`, JSON.stringify(val));
 
 async function fetchWithAuth(url, options = {}) {
-  // If we are using the mock token (offline mode), bypass fetch entirely
-  const isOffline = auth.getToken() === 'mock-jwt-token-for-nexasphere-admin';
+  const isOffline = auth.isOfflineMode();
 
   if (!isOffline) {
     try {
@@ -190,18 +189,27 @@ export const api = {
   events: {
     getAll: () => fetchWithAuth('/api/admin/events'),
     create: async (event) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       const result = await fetchWithAuth('/api/admin/events', { method: 'POST', body: JSON.stringify(event) });
       eventEmitter.emit(EVENTS.EVENT_CREATED, result);
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Event created' });
       return result;
     },
     update: async (id, event) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       const result = await fetchWithAuth(`/api/admin/events/${id}`, { method: 'PUT', body: JSON.stringify(event) });
       eventEmitter.emit(EVENTS.EVENT_UPDATED, result);
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Event updated' });
       return result;
     },
     delete: async (id) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       await fetchWithAuth(`/api/admin/events/${id}`, { method: 'DELETE' });
       eventEmitter.emit(EVENTS.EVENT_DELETED, { id });
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Event deleted' });
@@ -211,12 +219,18 @@ export const api = {
   activityEvents: {
     getAll: (activityKey) => fetchWithAuth(`/api/admin/activity-events/${activityKey}`),
     create: async (activityKey, event) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       const result = await fetchWithAuth(`/api/admin/activity-events/${activityKey}`, { method: 'POST', body: JSON.stringify(event) });
       eventEmitter.emit(EVENTS.ACTIVITY_EVENT_CREATED, { activityKey, event: result });
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Activity event added' });
       return result;
     },
     delete: async (activityKey, eventId) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       await fetchWithAuth(`/api/admin/activity-events/${activityKey}/${eventId}`, { method: 'DELETE' });
       eventEmitter.emit(EVENTS.ACTIVITY_EVENT_DELETED, { activityKey, eventId });
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Activity event deleted' });
@@ -238,12 +252,18 @@ export const api = {
       return { members };
     },
     add: async (member) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       const result = await fetchWithAuth('/api/admin/core-team', { method: 'POST', body: JSON.stringify(member) });
       eventEmitter.emit(EVENTS.CORE_TEAM_MEMBER_ADDED, result);
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Member added' });
       return result;
     },
     remove: async (id) => {
+      if (auth.isOfflineMode()) {
+        eventEmitter.emit(EVENTS.NOTIFY, { type: 'warning', message: 'Offline — changes not saved to server' });
+      }
       await fetchWithAuth(`/api/admin/core-team/${id}`, { method: 'DELETE' });
       eventEmitter.emit(EVENTS.CORE_TEAM_MEMBER_REMOVED, { id });
       eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Member removed' });

--- a/admin-dashboard/src/services/auth.js
+++ b/admin-dashboard/src/services/auth.js
@@ -1,13 +1,17 @@
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8080';
 const TOKEN_KEY = 'ns_admin_token';
 const EMAIL_KEY = 'ns_admin_email';
+const OFFLINE_FLAG_KEY = 'ns_offline_mode';
+
+function generateMockToken() {
+  return `offline-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
 
 export const auth = {
   async login(email, password) {
     const cleanEmail = email.trim().toLowerCase();
     const cleanPassword = password.trim();
 
-    // Always try the real Java backend first
     try {
       const res = await fetch(`${API_BASE}/api/admin/login`, {
         method: 'POST',
@@ -21,17 +25,17 @@ export const auth = {
       const data = await res.json();
       localStorage.setItem(TOKEN_KEY, data.token);
       localStorage.setItem(EMAIL_KEY, cleanEmail);
-      if (import.meta.env.DEV) console.log('[Auth] Logged in via LIVE Java backend ✓');
+      localStorage.removeItem(OFFLINE_FLAG_KEY);
+      if (import.meta.env.DEV) console.log('[Auth] Logged in via LIVE Java backend');
       return data;
     } catch (err) {
-      // Only fall back to mock if Java server is completely unreachable (network error)
       const isNetworkError = err instanceof TypeError && err.message.includes('fetch');
       if (isNetworkError && cleanEmail === 'nexasphere@glbajajgroup.org' && cleanPassword === 'Admin@123') {
-        if (import.meta.env.DEV) console.warn('[Auth] Java server unreachable — falling back to OFFLINE mock mode');
-        const mockToken = 'mock-jwt-token-for-nexasphere-admin';
+        const mockToken = generateMockToken();
         localStorage.setItem(TOKEN_KEY, mockToken);
         localStorage.setItem(EMAIL_KEY, cleanEmail);
-        return { token: mockToken, email: cleanEmail };
+        localStorage.setItem(OFFLINE_FLAG_KEY, 'true');
+        return { token: mockToken, email: cleanEmail, offline: true };
       }
       throw err;
     }
@@ -40,9 +44,11 @@ export const auth = {
   logout() {
     localStorage.removeItem(TOKEN_KEY);
     localStorage.removeItem(EMAIL_KEY);
+    localStorage.removeItem(OFFLINE_FLAG_KEY);
   },
 
   getToken() { return localStorage.getItem(TOKEN_KEY); },
   getEmail() { return localStorage.getItem(EMAIL_KEY); },
   isAuthenticated() { return !!this.getToken(); },
+  isOfflineMode() { return localStorage.getItem(OFFLINE_FLAG_KEY) === 'true'; },
 };

--- a/admin-dashboard/src/styles/admin.css
+++ b/admin-dashboard/src/styles/admin.css
@@ -31,6 +31,7 @@ body {
   flex: 1;
   margin-left: var(--sidebar-w);
   padding: 32px;
+  padding-top: 64px;
   min-height: 100vh;
   background: var(--bg);
 }
@@ -505,6 +506,7 @@ body {
 
 .toast-success { background: #166534; border: 1px solid #22c55e; color: #bbf7d0; }
 .toast-error { background: #7f1d1d; border: 1px solid #ef4444; color: #fecaca; }
+.toast-warning { background: #78350f; border: 1px solid #f59e0b; color: #fde68a; }
 
 @keyframes slideIn {
   from { transform: translateX(100%); opacity: 0; }
@@ -638,3 +640,30 @@ body {
 }
 
 .animate-spin { animation: spin 1s linear infinite; }
+
+/* ── Offline Banner ── */
+.offline-banner {
+  position: fixed;
+  top: 0;
+  left: var(--sidebar-w);
+  right: 0;
+  z-index: 150;
+  background: #78350f;
+  border-bottom: 1px solid #f59e0b;
+  color: #fde68a;
+  padding: 8px 20px;
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.offline-icon {
+  font-size: 16px;
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.5; }
+}


### PR DESCRIPTION
Closes #84

## Problem

When the Java backend is unreachable, the admin dashboard silently falls back to offline mock authentication. All CRUD operations run against `localStorage` with no visible warning — admins see success toasts but changes are never persisted to the server.

Additionally, the mock token was a hardcoded constant (`mock-jwt-token-for-nexasphere-admin`) that could be manually set in localStorage to bypass client-side auth checks.

## Solution

### Visible offline indicator
- Added `OfflineBanner` component that shows a persistent warning bar at the top of the dashboard when operating in offline mode
- Banner includes a pulsing warning icon and clear message that changes won't sync to the server

### Warning toasts for all operations
- Every CRUD operation (create, update, delete) now emits a warning toast before executing when in offline mode
- Admins see `Offline — changes not saved to server` before any success confirmation

### Dynamic mock token
- Replaced hardcoded `mock-jwt-token-for-nexasphere-admin` with a dynamically generated token (`offline-{timestamp}-{random}`)
- Prevents the token from being used as a known bypass value

### Offline state tracking
- Added `ns_offline_mode` localStorage flag to track offline state
- `auth.isOfflineMode()` helper checks this flag instead of comparing against a known token string
- Flag is cleared automatically on successful live login

## Files Changed
- `admin-dashboard/src/services/auth.js` — Dynamic token, offline flag, `isOfflineMode()` helper
- `admin-dashboard/src/services/api.js` — Warning toasts for all CRUD operations
- `admin-dashboard/src/components/OfflineBanner.jsx` — New persistent warning banner
- `admin-dashboard/src/App.jsx` — Integrated OfflineBanner into dashboard layout
- `admin-dashboard/src/styles/admin.css` — Banner styles and warning toast color