### PR TITLE
chore: remove leftover development console logs

### DIFF
--- a/src/pages/admin/AdminPage.jsx
+++ b/src/pages/admin/AdminPage.jsx
@@ -118,8 +118,7 @@ export default function AdminPage({ onBack }) {
 
     eventSource.addEventListener('login', (event) => {
       try {
-        const parsed = JSON.parse(event.data);
-        console.log(`SSE Login Alert: User ${parsed.data.username} connected from ${parsed.data.ip}`);
+        JSON.parse(event.data);
       } catch (err) {
         console.error('Failed to parse login SSE message:', err);
       }

--- a/src/pages/collab/CollabPage.jsx
+++ b/src/pages/collab/CollabPage.jsx
@@ -22,7 +22,6 @@ export default function CollabPage({ onBack }) {
 
   const handleJoinSubmit = async (requestData) => {
     // Send request to Java backend / Python notification webhook
-    console.log("Submitting request:", requestData);
     return new Promise(resolve => setTimeout(resolve, 1000));
   };
 

--- a/src/pages/membership/MembershipPage.jsx
+++ b/src/pages/membership/MembershipPage.jsx
@@ -1148,7 +1148,6 @@ export default function MembershipPage({ onBack }) {
                     <Turnstile
                       siteKey={import.meta.env.VITE_TURNSTILE_SITE_KEY}
                       onSuccess={(token) => {
-                        console.log("Turnstile Token generated:", token);
                         setCaptchaToken(token);
                       }}
                     />


### PR DESCRIPTION
**Description:**
This PR removes several leftover console.log statements from the frontend codebase. These were likely used for debugging during development but were inadvertently left in.

**Why is this change necessary:**
Keeping development logs in production code can clutter the browser console and occasionally leak sensitive data (such as tokens or request bodies) to end users.

**Changes made:**
Removed the following development logs:

-src/pages/membership/MembershipPage.jsx: Removed the log for generated Turnstile Tokens (Turnstile Token generated:).
-src/pages/collab/CollabPage.jsx: Removed the log that dumped submission request data (Submitting request:).
-src/pages/admin/AdminPage.jsx: Removed the log that exposed username and IP address on SSE login alerts (SSE Login Alert: ...).

Closes issue #289 