### PR TITLE
fix: strengthen portfolio passkey auth

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -815,6 +815,42 @@ const formRateLimiter = rateLimit({
   message: { error: 'Too many form submissions from this IP, please try again after 10 minutes' }
 });
 
+const portfolioRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 10, // Limit each IP to 10 requests per windowMs
+  message: { error: 'Too many portfolio update attempts from this IP, please try again after 15 minutes' }
+});
+
+const failedPasskeyAttempts = new Map();
+
+function checkPasskeyLockout(username, ip) {
+  const key = `${String(username || '').toLowerCase()}:${ip}`;
+  const entry = failedPasskeyAttempts.get(key);
+  if (!entry) return null;
+  if (Date.now() > entry.lockoutUntil) {
+    failedPasskeyAttempts.delete(key);
+    return null;
+  }
+  return entry;
+}
+
+function recordFailedPasskeyAttempt(username, ip) {
+  const key = `${String(username || '').toLowerCase()}:${ip}`;
+  const entry = failedPasskeyAttempts.get(key) || { count: 0, lockoutUntil: 0 };
+  entry.count += 1;
+  if (entry.count >= 5) {
+    entry.lockoutUntil = Date.now() + 15 * 60 * 1000; // 15 min lockout
+    entry.count = 0;
+  }
+  failedPasskeyAttempts.set(key, entry);
+  return entry;
+}
+
+function clearPasskeyAttempts(username, ip) {
+  const key = `${String(username || '').toLowerCase()}:${ip}`;
+  failedPasskeyAttempts.delete(key);
+}
+
 app.post('/api/forms/membership', formRateLimiter, (req, res) => handleForm('membership', req, res));
 app.post('/api/forms/recruitment', formRateLimiter, (req, res) => handleForm('recruitment', req, res));
 app.post('/api/core-team/apply', formRateLimiter, (req, res) => handleForm('core_team', req, res));
@@ -933,11 +969,12 @@ app.get('/api/portfolio/:username', async (req, res) => {
   }
 });
 
-app.put('/api/portfolio', async (req, res) => {
+app.put('/api/portfolio', portfolioRateLimiter, async (req, res) => {
   try {
     const body = req.body || {};
     const username = String(body.username || '').trim();
     const passkey = String(body.passkey || '').trim();
+    const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
 
     if (!username || username.length < 3) {
       return res.status(400).json({ error: 'Username must be at least 3 characters long' });
@@ -945,15 +982,24 @@ app.put('/api/portfolio', async (req, res) => {
     if (!/^[a-zA-Z0-9_-]+$/.test(username)) {
       return res.status(400).json({ error: 'Username can only contain alphanumeric characters, underscores, and hyphens' });
     }
-    if (!passkey || passkey.length < 4) {
-      return res.status(400).json({ error: 'Passkey must be at least 4 characters long' });
+    if (!passkey || passkey.length < 12) {
+      return res.status(400).json({ error: 'Passkey must be at least 12 characters long' });
+    }
+
+    // Check lockout before verifying
+    const lockout = checkPasskeyLockout(username, ip);
+    if (lockout) {
+      return res.status(429).json({ error: 'Too many failed passkey attempts. Please try again later.' });
     }
 
     // Verify ownership/passkey
     const isAuthorized = await portfolioRepository.verifyPasskey(username, passkey);
     if (!isAuthorized) {
+      recordFailedPasskeyAttempt(username, ip);
       return res.status(401).json({ error: 'Incorrect passkey for this username' });
     }
+
+    clearPasskeyAttempts(username, ip);
 
     // Save portfolio configuration
     const saved = await portfolioRepository.createOrUpdate(body);

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -11,6 +11,7 @@
         "@sendgrid/mail": "^8.1.3",
         "@sentry/node": "^7.84.0",
         "@sentry/profiling-node": "^7.84.0",
+        "bcryptjs": "^3.0.3",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "ejs": "^5.0.2",
@@ -971,6 +972,15 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/bcryptjs": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-3.0.3.tgz",
+      "integrity": "sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "bcrypt": "bin/bcrypt"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
@@ -1527,7 +1537,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -2943,18 +2952,12 @@
         }
       }
     },
-    "node_modules/pg-cloudflare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
-      "integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/pg-connection-string": {
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
       "integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pg-int8": {
       "version": "1.0.1",
@@ -2970,6 +2973,7 @@
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
       "integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "pg": ">=8.0"
       }
@@ -3001,6 +3005,7 @@
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -3482,6 +3487,7 @@
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }

--- a/server/package.json
+++ b/server/package.json
@@ -18,6 +18,7 @@
     "@sendgrid/mail": "^8.1.3",
     "@sentry/node": "^7.84.0",
     "@sentry/profiling-node": "^7.84.0",
+    "bcryptjs": "^3.0.3",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "ejs": "^5.0.2",

--- a/server/repositories/portfolioRepository.js
+++ b/server/repositories/portfolioRepository.js
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -8,10 +8,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const PORTFOLIOS_FILE = path.join(__dirname, '..', 'data', 'portfolios.json');
 
+const BCRYPT_ROUNDS = 12;
+
 let schemaReady = null;
 
-function hashPasskey(passkey) {
-  return crypto.createHash('sha256').update(String(passkey)).digest('hex');
+async function hashPasskey(passkey) {
+  return bcrypt.hash(String(passkey), BCRYPT_ROUNDS);
+}
+
+async function verifyHash(passkey, hash) {
+  return bcrypt.compare(String(passkey), hash);
 }
 
 async function ensureSchema(client) {
@@ -140,7 +146,6 @@ export const portfolioRepository = {
   async verifyPasskey(username, passkey) {
     const isDbAvailable = await ensureReady();
     const sanitizedUsername = String(username || '').trim().toLowerCase();
-    const passkeyHash = hashPasskey(passkey);
 
     if (isDbAvailable) {
       try {
@@ -150,7 +155,7 @@ export const portfolioRepository = {
             [sanitizedUsername]
           );
           if (!rows.length) return true; // Username does not exist, so it's a new registration (allow it)
-          return rows[0].passkey_hash === passkeyHash;
+          return await verifyHash(passkey, rows[0].passkey_hash);
         });
       } catch (err) {
         console.error('Database query failed in verifyPasskey. Falling back to local file.', err);
@@ -161,14 +166,14 @@ export const portfolioRepository = {
     const portfolios = await readLocalPortfolios();
     const portfolio = portfolios[sanitizedUsername];
     if (!portfolio) return true; // New registration
-    return portfolio.passkeyHash === passkeyHash;
+    return await verifyHash(passkey, portfolio.passkeyHash);
   },
 
   async createOrUpdate(data) {
     const isDbAvailable = await ensureReady();
     const username = String(data.username || '').trim();
     const sanitizedUsername = username.toLowerCase();
-    const passkeyHash = hashPasskey(data.passkey);
+    const passkeyHash = await hashPasskey(data.passkey);
 
     const theme = data.theme || 'glassmorphic';
     const visibleSections = data.visibleSections || { quests: true, roadmaps: true, projects: true, analytics: false };


### PR DESCRIPTION
## Problem

The Portfolio Builder system has three critical auth weaknesses:

1. **Unsalted SHA-256** — `hashPasskey()` uses `crypto.createHash('sha256')`, which is fast and unsalted. Any leaked password store can be cracked instantly with precomputed rainbow tables or cheap GPU offline attacks.

2. **Weak passkey policy** — Minimum passkey length is only 4 characters, making online brute-force trivial.

3. **No brute-force protection** — `PUT /api/portfolio` has no rate limiting, no per-IP throttling, and no lockout mechanism. An attacker can fire unlimited passkey guesses against any username.

## Changes

1. **`server/repositories/portfolioRepository.js`**
   - Replaced `hashPasskey()` (SHA-256) with `bcrypt.hash()` (salted, cost factor 12) and added `verifyHash()` using `bcrypt.compare()`.
   - Updated `verifyPasskey()` and `createOrUpdate()` to use the async bcrypt functions.
   - Removed `crypto` import (no longer needed).

2. **`server/index.js`**
   - **Passkey policy**: increased minimum length from 4 to 12 characters.
   - **Rate limiting**: added `portfolioRateLimiter` (10 requests per 15 minutes per IP) using the existing `express-rate-limit` middleware.
   - **Lockout**: added per-(username+IP) failed attempt tracking — 5 consecutive failures triggers a 15-minute lockout. Successful auth clears the counter.
   - Lockout is checked before `verifyPasskey()` to avoid unnecessary bcrypt work on blocked requests.

3. **`server/package.json`** — Added `bcryptjs` dependency (pure JavaScript, no native compilation required).

Fixes #228