### PR TITLE
Add Prettier configuration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+dist
+build
+coverage
+node_modules
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "tabWidth": 2,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}


### PR DESCRIPTION
## Summary
- Added a root `.prettierrc` to standardize formatting choices across the project.
- Added `.prettierignore` to keep generated output, coverage, dependencies, and lockfile content out of formatting runs.
- Kept the PR focused by avoiding a broad repository reformat.

## Validation
- Ran `git diff --check` successfully.

Closes #260