### PR TITLE
fix: restrict Socket.IO admin room to authenticated sockets

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -5,6 +5,7 @@
 
 import { Server } from 'socket.io';
 import logger from '../utils/logger.js';
+import { getAdminSession } from '../repositories/adminSessionsRepository.js';
 
 let io = null;
 const connectedUsers = new Map();
@@ -13,6 +14,15 @@ const rooms = {
   notifications: 'notifications-room',
   events: 'events-room',
 };
+const PROTECTED_ROOMS = ['admin-room'];
+
+/**
+ * Parse Bearer token from auth header
+ */
+function parseBearer(authHeader) {
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return '';
+  return authHeader.slice(7).trim();
+}
 
 /**
  * Initialize Socket.IO
@@ -30,8 +40,30 @@ export function initializeSocketIO(httpServer) {
     reconnectionAttempts: 5,
   });
 
+  // Connection auth middleware — checks handshake auth token
+  io.use(async (socket, next) => {
+    const token = socket.handshake.auth?.token || parseBearer(socket.handshake.headers?.authorization);
+    if (token) {
+      try {
+        const session = await getAdminSession(token);
+        if (session) {
+          socket.adminSession = session;
+          socket.adminAuthenticated = true;
+        }
+      } catch {
+        // Auth check is best-effort at connection time
+      }
+    }
+    next();
+  });
+
   io.on('connection', (socket) => {
-    logger.info('User connected', { socketId: socket.id });
+    logger.info('User connected', { socketId: socket.id, admin: !!socket.adminAuthenticated });
+
+    // Auto-join authenticated admin sockets to admin room
+    if (socket.adminAuthenticated) {
+      socket.join('admin-room');
+    }
 
     // Store connected user
     socket.on('user:identify', (userData) => {
@@ -46,6 +78,10 @@ export function initializeSocketIO(httpServer) {
 
     // Join notification room
     socket.on('room:join', (roomName) => {
+      if (PROTECTED_ROOMS.includes(roomName) && !socket.adminAuthenticated) {
+        logger.warn('Unauthorized room join attempt', { socketId: socket.id, room: roomName });
+        return socket.emit('room:join:error', { error: 'Authentication required to join this room' });
+      }
       socket.join(roomName);
       logger.info('User joined room', { socketId: socket.id, room: roomName });
     });
@@ -54,6 +90,27 @@ export function initializeSocketIO(httpServer) {
     socket.on('room:leave', (roomName) => {
       socket.leave(roomName);
       logger.info('User left room', { socketId: socket.id, room: roomName });
+    });
+
+    // Authenticate socket for admin rooms using admin token
+    socket.on('admin:authenticate', async ({ token } = {}) => {
+      if (!token) {
+        return socket.emit('admin:authenticated', { success: false, error: 'Token is required' });
+      }
+      try {
+        const session = await getAdminSession(token);
+        if (!session) {
+          return socket.emit('admin:authenticated', { success: false, error: 'Invalid or expired token' });
+        }
+        socket.adminSession = session;
+        socket.adminAuthenticated = true;
+        socket.join('admin-room');
+        logger.info('Admin authenticated via socket event', { socketId: socket.id, username: session.username });
+        socket.emit('admin:authenticated', { success: true });
+      } catch (e) {
+        logger.error('Admin authentication error', { error: e.message, socketId: socket.id });
+        socket.emit('admin:authenticated', { success: false, error: 'Authentication failed' });
+      }
     });
 
     // Handle disconnection


### PR DESCRIPTION
Closes #177

## Root Cause
The Socket.IO `room:join` handler in `server/config/socket.js` accepted any room name from any connected client with zero access control. Since room names (`admin-room`, `notifications-room`, `events-room`) were predictable, any WebSocket client could join `admin-room` and receive admin-targeted events like:

- `admin:new-registration` (fullName, formType, timestamp)
- `admin:waitlist-promotion`
- `admin:attendance-marked`

## Fix (3 layers of protection)

### 1. Connection-level auth middleware
Added `io.use` middleware that checks for an admin token in `socket.handshake.auth.token` or the `Authorization` header. If valid, the socket is marked as authenticated and auto-joined to `admin-room`.

### 2. Protected rooms list
Introduced `PROTECTED_ROOMS = ['admin-room']`. The `room:join` handler rejects joining any protected room unless the socket has been authenticated.

### 3. Runtime authentication event
Added `admin:authenticate` event that lets admin dashboard clients send their Bearer token after connection (e.g., if the token wasn't available at handshake time).

## Backward Compatibility
- Non-admin rooms (`notifications-room`, `events-room`, `global-announcements`, `user-{id}`) remain freely joinable
- Regular frontend users are unaffected — they never send auth tokens
- Admin dashboard clients can pass tokens via handshake auth or the `admin:authenticate` event

## Suggested Labels
security, bug, level:beginner