### PR TITLE
fix: preserve matching CORS origin for admin SSE stream

### DIFF
--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -59,15 +59,12 @@ export function getConnectedSSEClientsCount() {
  * SSE middleware setup
  */
 export function setupSSEHeaders(req, res, next) {
-  const allowedOrigin = process.env.PUBLIC_APP_URL || process.env.CORS_ORIGIN?.split(',')[0]?.trim() || 'http://localhost:5173';
-
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
-  res.setHeader('Access-Control-Allow-Origin', allowedOrigin);
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
-  res.setHeader('Access-Control-Allow-Credentials', 'true');
+
+  // The app-level cors() middleware already selected the correct origin.
+  // Do not overwrite it here, or multi-origin deployments break.
 
   // Send initial connection message
   res.write(': SSE connection established\n\n');

--- a/server/test/sseService.test.js
+++ b/server/test/sseService.test.js
@@ -1,0 +1,89 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import http from 'node:http';
+import test from 'node:test';
+
+import cors from 'cors';
+import express from 'express';
+
+import { setupSSEHeaders } from '../services/sseService.js';
+
+function buildCorsOriginOption() {
+  const origins = process.env.CORS_ORIGIN?.split(',')
+    .map((origin) => origin.trim())
+    .filter(Boolean);
+
+  return origins?.length ? origins : true;
+}
+
+async function withStreamServer(t) {
+  const app = express();
+
+  app.use(cors({
+    origin: buildCorsOriginOption(),
+    credentials: false,
+  }));
+
+  app.get('/stream', setupSSEHeaders, (req, res) => {
+    res.end('ok');
+  });
+
+  const server = http.createServer(app);
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+
+  t.after(() => {
+    server.close();
+  });
+
+  const address = server.address();
+  return `http://127.0.0.1:${address.port}/stream`;
+}
+
+test('setupSSEHeaders preserves the matching allowed origin selected by cors()', async (t) => {
+  const previousCorsOrigin = process.env.CORS_ORIGIN;
+  const previousPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+  process.env.CORS_ORIGIN = 'https://prod.example.com, https://preview.example.com';
+  process.env.PUBLIC_APP_URL = 'https://prod.example.com';
+
+  t.after(() => {
+    process.env.CORS_ORIGIN = previousCorsOrigin;
+    process.env.PUBLIC_APP_URL = previousPublicAppUrl;
+  });
+
+  const url = await withStreamServer(t);
+  const response = await fetch(url, {
+    headers: {
+      Origin: 'https://preview.example.com',
+    },
+  });
+
+  assert.equal(response.headers.get('access-control-allow-origin'), 'https://preview.example.com');
+
+  await response.body?.cancel();
+});
+
+test('setupSSEHeaders does not emit a CORS allow-origin header for disallowed origins', async (t) => {
+  const previousCorsOrigin = process.env.CORS_ORIGIN;
+  const previousPublicAppUrl = process.env.PUBLIC_APP_URL;
+
+  process.env.CORS_ORIGIN = 'https://prod.example.com, https://preview.example.com';
+  process.env.PUBLIC_APP_URL = 'https://prod.example.com';
+
+  t.after(() => {
+    process.env.CORS_ORIGIN = previousCorsOrigin;
+    process.env.PUBLIC_APP_URL = previousPublicAppUrl;
+  });
+
+  const url = await withStreamServer(t);
+  const response = await fetch(url, {
+    headers: {
+      Origin: 'https://rogue.example.com',
+    },
+  });
+
+  assert.equal(response.headers.get('access-control-allow-origin'), null);
+
+  await response.body?.cancel();
+});


### PR DESCRIPTION
## Description

This fixes the admin SSE CORS bug when `CORS_ORIGIN` contains more than one allowed origin. The global `cors()` middleware was already picking the right origin for each request, but `setupSSEHeaders()` replaced that header with `PUBLIC_APP_URL` or the first entry from `CORS_ORIGIN`. That meant a preview or secondary origin could log in successfully and still lose the live admin stream.

The fix leaves origin selection to the existing app-level CORS middleware and adds a regression test for both a secondary allowed origin and a disallowed origin.

Verified locally with:

- `cd server && node --test test/sseService.test.js`
- `cd server && node --test test/*.test.js`

## Related Issue

Closes #281

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

Not applicable. This change only affects backend SSE response headers and test coverage.
