### PR TITLE
Add auth to monitoring routes and improve data sanitization

### DIFF
--- a/server/.env.example.monitoring
+++ b/server/.env.example.monitoring
@@ -41,6 +41,11 @@ ENABLE_ERROR_TRACKING=true
 # Maximum number of errors to store in memory
 MAX_ERRORS_IN_MEMORY=1000
 
+# --------- MONITORING API AUTHENTICATION ---------
+# Token required to access /api/monitoring/** endpoints (except /health)
+# Generate a strong random token: openssl rand -hex 32
+MONITORING_API_TOKEN=
+
 # --------- NODE ENVIRONMENT ---------
 NODE_ENV=development
 

--- a/server/routes/monitoring.js
+++ b/server/routes/monitoring.js
@@ -14,9 +14,25 @@ const {
 } = require("../services/errorTrackingService");
 const logger = require("../utils/logger");
 
+function requireMonitoringAuth(req, res, next) {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+
+  const token = authHeader.slice(7).trim();
+  const expectedToken = process.env.MONITORING_API_TOKEN;
+
+  if (!expectedToken || token !== expectedToken) {
+    return res.status(403).json({ error: "Forbidden" });
+  }
+
+  next();
+}
+
 /**
  * GET /api/monitoring/health
- * Health check endpoint
+ * Health check endpoint — no auth required
  */
 router.get("/health", (req, res) => {
   res.status(200).json({
@@ -31,7 +47,7 @@ router.get("/health", (req, res) => {
  * GET /api/monitoring/metrics
  * Get current performance metrics
  */
-router.get("/metrics", (req, res) => {
+router.get("/metrics", requireMonitoringAuth, (req, res) => {
   try {
     const metrics = getMetrics();
 
@@ -53,7 +69,7 @@ router.get("/metrics", (req, res) => {
  * GET /api/monitoring/errors/stats
  * Get error statistics
  */
-router.get("/errors/stats", (req, res) => {
+router.get("/errors/stats", requireMonitoringAuth, (req, res) => {
   try {
     const stats = getErrorStats();
 
@@ -76,7 +92,7 @@ router.get("/errors/stats", (req, res) => {
  * Get recent errors
  * Query params: limit (default 50)
  */
-router.get("/errors/recent", (req, res) => {
+router.get("/errors/recent", requireMonitoringAuth, (req, res) => {
   try {
     const limit = Math.min(parseInt(req.query.limit) || 50, 1000);
     const errors = getRecentErrors(limit);
@@ -100,7 +116,7 @@ router.get("/errors/recent", (req, res) => {
  * GET /api/monitoring/errors/endpoint/:endpoint
  * Get errors for specific endpoint
  */
-router.get("/errors/endpoint", (req, res) => {
+router.get("/errors/endpoint", requireMonitoringAuth, (req, res) => {
   try {
     const endpoint = req.query.url;
 
@@ -134,7 +150,7 @@ router.get("/errors/endpoint", (req, res) => {
  * GET /api/monitoring/errors/user/:userId
  * Get errors for specific user
  */
-router.get("/errors/user/:userId", (req, res) => {
+router.get("/errors/user/:userId", requireMonitoringAuth, (req, res) => {
   try {
     const { userId } = req.params;
     const limit = Math.min(parseInt(req.query.limit) || 20, 1000);
@@ -161,12 +177,11 @@ router.get("/errors/user/:userId", (req, res) => {
  * Get application logs
  * Query params: level, limit
  */
-router.get("/logs", (req, res) => {
+router.get("/logs", requireMonitoringAuth, (req, res) => {
   try {
     const level = req.query.level || "all";
     const limit = Math.min(parseInt(req.query.limit) || 100, 1000);
 
-    // For now, return a message about how to access logs
     res.status(200).json({
       success: true,
       message: "Logs are available in server/logs/combined.log",
@@ -191,7 +206,7 @@ router.get("/logs", (req, res) => {
  * Test endpoint for triggering an error
  * For development/testing only
  */
-router.post("/test-error", (req, res, next) => {
+router.post("/test-error", requireMonitoringAuth, (req, res, next) => {
   if (process.env.NODE_ENV === "production") {
     return res.status(403).json({
       success: false,

--- a/server/services/errorTrackingService.js
+++ b/server/services/errorTrackingService.js
@@ -153,19 +153,38 @@ function getUserErrors(userId, limit = 20) {
 
 /**
  * Sanitize sensitive data from request body
+ * Uses pattern matching to catch variations like adminPassword, refreshToken, etc.
  * @param {Object} data - Request data
  */
 function sanitizeData(data) {
   if (!data) return null;
 
   const sanitized = { ...data };
-  const sensitiveFields = ["password", "token", "secret", "apiKey", "credit_card"];
+  const sensitivePatterns = [
+    /password/i,
+    /passwd/i,
+    /pwd/i,
+    /token/i,
+    /secret/i,
+    /apikey/i,
+    /api_key/i,
+    /credit.?card/i,
+    /cc.?number/i,
+    /card.?number/i,
+    /ssn/i,
+    /social.?security/i,
+    /private.?key/i,
+    /access.?key/i,
+  ];
 
-  sensitiveFields.forEach((field) => {
-    if (sanitized[field]) {
-      sanitized[field] = "***REDACTED***";
+  for (const key of Object.keys(sanitized)) {
+    for (const pattern of sensitivePatterns) {
+      if (pattern.test(key)) {
+        sanitized[key] = "***REDACTED***";
+        break;
+      }
     }
-  });
+  }
 
   return sanitized;
 }
@@ -178,7 +197,17 @@ function sanitizeHeaders(headers) {
   if (!headers) return null;
 
   const sanitized = { ...headers };
-  const sensitiveHeaders = ["authorization", "cookie", "x-api-key"];
+  const sensitiveHeaders = [
+    "authorization",
+    "cookie",
+    "x-api-key",
+    "x-csrf-token",
+    "x-session-id",
+    "x-auth-token",
+    "x-access-token",
+    "x-refresh-token",
+    "set-cookie",
+  ];
 
   sensitiveHeaders.forEach((header) => {
     if (sanitized[header.toLowerCase()]) {


### PR DESCRIPTION
Closes #81

## Problem

All routes under `/api/monitoring/**` were publicly accessible with zero authentication. This exposed:
- Full error stack traces revealing internal file paths and library versions
- User emails and IP addresses from error contexts
- Request bodies with potentially sensitive data
- Per-user error histories allowing PII enumeration
- Server log file paths

Additionally, the data sanitization only matched exact field names (`password`, `token`), leaving variations like `adminPassword`, `refreshToken`, `private_key` exposed in plaintext.

## Solution

### Authentication for monitoring endpoints
- Added `requireMonitoringAuth` middleware to all monitoring routes except `/health`
- Uses Bearer token authentication via `MONITORING_API_TOKEN` environment variable
- Returns 401 if no token provided, 403 if token doesn't match
- Health check remains public (standard practice)

### Improved data sanitization
- Replaced exact field matching with regex pattern matching in `sanitizeData()`
- Now catches variations: `adminPassword`, `userPassword`, `refreshToken`, `private_key`, `access_key`, etc.
- Patterns cover: password/passwd/pwd, token, secret, apikey/api_key, credit card, SSN, private/access keys

### Expanded header sanitization
- Added `x-csrf-token`, `x-session-id`, `x-auth-token`, `x-access-token`, `x-refresh-token`, `set-cookie` to the redaction list

## Files Changed
- `server/routes/monitoring.js` — Added auth middleware to all routes except /health
- `server/services/errorTrackingService.js` — Regex-based sanitization, expanded header list
- `server/.env.example.monitoring` — Added MONITORING_API_TOKEN config