### PR TITLE
fix: introduce PUBLIC_APP_URL env var to fix broken verify links with multi-origin CORS_ORIGIN

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -4,6 +4,8 @@
 PORT=8787
 NODE_ENV=development
 CORS_ORIGIN=http://localhost:5173
+# Canonical public URL for building email verification and other app links (single URL, not comma-separated). Falls back to the first CORS_ORIGIN if not set.
+PUBLIC_APP_URL=http://localhost:5173
 
 # Database & Authentication (Supabase)
 SUPABASE_URL=

--- a/server/index.js
+++ b/server/index.js
@@ -109,6 +109,25 @@ function requiredStrongPassword(name) {
 
 const ADMIN_EVENT_PASSWORD = requiredStrongPassword('ADMIN_EVENT_PASSWORD');
 
+if (process.env.PUBLIC_APP_URL) {
+  if (process.env.PUBLIC_APP_URL.includes(',')) {
+    throw new Error('PUBLIC_APP_URL must be a single URL, not a comma-separated list');
+  }
+  try {
+    new URL(process.env.PUBLIC_APP_URL);
+  } catch {
+    throw new Error(`PUBLIC_APP_URL must be a valid absolute URL, got: ${process.env.PUBLIC_APP_URL}`);
+  }
+}
+
+function getPublicAppUrl() {
+  if (process.env.PUBLIC_APP_URL) {
+    return process.env.PUBLIC_APP_URL.replace(/\/+$/, '');
+  }
+  const firstOrigin = process.env.CORS_ORIGIN?.split(',')[0]?.trim();
+  return firstOrigin || 'http://localhost:5173';
+}
+
 function normalizePrivateKey(k) {
   return k.includes('\\n') ? k.replace(/\\n/g, '\n') : k;
 }
@@ -778,7 +797,7 @@ async function handleForm(formType, req, res) {
 
     // NEW: Send a welcome email to the user
     try {
-      const verifyUrl = `${process.env.CORS_ORIGIN || 'http://localhost:5173'}/verify?email=${encodeURIComponent(req.body.collegeEmail)}`;
+      const verifyUrl = `${getPublicAppUrl()}/verify?email=${encodeURIComponent(req.body.collegeEmail)}`;
       await sendWelcomeVerificationEmail(req.body.collegeEmail, req.body.fullName, verifyUrl);
     } catch (emailErr) {
       console.error('[Form Handler] Failed to send welcome email:', emailErr);

--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -59,7 +59,7 @@ export function getConnectedSSEClientsCount() {
  * SSE middleware setup
  */
 export function setupSSEHeaders(req, res, next) {
-  const allowedOrigin = process.env.CORS_ORIGIN?.split(',')[0]?.trim() || 'http://localhost:5173';
+  const allowedOrigin = process.env.PUBLIC_APP_URL || process.env.CORS_ORIGIN?.split(',')[0]?.trim() || 'http://localhost:5173';
 
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');


### PR DESCRIPTION
## Problem

`CORS_ORIGIN` is treated as a comma-separated allowlist in the CORS config (`process.env.CORS_ORIGIN.split(',')`), but the welcome/verification email link uses the raw `CORS_ORIGIN` string as if it were a single base URL:

```js
const verifyUrl = `${process.env.CORS_ORIGIN || 'http://localhost:5173'}/verify?email=...`;
```

If `CORS_ORIGIN` is set to multiple origins (common in production), the generated `verifyUrl` becomes malformed — e.g. `https://app.example.com,https://www.example.com/verify?email=...` — which breaks email verification entirely.

The same "first origin wins" anti-pattern exists in the SSE service's `setupSSEHeaders()`, which picks only the first origin from the comma-separated list.

## Changes

1. **New `PUBLIC_APP_URL` env var** — a single canonical base URL for building app links. Validated at startup: rejects commas and invalid absolute URLs.
2. **`getPublicAppUrl()` helper** — resolves `PUBLIC_APP_URL` → first `CORS_ORIGIN` → `http://localhost:5173` fallback.
3. **`server/index.js`** — verify URL in `handleForm()` now uses `getPublicAppUrl()` instead of raw `CORS_ORIGIN`.
4. **`server/services/sseService.js`** — SSE `Access-Control-Allow-Origin` prefers `PUBLIC_APP_URL` before falling back to the first CORS origin.
5. **`server/.env.example`** — documented `PUBLIC_APP_URL`.

Backward compatible: if `PUBLIC_APP_URL` is not set, behavior falls back to the first `CORS_ORIGIN` entry or `http://localhost:5173`.

Fixes #231
