### PR TITLE
fix: strip creator PII from public activity event API

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -360,7 +360,9 @@ async function listActivityEventsStore(activityKey) {
 }
 
 function sanitizeActivityEventRecord(event) {
-  return event;
+  if (!event || typeof event !== 'object') return event;
+  const { createdBy, ...safe } = event;
+  return safe;
 }
 
 async function createActivityEventStore(activityKey, event) {

--- a/server/test/sanitize.test.js
+++ b/server/test/sanitize.test.js
@@ -55,7 +55,7 @@ test('sanitizeCoreTeamMemberRecord escapes profile fields and optional links', (
   assert.equal(sanitized.photoUrl, 'https://cdn.example.com/&quot;avatar&quot;.png?alt=&lt;img&gt;');
 });
 
-test('sanitizeActivityEventRecord escapes nested creator fields', () => {
+test('sanitizeActivityEventRecord strips createdBy PII', () => {
   const sanitized = sanitizeActivityEventRecord({
     name: '<script>Session</script>',
     date: 'June 1, 2026',
@@ -63,15 +63,13 @@ test('sanitizeActivityEventRecord escapes nested creator fields', () => {
     description: '<p>body</p> & "data"',
     createdBy: {
       name: 'Bob <admin>',
-      email: 'bob@example.com?x=<script>',
-      phone: '123-456-7890 & 999',
+      email: 'bob@example.com',
+      phone: '123-456-7890',
     },
   });
 
   assert.equal(sanitized.name, '&lt;script&gt;Session&lt;/script&gt;');
   assert.equal(sanitized.tagline, 'Tagline &amp; &quot;quote&quot;');
   assert.equal(sanitized.description, '&lt;p&gt;body&lt;/p&gt; &amp; &quot;data&quot;');
-  assert.equal(sanitized.createdBy.name, 'Bob &lt;admin&gt;');
-  assert.equal(sanitized.createdBy.email, 'bob@example.com?x=&lt;script&gt;');
-  assert.equal(sanitized.createdBy.phone, '123-456-7890 &amp; 999');
+  assert.equal(sanitized.createdBy, undefined);
 });

--- a/server/utils/sanitize.js
+++ b/server/utils/sanitize.js
@@ -45,19 +45,13 @@ export function sanitizeEventRecord(event = {}) {
 }
 
 export function sanitizeActivityEventRecord(event = {}) {
+  const { createdBy, ...rest } = event;
   return {
-    ...event,
+    ...rest,
     name: sanitizeText(event.name, 120),
     date: sanitizeText(event.date, 80),
     tagline: sanitizeNullableText(event.tagline, 240),
     description: sanitizeText(event.description, 1200),
-    createdBy: event.createdBy
-      ? {
-          name: sanitizeText(event.createdBy.name, 120),
-          email: sanitizeText(event.createdBy.email, 140),
-          phone: sanitizeText(event.createdBy.phone, 40),
-        }
-      : undefined,
   };
 }
 


### PR DESCRIPTION
Closes #179

## Root Cause
sanitizeActivityEventRecord in server/index.js was a no-op — it returned the full event including createdBy with name, email, phone. The Supabase code path worked correctly (intentionally omitted created_by_ fields), but the file-based storage path exposed PII through GET /api/content/activity-events/:key.

## Fix
sanitizeActivityEventRecord now strips the createdBy field before returning. Applied to both server/index.js (the function used at runtime) and server/utils/sanitize.js (tested utility).

## Verification
- PII still stored in content.json for audit
- PII stripped from all public API responses
- All 4 existing tests pass

## Suggested Labels
security, bug