### PR TITLE
Fix navbar layout and notification icon visibility glitch

### DIFF
--- a/src/shared/Navbar.jsx
+++ b/src/shared/Navbar.jsx
@@ -138,7 +138,7 @@ export default function Navbar({ activeTab, onTabChange, onToggleTheme, theme, o
           ))}
         </ul>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifySelf: 'end' }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <NotificationBell />
           <BookmarkToggle onToggle={onToggleBookmarks} />
           <div className="ns-nav-ctas">

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -54,7 +54,7 @@ img, svg { display: block; max-width: 100%; }
 button { cursor: none; font-family: 'Rajdhani', sans-serif; border: none; background: none; }
 button, a { touch-action: manipulation; -webkit-tap-highlight-color: transparent; }
 
-.container { width: 100%; max-width: 1240px; margin: 0 auto; padding: 0 28px; }
+.container { width: 100%; max-width: 1240px; margin: 0 auto; }
 .section   { padding: 100px 0; }
 
 .section-title {


### PR DESCRIPTION
## Related Issue
Closes #138

## Description

Fixed the navbar layout issue where the notification bell and bookmark icons were not visible on laptop/desktop screen sizes. The issue was caused by navbar spacing and layout overflow on larger widths.

## Type of PR

- [X] Bug fix

## Screenshots / Videos (if applicable)

Before: 
<img width="1915" height="974" alt="image" src="https://github.com/user-attachments/assets/bcbe49f3-81dd-4d37-9684-75614d78fcc2" />

After:
<img width="1905" height="975" alt="image" src="https://github.com/user-attachments/assets/c42b587d-dd8b-45b8-b7e8-cee12345eab3" />
