### PR TITLE
Disable H2 console in production and restrict frame options

### DIFF
--- a/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
+++ b/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package org.nexasphere.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -13,15 +14,22 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.core.env.Environment;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
 
     private final BearerTokenAuthFilter bearerTokenAuthFilter;
+    private final Environment environment;
 
-    public SecurityConfig(BearerTokenAuthFilter bearerTokenAuthFilter) {
+    public SecurityConfig(BearerTokenAuthFilter bearerTokenAuthFilter, Environment environment) {
         this.bearerTokenAuthFilter = bearerTokenAuthFilter;
+        this.environment = environment;
+    }
+
+    private boolean isDevProfile() {
+        return environment.matchesProfiles("dev");
     }
 
     @Bean
@@ -39,12 +47,29 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/health").permitAll()
                         .requestMatchers("/api/admin/login").permitAll()
                         .requestMatchers("/api/content/**").permitAll()
-                        .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/api/admin/**").authenticated()
                         .anyRequest().permitAll()
                 )
-                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .headers(headers -> {
+                    if (isDevProfile()) {
+                        headers.frameOptions(frame -> frame.sameOrigin());
+                    } else {
+                        headers.frameOptions(frame -> frame.deny());
+                    }
+                })
                 .addFilterBefore(bearerTokenAuthFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+
+    @Bean
+    @Profile("dev")
+    public SecurityFilterChain h2ConsoleFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher("/h2-console/**")
+                .csrf(csrf -> csrf.disable())
+                .headers(headers -> headers.frameOptions(frame -> frame.sameOrigin()))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
 
         return http.build();
     }

--- a/server-java/src/main/resources/application-dev.properties
+++ b/server-java/src/main/resources/application-dev.properties
@@ -1,0 +1,3 @@
+# Development profile — H2 console enabled for local debugging only
+spring.h2.console.enabled=true
+spring.h2.console.settings.web-allow-others=false

--- a/server-java/src/main/resources/application.properties
+++ b/server-java/src/main/resources/application.properties
@@ -7,7 +7,8 @@ spring.datasource.driver-class-name=${DB_DRIVER:org.h2.Driver}
 spring.datasource.username=${DB_USER:sa}
 spring.datasource.password=${DB_PASS:}
 
-spring.h2.console.enabled=true
+# H2 console disabled by default — only enabled in 'dev' profile
+spring.h2.console.enabled=false
 spring.h2.console.path=/h2-console
 spring.h2.console.settings.web-allow-others=false
 


### PR DESCRIPTION
Closes #83

## Problem

The Spring Boot Java backend had two critical security issues:

1. **H2 console publicly accessible** — `/h2-console/**` was set to `permitAll()` with no authentication required, allowing anyone to execute arbitrary SQL queries
2. **frameOptions set to sameOrigin** — allowed the H2 console to be embedded in iframes on same-origin pages, enabling clickjacking attacks
3. **No profile separation** — H2 console was enabled in all environments including production

## Solution

### H2 console disabled by default
- Changed `spring.h2.console.enabled=true` to `false` in `application.properties`
- Created `application-dev.properties` to enable H2 console only for local development
- Removed `/h2-console/**` from the main security filter chain

### Profile-based H2 console access
- Added a separate `SecurityFilterChain` bean for `/h2-console/**` with `@Profile("dev")` annotation
- H2 console is only accessible when the `dev` Spring profile is active
- Production deployments have zero H2 console exposure

### Frame options restricted
- Set `frameOptions` to `DENY` by default in production
- Only allows `sameOrigin` when running with the `dev` profile

### CSRF note
CSRF protection remains disabled for the stateless API. This is correct behavior for Bearer token authentication since CSRF attacks require cookie-based sessions. The real vulnerability was the exposed H2 console, which is now properly restricted.

## Files Changed
- `server-java/src/main/resources/application.properties` — Disabled H2 console by default
- `server-java/src/main/resources/application-dev.properties` — New dev profile config
- `server-java/src/main/java/org/nexasphere/config/SecurityConfig.java` — Profile-based H2 access, frame options