### PR TITLE
fix: prevent health check endpoint from crashing server on DB failure

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -548,8 +548,12 @@ function isPhoneish(s) {
 }
 
 app.get('/healthz', async (req, res) => {
-  const events = await listEventsStore();
-  res.json({ ok: true, events: events.length, storage: HAS_SUPABASE ? 'supabase' : 'file' });
+  try {
+    const events = await listEventsStore();
+    res.json({ ok: true, events: events.length, storage: HAS_SUPABASE ? 'supabase' : 'file' });
+  } catch (e) {
+    res.status(503).json({ ok: false, error: e?.message || 'Health check failed', storage: HAS_SUPABASE ? 'supabase' : 'file' });
+  }
 });
 
 app.get('/api/content/events', async (req, res) => {
@@ -964,6 +968,10 @@ app.put('/api/portfolio', async (req, res) => {
   }
 });
 
+
+process.on('unhandledRejection', (reason) => {
+  console.error('[Process] Unhandled rejection:', reason instanceof Error ? reason.message : reason);
+});
 
 const port = Number(process.env.PORT || 8787);
 if (!process.env.VERCEL) {


### PR DESCRIPTION
Closes #178

## Root Cause
GET /healthz at server/index.js:550 was the only async route handler in the entire server without a try/catch block. Express 4.x does not catch promise rejections from async handlers. In Node.js 15+, unhandled promise rejections terminate the process with exit code 1.

When listEventsStore() failed (Supabase network error, corrupted content.json, disk full), the server crashed, creating a restart loop: health check fails -> process exits -> restarts -> health check fails again.

## Fix (2 changes)

### 1. Wrap /healthz in try/catch
Returns HTTP 503 with error details instead of crashing:
- ok: false on failure (vs ok: true on success)
- Includes storage backend info for debugging

### 2. Process-level unhandledRejection handler
Added a safety net at server startup that logs any unhandled promise rejection with console.error. This prevents future unprotected async code from silently crashing the process.

## Verification
- Every other async route handler in the file already has try/catch
- Pattern matches existing error handling style (e.g., /api/content/events at line 559)
- No existing tests to break

## Suggested Labels
bug, enhancement, level:beginner