### PR TITLE
fix: use env var for chatbot API endpoint

### DIFF
--- a/src/shared/Chatbot.jsx
+++ b/src/shared/Chatbot.jsx
@@ -56,7 +56,8 @@ const Chatbot = () => {
     setInput('');
 
     try {
-      const response = await fetch('http://localhost:8000/ai/chat', {
+      const base = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
+      const response = await fetch(`${base}/ai/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: currentInput }),


### PR DESCRIPTION
## Description

This PR fixes an issue where the frontend Chatbot component (`src/shared/Chatbot.jsx`) was attempting to fetch data from a hardcoded local endpoint (`http://localhost:8000/ai/chat`). It replaces the hardcoded URL with the `VITE_API_BASE` environment variable, with a fallback to localhost.

## Related Issue

Closes #288 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

**Changes made:**
- `src/shared/Chatbot.jsx`: Updated `handleSend` fetch request to dynamically resolve the API base URL using `import.meta.env.VITE_API_BASE`.
