### PR TITLE
fix: restore chat and socket backend URL handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-# Application
-NEXT_PUBLIC_APP_URL="http://localhost:3000"
+# Frontend Runtime
+VITE_APP_URL="http://localhost:5173"
+VITE_API_BASE="http://localhost:8787"
+VITE_AI_API_BASE="http://localhost:8000"
+VITE_SOCKET_URL="http://localhost:8787"
+VITE_SOCKET_PATH="/socket.io"
 
 # Database (Example)
 DATABASE_URL="postgresql://user:password@localhost:5432/nexasphere"
@@ -11,3 +15,6 @@ NEXTAUTH_SECRET="your-super-secret-string-here"
 # Rate Limiting / KV (From previous PRs)
 UPSTASH_REDIS_REST_URL="https://your-upstash-url.upstash.io"
 UPSTASH_REDIS_REST_TOKEN="your-upstash-token"
+
+# Backend CORS
+CORS_ORIGIN="http://localhost:5173,https://nexasphere-glbajaj.vercel.app"

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3235,8 +3234,7 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
       "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/chai-subset": {
       "version": "1.3.6",
@@ -3329,7 +3327,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.7.0.tgz",
       "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.21.0"
       }
@@ -3363,7 +3360,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3625,7 +3621,6 @@
       "integrity": "sha512-iizUu9R5Rsvsq8FtdJ0suMqEfIsIIzziqnasMHe4VH8vG+FnZSA3UAtCHx6rLeRupIFVAVg7bptMmuvMcsn8WQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "0.34.7",
         "fast-glob": "^3.3.0",
@@ -3738,7 +3733,6 @@
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -4018,7 +4012,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7408,7 +7401,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7629,7 +7621,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -7642,7 +7633,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -7655,15 +7645,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -7749,8 +7737,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -7964,7 +7951,6 @@
       "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9228,7 +9214,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -9344,7 +9329,6 @@
       "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^4.3.5",
         "@types/chai-subset": "^1.3.3",

--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -29,9 +29,13 @@ function parseBearer(authHeader) {
  * @param {Object} httpServer - HTTP server instance
  */
 export function initializeSocketIO(httpServer) {
+  const allowedOrigins = process.env.CORS_ORIGIN
+    ? process.env.CORS_ORIGIN.split(',').map(origin => origin.trim()).filter(Boolean)
+    : [process.env.FRONTEND_URL || 'http://localhost:5173'];
+
   io = new Server(httpServer, {
     cors: {
-      origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+      origin: allowedOrigins,
       credentials: true,
     },
     reconnection: true,

--- a/src/components/dashboard/AiMentor.jsx
+++ b/src/components/dashboard/AiMentor.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { buildUrl, getAiApiBase } from '../../utils/runtimeConfig';
 
 export default function AiMentor() {
   const [code, setCode] = useState('');
@@ -12,8 +13,12 @@ export default function AiMentor() {
     setResult(null);
 
     try {
-      const base = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
-      const res = await fetch(`${base}/ai/review`, {
+      const reviewUrl = buildUrl(getAiApiBase(), '/ai/review');
+      if (!reviewUrl) {
+        throw new Error('AI review service is not configured');
+      }
+
+      const res = await fetch(reviewUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ code, language })

--- a/src/hooks/useNotifications.js
+++ b/src/hooks/useNotifications.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import socketClient from '../utils/socketClient';
+import { buildUrl, getApiBase, getSocketServerUrl } from '../utils/runtimeConfig';
 
 export function useNotifications() {
   const [notifications, setNotifications] = useState([]);
@@ -12,8 +13,7 @@ export function useNotifications() {
     // Fetch persisted notifications from server (if available)
     (async () => {
       try {
-        const base = import.meta?.env?.VITE_API_BASE || '';
-        const res = await fetch(base + '/api/notifications');
+        const res = await fetch(buildUrl(getApiBase(), '/api/notifications'));
         if (res.ok) {
           const json = await res.json();
           if (Array.isArray(json.notifications)) setNotifications(json.notifications);
@@ -24,8 +24,11 @@ export function useNotifications() {
       }
     })();
 
-    const base = (import.meta?.env?.VITE_API_BASE || window.location.origin).replace(/\/+$/, '');
+    const base = getSocketServerUrl();
     const socket = socketClient.initializeSocket(base);
+    if (!socket) {
+      return undefined;
+    }
 
     // Identify user if logged in (for personalized notifications)
     const storedUser = localStorage.getItem('ns_user');
@@ -129,8 +132,7 @@ export function useNotifications() {
     // Persist
     (async () => {
       try {
-        const base = import.meta?.env?.VITE_API_BASE || '';
-        await fetch(base + '/api/notifications/mark-read', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }) });
+        await fetch(buildUrl(getApiBase(), '/api/notifications/mark-read'), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id }) });
       } catch (e) {}
     })();
   }, []);
@@ -139,8 +141,7 @@ export function useNotifications() {
     setNotifications(prev => prev.map(n => ({ ...n, isRead: true })));
     (async () => {
       try {
-        const base = import.meta?.env?.VITE_API_BASE || '';
-        await fetch(base + '/api/notifications/mark-all-read', { method: 'POST' });
+        await fetch(buildUrl(getApiBase(), '/api/notifications/mark-all-read'), { method: 'POST' });
       } catch (e) {}
     })();
   }, []);
@@ -149,8 +150,7 @@ export function useNotifications() {
     setNotifications([]);
     (async () => {
       try {
-        const base = import.meta?.env?.VITE_API_BASE || '';
-        await fetch(base + '/api/notifications', { method: 'DELETE' });
+        await fetch(buildUrl(getApiBase(), '/api/notifications'), { method: 'DELETE' });
       } catch (e) {}
     })();
   }, []);

--- a/src/hooks/useSocket.js
+++ b/src/hooks/useSocket.js
@@ -5,6 +5,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import socketClient from '../utils/socketClient';
+import { getSocketServerUrl } from '../utils/runtimeConfig';
 
 export function useSocket(serverUrl) {
   const [connected, setConnected] = useState(false);
@@ -12,8 +13,13 @@ export function useSocket(serverUrl) {
 
   useEffect(() => {
     // Initialize socket connection if not already done
-    const base = serverUrl || (import.meta?.env?.VITE_API_BASE || window.location.origin).replace(/\/+$/, '');
+    const base = serverUrl || getSocketServerUrl();
     const socket = socketClient.initializeSocket(base);
+    if (!socket) {
+      setConnected(false);
+      setSocketId(null);
+      return undefined;
+    }
 
     const onConnect = () => {
       setConnected(true);

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,14 +2,10 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
 import GlobalErrorBoundary from './components/GlobalErrorBoundary.jsx';
-import { registerSW } from 'virtual:pwa-register';
 
 // Apply saved theme before React renders — prevents flash of wrong theme
 const savedTheme = localStorage.getItem('ns-theme') || 'dark';
 document.documentElement.setAttribute('data-theme', savedTheme);
-
-// Register service worker
-registerSW({ immediate: true });
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/dashboard/DashboardPage.jsx
+++ b/src/pages/dashboard/DashboardPage.jsx
@@ -3,6 +3,7 @@ import InterestSelector from '../../components/dashboard/InterestSelector';
 import QuestTracker from '../../components/dashboard/QuestTracker';
 import Leaderboard from '../../components/dashboard/Leaderboard';
 import AiMentor from '../../components/dashboard/AiMentor';
+import { buildUrl, getAiApiBase } from '../../utils/runtimeConfig';
 
 export default function DashboardPage({ onBack }) {
   // Mock current user for demonstration
@@ -48,8 +49,12 @@ export default function DashboardPage({ onBack }) {
     if (interests.length === 0) return;
     setLoadingRecs(true);
     try {
-      const base = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
-      const res = await fetch(`${base}/recommend/events/${currentUser.id}`);
+      const recommendationsUrl = buildUrl(getAiApiBase(), `/recommend/events/${currentUser.id}`);
+      if (!recommendationsUrl) {
+        throw new Error('Recommendations service is not configured');
+      }
+
+      const res = await fetch(recommendationsUrl);
       if (res.ok) {
         const data = await res.json();
         setRecommendations(data.recommended_events || []);

--- a/src/shared/Chatbot.jsx
+++ b/src/shared/Chatbot.jsx
@@ -5,10 +5,12 @@ import SearchBar from '../components/history/SearchBar';
 import PinnedChats from '../components/history/PinnedChats';
 import { savePrompt } from '../lib/promptStore';
 import { initializeWorkspaces } from '../lib/workspaceService';
+import { buildUrl, getAiApiBase } from '../utils/runtimeConfig';
 
 const Chatbot = () => {
   const [isOpen, setIsOpen] = useState(false);
   const [input, setInput] = useState('');
+  const [isSending, setIsSending] = useState(false);
   const [messages, setMessages] = useState([
     { role: 'bot', text: 'Nexa-Intelligence Online. How can I assist your journey?' }
   ]);
@@ -49,22 +51,52 @@ const Chatbot = () => {
   }, [messages, currentWorkspace]);
 
   const handleSend = async () => {
-    if (!input.trim()) return;
+    if (!input.trim() || isSending) return;
     const userMsg = { role: 'user', text: input };
     setMessages(prev => [...prev, userMsg]);
     const currentInput = input;
     setInput('');
+    setIsSending(true);
+
+    const aiChatUrl = buildUrl(getAiApiBase(), '/ai/chat');
+
+    if (!aiChatUrl) {
+      setMessages(prev => [
+        ...prev,
+        { role: 'bot', text: 'Nexa-AI is offline right now. The AI service URL is not configured for this deployment.' }
+      ]);
+      setIsSending(false);
+      return;
+    }
 
     try {
-      const response = await fetch('http://localhost:8000/ai/chat', {
+      const controller = new AbortController();
+      const timeoutId = window.setTimeout(() => controller.abort(), 12000);
+      const response = await fetch(aiChatUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: currentInput }),
+        signal: controller.signal,
       });
+      window.clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        throw new Error(`AI chat request failed with status ${response.status}`);
+      }
+
       const data = await response.json();
-      setMessages(prev => [...prev, { role: 'bot', text: data.reply }]);
+      setMessages(prev => [
+        ...prev,
+        { role: 'bot', text: data.reply || 'Nexa-AI received the request, but the reply came back empty. Please try again.' }
+      ]);
     } catch (e) {
-      setMessages(prev => [...prev, { role: 'bot', text: 'Nexa-AI: Core Link Failure. Try again.' }]);
+      console.error('AI chat request failed', e);
+      setMessages(prev => [
+        ...prev,
+        { role: 'bot', text: 'Nexa-AI: Core link unavailable right now. Please try again in a moment.' }
+      ]);
+    } finally {
+      setIsSending(false);
     }
   };
 
@@ -142,9 +174,12 @@ const Chatbot = () => {
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
                 onKeyDown={(e) => e.key === 'Enter' && handleSend()}
-                placeholder="Query system..."
+                placeholder={isSending ? 'Transmitting...' : 'Query system...'}
+                disabled={isSending}
               />
-              <button onClick={handleSend} className="send-btn">🚀</button>
+              <button onClick={handleSend} className="send-btn" disabled={isSending}>
+                {isSending ? '...' : '🚀'}
+              </button>
             </div>
           </div>
         </div>

--- a/src/utils/runtimeConfig.js
+++ b/src/utils/runtimeConfig.js
@@ -1,0 +1,51 @@
+function normalizeUrl(value) {
+  return String(value || '').trim().replace(/\/+$/, '');
+}
+
+function isLocalHostname(hostname) {
+  return hostname === 'localhost' || hostname === '127.0.0.1';
+}
+
+function getBrowserHostname() {
+  if (typeof window === 'undefined') return '';
+  return window.location.hostname;
+}
+
+function getLocalDefaultUrl(port) {
+  return isLocalHostname(getBrowserHostname()) ? `http://localhost:${port}` : '';
+}
+
+export function getApiBase() {
+  return normalizeUrl(import.meta.env.VITE_API_BASE) || getLocalDefaultUrl(8787);
+}
+
+export function getAiApiBase() {
+  return (
+    normalizeUrl(import.meta.env.VITE_AI_API_BASE) ||
+    getLocalDefaultUrl(8000) ||
+    getApiBase()
+  );
+}
+
+export function getSocketServerUrl() {
+  return (
+    normalizeUrl(import.meta.env.VITE_SOCKET_URL) ||
+    getApiBase() ||
+    getLocalDefaultUrl(8787)
+  );
+}
+
+export function getSocketPath() {
+  return import.meta.env.VITE_SOCKET_PATH || '/socket.io';
+}
+
+export function hasSocketServer() {
+  return Boolean(getSocketServerUrl());
+}
+
+export function buildUrl(base, path) {
+  const normalizedBase = normalizeUrl(base);
+  if (!normalizedBase) return '';
+  if (!path) return normalizedBase;
+  return `${normalizedBase}${path.startsWith('/') ? path : `/${path}`}`;
+}

--- a/src/utils/socketClient.js
+++ b/src/utils/socketClient.js
@@ -5,20 +5,43 @@
 
 import io from 'socket.io-client';
 import { captureHandledException } from './errorTracking';
+import { getSocketPath, getSocketServerUrl } from './runtimeConfig';
 
 let socket = null;
 let eventHandlers = {};
+let currentSocketUrl = '';
+let warnedMissingSocketConfig = false;
 
 /**
  * Initialize Socket.IO client
  */
-export function initializeSocket(serverUrl = window.location.origin) {
-  socket = io(serverUrl, {
+export function initializeSocket(serverUrl = getSocketServerUrl()) {
+  const resolvedUrl = serverUrl || getSocketServerUrl();
+  if (!resolvedUrl) {
+    if (!warnedMissingSocketConfig) {
+      warnedMissingSocketConfig = true;
+      console.warn('Socket.IO disabled: no socket server URL configured for this environment.');
+    }
+    return null;
+  }
+
+  if (socket && currentSocketUrl === resolvedUrl) {
+    return socket;
+  }
+
+  if (socket) {
+    socket.disconnect();
+  }
+
+  currentSocketUrl = resolvedUrl;
+  socket = io(resolvedUrl, {
+    path: getSocketPath(),
     reconnection: true,
     reconnectionDelay: 1000,
     reconnectionDelayMax: 5000,
-    reconnectionAttempts: 5,
+    reconnectionAttempts: 8,
     transports: ['websocket', 'polling'],
+    timeout: 5000,
   });
 
   // Global event handlers
@@ -32,6 +55,14 @@ export function initializeSocket(serverUrl = window.location.origin) {
 
   socket.on('error', (error) => {
     captureHandledException(error, 'Socket.IO error:');
+  });
+
+  socket.on('connect_error', (error) => {
+    captureHandledException(error, 'Socket.IO connection error:');
+  });
+
+  socket.on('reconnect_failed', () => {
+    captureHandledException(new Error('Socket.IO reconnect attempts exhausted'), 'Socket.IO reconnect failed:');
   });
 
   // Setup custom event listeners
@@ -161,6 +192,7 @@ export function disconnect() {
   if (socket) {
     socket.disconnect();
     socket = null;
+    currentSocketUrl = '';
   }
 }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,5 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import { VitePWA } from 'vite-plugin-pwa'
 
 export default defineConfig({
   resolve: {
@@ -11,44 +10,7 @@ export default defineConfig({
   },
   // Supports Vercel (/) and GitHub Pages (/NexaSphere/) via env var
   base: process.env.VITE_BASE_PATH || '/',
-  plugins: [
-    react(),
-    VitePWA({
-      disable: true,
-      registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'pwa-192x192.png', 'pwa-512x512.png'],
-      manifest: {
-        name: 'NexaSphere — Connecting GL Bajaj Tech Ecosystem',
-        short_name: 'NexaSphere',
-        description: 'The premier tech community of GL Bajaj Group of Institutions.',
-        theme_color: '#CC1111',
-        background_color: '#0A0A0A',
-        display: 'standalone',
-        icons: [
-          {
-            src: 'pwa-192x192.png',
-            sizes: '192x192',
-            type: 'image/png'
-          },
-          {
-            src: 'pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png'
-          },
-          {
-            src: 'pwa-512x512.png',
-            sizes: '512x512',
-            type: 'image/png',
-            purpose: 'any maskable'
-          }
-        ]
-      },
-      workbox: {
-        inlineWorkboxRuntime: true,
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,jpg}']
-      }
-    })
-  ],
+  plugins: [react()],
   server: {
     port: 5175,
     proxy: {


### PR DESCRIPTION
1. replace hardcoded localhost AI/chat endpoints with shared env-based runtime config
2. route chatbot, AI mentor, recommendations, and notifications through configurable backend URLs
3. prevent Socket.IO from connecting to the frontend origin in production and add safer reconnect/error handling
4. align backend Socket.IO CORS with multi-origin env configuration
5. remove stale disabled PWA wiring that was breaking the Vite production build
6. update .env.example with required frontend/backend URL variables for deployment

closes #227 