### PR TITLE
Feature: notifications API + persistence (in-memory) and frontend 

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -824,6 +824,75 @@ app.post('/api/notifications/unsubscribe', (req, res) => {
   }
 });
 
+// Server-side notifications API (simple in-memory store)
+import notificationsService from './services/notificationsService.js';
+
+app.get('/api/notifications', (req, res) => {
+  try {
+    // If user id provided via query or auth, use that; otherwise global
+    const userId = req.query.userId || 'global';
+    const list = notificationsService.getNotifications(userId);
+    return res.json({ notifications: list });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/notifications/mark-read', (req, res) => {
+  try {
+    const { id, userId } = req.body || {};
+    if (!id) return res.status(400).json({ error: 'id required' });
+    const uid = userId || 'global';
+    const ok = notificationsService.markAsRead(uid, id);
+    return res.json({ success: ok });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+app.post('/api/notifications/mark-all-read', (req, res) => {
+  try {
+    const { userId } = req.body || {};
+    notificationsService.markAllAsRead(userId || 'global');
+    return res.json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+app.delete('/api/notifications/:id', (req, res) => {
+  try {
+    const id = req.params.id;
+    const userId = req.query.userId || 'global';
+    notificationsService.removeNotification(userId, id);
+    return res.json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// Delete all notifications for a user (or global)
+app.delete('/api/notifications', (req, res) => {
+  try {
+    const userId = req.query.userId || 'global';
+    notificationsService.clearAll(userId);
+    return res.json({ success: true });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
+// Create notification (admin/testing)
+app.post('/api/notifications', (req, res) => {
+  try {
+    const { userId, title, message, type, link } = req.body || {};
+    const note = notificationsService.addNotification(userId || 'global', { title, message, type, link });
+    return res.json({ success: true, notification: note });
+  } catch (err) {
+    return res.status(500).json({ error: err.message });
+  }
+});
+
 // Portfolio System API Endpoints
 app.get('/api/portfolio/:username', async (req, res) => {
   try {

--- a/server/services/eventEmitterService.js
+++ b/server/services/eventEmitterService.js
@@ -6,6 +6,7 @@
 import EventEmitter from 'events';
 import logger from '../utils/logger.js';
 import { emitToRoom, getRoom } from '../config/socket.js';
+import notificationsService from './notificationsService.js';
 import {
   sendRegistrationConfirmationEmail,
   sendWaitlistPromotionEmail,
@@ -71,6 +72,16 @@ class RealTimeEventManager extends EventEmitter {
         timestamp: new Date(),
       });
 
+      // Persist notification (store per-user if userId provided)
+      try {
+        notificationsService.addNotification(data.userId || 'global', {
+          type: 'connection',
+          title: 'Registration Confirmed',
+          message: `You're registered for ${data.eventName}`,
+          link: `/events/${data.eventId}`,
+        });
+      } catch (err) { logger.warn('Failed to persist notification', { err: err.message }); }
+
       // Notify admin
       emitToRoom(getRoom('admin'), 'admin:new-registration', {
         userId: data.userId,
@@ -120,6 +131,16 @@ class RealTimeEventManager extends EventEmitter {
         eventId: data.eventId,
         timestamp: new Date(),
       });
+
+      // Persist notification
+      try {
+        notificationsService.addNotification(data.userId || 'global', {
+          type: 'mention',
+          title: 'Waitlist Promotion',
+          message: `You've been promoted for ${data.eventName}`,
+          link: `/events/${data.eventId}`,
+        });
+      } catch (err) { logger.warn('Failed to persist notification', { err: err.message }); }
 
       // Notify admin
       emitToRoom(getRoom('admin'), 'admin:waitlist-promotion', {
@@ -172,6 +193,16 @@ class RealTimeEventManager extends EventEmitter {
         eventName: data.eventName,
         timestamp: new Date(),
       });
+
+      // Persist notification
+      try {
+        notificationsService.addNotification(data.userId || 'global', {
+          type: 'system',
+          title: `Reminder: ${data.eventName}`,
+          message: `${data.eventName} is starting soon`,
+          link: `/events/${data.eventId}`,
+        });
+      } catch (err) { logger.warn('Failed to persist notification', { err: err.message }); }
     } catch (error) {
       logger.error('Error handling event reminder', { error: error.message });
     }
@@ -212,6 +243,16 @@ class RealTimeEventManager extends EventEmitter {
         points: data.points,
         timestamp: new Date(),
       });
+
+      // Persist notification
+      try {
+        notificationsService.addNotification(data.userId || 'global', {
+          type: 'system',
+          title: 'Attendance Marked',
+          message: `Attendance for ${data.eventName} recorded. You earned ${data.points || 0} points.`,
+          link: `/events/${data.eventId}`,
+        });
+      } catch (err) { logger.warn('Failed to persist notification', { err: err.message }); }
 
       // Notify admin
       emitToRoom(getRoom('admin'), 'admin:attendance-marked', {

--- a/server/services/notificationsService.js
+++ b/server/services/notificationsService.js
@@ -1,0 +1,58 @@
+/**
+ * Simple in-memory notifications service.
+ * For production, replace with DB-backed implementation (Postgres, Mongo, etc.).
+ */
+const notificationsStore = new Map(); // key: userId|'global', value: array
+
+function _ensureList(userId = 'global') {
+  if (!notificationsStore.has(userId)) notificationsStore.set(userId, []);
+  return notificationsStore.get(userId);
+}
+
+export function getNotifications(userId = 'global') {
+  return _ensureList(userId).slice().sort((a,b)=> new Date(b.createdAt) - new Date(a.createdAt));
+}
+
+export function addNotification(userId = 'global', payload = {}) {
+  const list = _ensureList(userId);
+  const id = `${Date.now()}-${Math.random().toString(36).substr(2,6)}`;
+  const note = {
+    id,
+    type: payload.type || 'system',
+    title: payload.title || 'Notification',
+    message: payload.message || '',
+    link: payload.link || null,
+    isRead: !!payload.isRead,
+    createdAt: payload.createdAt || new Date().toISOString(),
+  };
+  list.unshift(note);
+  return note;
+}
+
+export function markAsRead(userId = 'global', id) {
+  const list = _ensureList(userId);
+  let changed = false;
+  for (const n of list) {
+    if (n.id === id) { n.isRead = true; changed = true; break; }
+  }
+  return changed;
+}
+
+export function markAllAsRead(userId = 'global') {
+  const list = _ensureList(userId);
+  list.forEach(n => n.isRead = true);
+}
+
+export function clearAll(userId = 'global') {
+  notificationsStore.set(userId, []);
+}
+
+export function removeNotification(userId = 'global', id) {
+  const list = _ensureList(userId);
+  const idx = list.findIndex(n => n.id === id);
+  if (idx >= 0) list.splice(idx, 1);
+}
+
+export default {
+  getNotifications, addNotification, markAsRead, markAllAsRead, clearAll, removeNotification,
+};

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,15 +1,29 @@
 import { useState, useEffect, useCallback } from 'react';
-import notificationsData from '../data/notificationsData';
 import socketClient from '../utils/socketClient';
 
 export function useNotifications() {
-  const [notifications, setNotifications] = useState(notificationsData);
+  const [notifications, setNotifications] = useState([]);
   const [isOpen, setIsOpen] = useState(false);
 
   const unreadCount = notifications.filter(n => !n.isRead).length;
 
   // Initialize socket and listen to real-time events
   useEffect(() => {
+    // Fetch persisted notifications from server (if available)
+    (async () => {
+      try {
+        const base = import.meta?.env?.VITE_API_BASE || '';
+        const res = await fetch(base + '/api/notifications');
+        if (res.ok) {
+          const json = await res.json();
+          if (Array.isArray(json.notifications)) setNotifications(json.notifications);
+        }
+      } catch (err) {
+        // ignore fetch errors — fallback to empty list
+        console.warn('Failed to fetch notifications', err.message);
+      }
+    })();
+
     const base = (import.meta?.env?.VITE_API_BASE || window.location.origin).replace(/\/+$/, '');
     const socket = socketClient.initializeSocket(base);
 
@@ -111,17 +125,34 @@ export function useNotifications() {
   }, []);
 
   const markAsRead = useCallback((id) => {
-    setNotifications(prev =>
-      prev.map(n => n.id === id ? { ...n, isRead: true } : n)
-    );
+    setNotifications(prev => prev.map(n => n.id === id ? { ...n, isRead: true } : n));
+    // Persist
+    (async () => {
+      try {
+        const base = import.meta?.env?.VITE_API_BASE || '';
+        await fetch(base + '/api/notifications/mark-read', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }) });
+      } catch (e) {}
+    })();
   }, []);
 
   const markAllAsRead = useCallback(() => {
     setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
+    (async () => {
+      try {
+        const base = import.meta?.env?.VITE_API_BASE || '';
+        await fetch(base + '/api/notifications/mark-all-read', { method: 'POST' });
+      } catch (e) {}
+    })();
   }, []);
 
   const clearAll = useCallback(() => {
     setNotifications([]);
+    (async () => {
+      try {
+        const base = import.meta?.env?.VITE_API_BASE || '';
+        await fetch(base + '/api/notifications', { method: 'DELETE' });
+      } catch (e) {}
+    })();
   }, []);
 
   const togglePanel = useCallback(() => {
@@ -142,4 +173,4 @@ export function useNotifications() {
     markAllAsRead,
     clearAll,
   };
-}
+}


### PR DESCRIPTION
Closes #188 

Title: Feature: Add notifications system (real-time + API) (Closes #188)

Summary

Adds a minimal notifications system: notification bell + unread badge, notification panel, real-time socket updates and a simple server-side API + in-memory persistence to surface notifications.

Changes

Frontend
[useNotifications.js:1](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — fetch + persist notifications; socket integration
[NotificationBell.jsx:1](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — panel + badge UI (already present; integrated)

Backend
[notificationsService.js:1](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — simple in-memory store (CRUD)
[index.js:1](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — REST endpoints:
[GET /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[POST /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (create)
POST /api/notifications/mark-read
POST /api/notifications/mark-all-read
[DELETE /api/notifications/:id](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[DELETE /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (clear all)
[eventEmitterService.js:1](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — persist emitted events to notifications store

How it works

Frontend boot: [useNotifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now fetches the persisted feed from [GET /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Real-time: server emits socket events (already supported). [useNotifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html) listens and prepends new items to the feed.
Actions (mark read / mark all / clear) are persisted via REST endpoints so the UI and server stay in sync.
Current persistence is in-memory (for demo). Production should replace with a DB-backed store.
Manual testing / QA

Start backend and frontend (separate terminals):
Open the app in browser and click the bell in the header:
Expected: panel opens showing notifications returned by [GET /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html).
Create a test notification (server):
Expected: bell badge increments; new item appears in panel (if socket connected) and persists on [GET /api/notifications](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html).


Persistence: in-memory store only. Must migrate to DB (Postgres/Mongo) for production and add user-auth to scope notifications per-user.
Authorization: endpoints are not access-controlled; add auth middleware for per-user data.
Tests: no automated tests added in this PR; recommend adding API/unit tests and Playwright e2e for notification flows in follow-up.

Related

Closes #188


Labels: [type:feature](vscode-file://vscode-app/c:/Users/Satyam/AppData/Local/Programs/Microsoft%20VS%20Code%20Insiders/859cf8dc73/resources/app/out/vs/code/electron-browser/workbench/workbench.html), GSSoC'26, difficulty:level:beginner
Reviewers: @Ayushh-Sharmaa, backend maintainer(s)
