### PR TITLE
Title: Bug: Fix memory leak in Push Subscriptions by capping Set size (#153)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -788,7 +788,14 @@ const pushSubscriptions = new Set();
 app.post('/api/notifications/subscribe', (req, res) => {
   try {
     const { subscription } = req.body;
-    if (subscription) pushSubscriptions.add(JSON.stringify(subscription));
+        if (subscription) {
+      pushSubscriptions.add(JSON.stringify(subscription));
+      // Prevent memory leak by capping maximum subscriptions to 10,000
+      if (pushSubscriptions.size > 10000) {
+        const oldest = pushSubscriptions.values().next().value;
+        pushSubscriptions.delete(oldest);
+      }
+    }
     return res.json({ success: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });


### PR DESCRIPTION
Description Even though an unsubscribe endpoint exists, users who simply close their browsers leave their tokens trapped in the pushSubscriptions Set indefinitely, causing eventual Out-Of-Memory crashes.

Changes Made

Added an LRU (Least Recently Used) style size cap to the Set.
If the pushSubscriptions Set exceeds 10,000 items, the oldest subscription is safely removed, guaranteeing memory stability.
Closes #153