### PR TITLE
fix: add auth and rate limiting to notification CRUD endpoints; add uncaughtException handler; fix ESM require() crash

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -893,9 +893,15 @@ app.post('/api/notifications/unsubscribe', (req, res) => {
 // Server-side notifications API (simple in-memory store)
 import notificationsService from './services/notificationsService.js';
 
-app.get('/api/notifications', (req, res) => {
+const notificationAuthRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 60,
+  message: { error: 'Too many notification requests, please try again later' },
+});
+
+// GET is read-only — apply rate limiting but not admin auth
+app.get('/api/notifications', notificationAuthRateLimiter, (req, res) => {
   try {
-    // If user id provided via query or auth, use that; otherwise global
     const userId = req.query.userId || 'global';
     const list = notificationsService.getNotifications(userId);
     return res.json({ notifications: list });
@@ -904,19 +910,21 @@ app.get('/api/notifications', (req, res) => {
   }
 });
 
-app.post('/api/notifications/mark-read', (req, res) => {
+// Mutation endpoints require admin auth + rate limiting
+app.post('/api/notifications/mark-read', adminAuth, notificationAuthRateLimiter, (req, res) => {
   try {
     const { id, userId } = req.body || {};
     if (!id) return res.status(400).json({ error: 'id required' });
     const uid = userId || 'global';
     const ok = notificationsService.markAsRead(uid, id);
-    return res.json({ success: ok });
+    if (!ok) return res.status(404).json({ error: 'Notification not found' });
+    return res.json({ success: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }
 });
 
-app.post('/api/notifications/mark-all-read', (req, res) => {
+app.post('/api/notifications/mark-all-read', adminAuth, notificationAuthRateLimiter, (req, res) => {
   try {
     const { userId } = req.body || {};
     notificationsService.markAllAsRead(userId || 'global');
@@ -926,11 +934,12 @@ app.post('/api/notifications/mark-all-read', (req, res) => {
   }
 });
 
-app.delete('/api/notifications/:id', (req, res) => {
+app.delete('/api/notifications/:id', adminAuth, notificationAuthRateLimiter, (req, res) => {
   try {
     const id = req.params.id;
     const userId = req.query.userId || 'global';
-    notificationsService.removeNotification(userId, id);
+    const removed = notificationsService.removeNotification(userId, id);
+    if (!removed) return res.status(404).json({ error: 'Notification not found' });
     return res.json({ success: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });
@@ -938,7 +947,7 @@ app.delete('/api/notifications/:id', (req, res) => {
 });
 
 // Delete all notifications for a user (or global)
-app.delete('/api/notifications', (req, res) => {
+app.delete('/api/notifications', adminAuth, notificationAuthRateLimiter, (req, res) => {
   try {
     const userId = req.query.userId || 'global';
     notificationsService.clearAll(userId);
@@ -948,12 +957,15 @@ app.delete('/api/notifications', (req, res) => {
   }
 });
 
-// Create notification (admin/testing)
-app.post('/api/notifications', (req, res) => {
+// Create notification (admin-only)
+app.post('/api/notifications', adminAuth, notificationAuthRateLimiter, (req, res) => {
   try {
     const { userId, title, message, type, link } = req.body || {};
+    if (!title || !message) {
+      return res.status(400).json({ error: 'title and message are required' });
+    }
     const note = notificationsService.addNotification(userId || 'global', { title, message, type, link });
-    return res.json({ success: true, notification: note });
+    return res.status(201).json({ success: true, notification: note });
   } catch (err) {
     return res.status(500).json({ error: err.message });
   }
@@ -1021,6 +1033,11 @@ app.put('/api/portfolio', portfolioRateLimiter, async (req, res) => {
 
 process.on('unhandledRejection', (reason) => {
   console.error('[Process] Unhandled rejection:', reason instanceof Error ? reason.message : reason);
+});
+
+process.on('uncaughtException', (err) => {
+  console.error('[Process] Uncaught exception:', err instanceof Error ? err.message : err);
+  if (err && err.stack) console.error(err.stack);
 });
 
 const port = Number(process.env.PORT || 8787);

--- a/server/routes/documentation.js
+++ b/server/routes/documentation.js
@@ -8,6 +8,7 @@ import swaggerUi from 'swagger-ui-express';
 import redoc from 'redoc-express';
 import specs from '../config/swagger.js';
 import logger from '../utils/logger.js';
+import yaml from 'yaml';
 
 const router = express.Router();
 
@@ -53,8 +54,7 @@ router.get('/swagger.json', (req, res) => {
  */
 router.get('/swagger.yaml', (req, res) => {
   res.setHeader('Content-Type', 'application/yaml');
-  const YAML = require('yaml');
-  res.send(YAML.stringify(specs));
+  res.send(yaml.stringify(specs));
   logger.info('OpenAPI YAML spec requested', { ip: req.ip });
 });
 

--- a/server/services/notificationsService.js
+++ b/server/services/notificationsService.js
@@ -50,7 +50,9 @@ export function clearAll(userId = 'global') {
 export function removeNotification(userId = 'global', id) {
   const list = _ensureList(userId);
   const idx = list.findIndex(n => n.id === id);
-  if (idx >= 0) list.splice(idx, 1);
+  if (idx < 0) return false;
+  list.splice(idx, 1);
+  return true;
 }
 
 export default {


### PR DESCRIPTION
## Summary

Two critical issues found during deep codebase analysis:

### Issue 1: Notification CRUD endpoints completely unprotected
All notification mutation endpoints (`POST /api/notifications`, `DELETE /api/notifications/:id`, `DELETE /api/notifications`, `POST /api/notifications/mark-read`, `POST /api/notifications/mark-all-read`) had zero authentication — anyone could create, delete, or manipulate all notifications globally. Also added input validation to prevent creating notifications without required fields, proper 404 responses for missing notification IDs, and rate limiting.

**Files changed:**
- `server/index.js` — Added `adminAuth` + `notificationAuthRateLimiter` to all notification mutation endpoints
- `server/services/notificationsService.js` — `removeNotification` now returns boolean for proper 404 handling

### Issue 2: Server crash on uncaughtException + ESM require() bug
1. No `process.on('uncaughtException')` handler — any uncaught exception kills the process silently
2. `server/routes/documentation.js` used CJS `require('yaml')` in an ESM module — hits `ReferenceError: require is not defined` at runtime

**Files changed:**
- `server/index.js` — Added `process.on('uncaughtException')` handler with stack trace logging
- `server/routes/documentation.js` — Replaced `require('yaml')` with proper ESM `import yaml from 'yaml'`