### PR TITLE
fix: remove token query param auth support from admin endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -31,6 +31,10 @@ app.use(cors({
 }));
 app.use(express.json({ limit: '512kb' }));
 
+function redactUrl(url) {
+  return url.replace(/[?&]token=[^&\s]+/gi, '$1token=REDACTED');
+}
+
 function requestLogger(req, res, next) {
   const start = process.hrtime.bigint();
   const { method, path } = req;
@@ -38,7 +42,9 @@ function requestLogger(req, res, next) {
   res.on('finish', () => {
     const duration = Number(process.hrtime.bigint() - start) / 1e6;
     const status = res.statusCode;
-    const message = `[${method}] ${path} → ${status} (${Math.round(duration)}ms)`;
+    const redactedPath = redactUrl(path);
+    const redactedUrl = req.originalUrl ? redactUrl(req.originalUrl) : redactedPath;
+    const message = `[${method}] ${redactedUrl} → ${status} (${Math.round(duration)}ms)`;
 
     if (status >= 500) {
       console.error(message);

--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -80,7 +80,11 @@ function parseBearer(authHeader = '') {
 
 async function requireAdmin(req, res, next) {
   try {
-    const bearer = parseBearer(req.headers.authorization || '') || req.query.token;
+    if (req.query.token) {
+      return res.status(400).json({ error: 'Do not pass tokens in URLs. Use Authorization: Bearer header.' });
+    }
+
+    const bearer = parseBearer(req.headers.authorization || '');
     const session = await getAdminSession(bearer);
 
     if (!session) {

--- a/src/pages/admin/AdminPage.jsx
+++ b/src/pages/admin/AdminPage.jsx
@@ -77,14 +77,79 @@ export default function AdminPage({ onBack }) {
     if (!token) return;
 
     const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
-    // Connect to SSE metrics stream endpoint using query token auth
-    const eventSource = new EventSource(`${base}/api/admin/metrics/stream?token=${encodeURIComponent(token)}`);
+    const url = `${base}/api/admin/metrics/stream`;
 
-    eventSource.addEventListener('registration', (event) => {
+    const listeners = {};
+    let closed = false;
+    let reconnectTimeout;
+
+    async function connect() {
+      if (closed) return;
+      try {
+        const response = await fetch(url, {
+          headers: { 'Authorization': `Bearer ${token}` },
+        });
+
+        if (!response.ok) {
+          if (response.status === 401) {
+            setToken(null);
+            localStorage.removeItem('ns_admin_token');
+            return;
+          }
+          throw new Error(`SSE connection failed: ${response.status}`);
+        }
+
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = '';
+        let currentEvent = '';
+        let currentData = '';
+
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+
+          for (const line of lines) {
+            if (line.startsWith('event: ')) {
+              currentEvent = line.slice(7).trim();
+            } else if (line.startsWith('data: ')) {
+              currentData = line.slice(6);
+            } else if (line === '' && currentEvent && currentData) {
+              const event = { data: currentData };
+              (listeners[currentEvent] || []).forEach(fn => fn(event));
+              currentEvent = '';
+              currentData = '';
+            }
+          }
+        }
+      } catch (err) {
+        console.warn('Admin SSE metrics stream connection interrupted or reconnecting...', err);
+      }
+
+      if (!closed) {
+        reconnectTimeout = setTimeout(connect, 3000);
+      }
+    }
+
+    const sseClient = {
+      addEventListener(event, fn) {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(fn);
+      },
+      close() {
+        closed = true;
+        clearTimeout(reconnectTimeout);
+      },
+    };
+
+    sseClient.addEventListener('registration', (event) => {
       try {
         const parsed = JSON.parse(event.data);
         const payload = parsed.data;
-        
+
         setData(prev => {
           const currentStats = prev.stats || { totalUsers: 1240, activeRegistrations: 85, upcomingEvents: 3, conversionRate: '12.5%' };
           const nextStats = {
@@ -116,7 +181,7 @@ export default function AdminPage({ onBack }) {
       }
     });
 
-    eventSource.addEventListener('login', (event) => {
+    sseClient.addEventListener('login', (event) => {
       try {
         const parsed = JSON.parse(event.data);
         console.log(`SSE Login Alert: User ${parsed.data.username} connected from ${parsed.data.ip}`);
@@ -125,12 +190,10 @@ export default function AdminPage({ onBack }) {
       }
     });
 
-    eventSource.onerror = (err) => {
-      console.warn('Admin SSE metrics stream connection interrupted or reconnecting...', err);
-    };
+    connect();
 
     return () => {
-      eventSource.close();
+      sseClient.close();
     };
   }, [token]);
 


### PR DESCRIPTION
## Problem

`requireAdmin` middleware accepts an admin session token from a URL query parameter (`req.query.token`), which is a security risk because:

- URLs are logged by reverse proxies, CDNs, WAFs, and server access logs
- URLs are stored in browser history
- Tokens can leak via `Referer` headers when the page makes requests to other origins
- URLs can be shared unintentionally via screenshots, copy/paste, or chat

Even if the frontend primarily uses `Authorization: Bearer` headers, the backend support for `?token=` encourages insecure usage and increases the blast radius of any accidental token exposure.

## Changes

1. **`server/middleware/adminAuthMiddleware.js`** — Removed `|| req.query.token` fallback from `requireAdmin()`. Added a fail-fast guard: if `req.query.token` is present, returns `400` with the message `"Do not pass tokens in URLs. Use Authorization: Bearer header."`

2. **`src/pages/admin/AdminPage.jsx`** — The admin dashboard used `EventSource` (SSE) with `?token=` in the URL because the browser API doesn't support custom headers. Replaced it with a fetch-based SSE client that sends `Authorization: Bearer` via the standard `headers` option, while preserving auto-reconnect behavior on connection drops.

3. **`server/index.js`** — Added `redactUrl()` to the request logger to redact `token` query parameter values from logged URLs, preventing accidental token leakage in server/access logs.

Fixes #229