### PR TITLE
fix:resolve SSE Set mutation during forEach and zombie heartbeat intervals

### DIFF
--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -16,11 +16,13 @@ export function addSSEClient(res) {
 
   res.on('close', () => {
     adminClients.delete(res);
+    if (res._heartbeat) clearInterval(res._heartbeat);
     logger.info('SSE client disconnected', { totalClients: adminClients.size });
   });
 
   res.on('error', (error) => {
     adminClients.delete(res);
+    if (res._heartbeat) clearInterval(res._heartbeat)
     logger.error('SSE client error', { error: error.message });
   });
 }
@@ -35,14 +37,20 @@ export function broadcastSSEEvent(eventName, data) {
     timestamp: new Date().toISOString(),
   });
 
+  const dead = [];
   adminClients.forEach((client) => {
     try {
       client.write(`event: ${eventName}\n`);
       client.write(`data: ${eventData}\n\n`);
     } catch (error) {
       logger.error('Failed to send SSE event', { error: error.message });
-      adminClients.delete(client);
+      dead.push(client);
     }
+  });
+
+  dead.forEach((c) => {
+    adminClients.delete(c);
+    clearInterval(c._heartbeat);
   });
 
   logger.debug('SSE event broadcast', { event: eventName, clientCount: adminClients.size });
@@ -73,16 +81,16 @@ export function setupSSEHeaders(req, res, next) {
   res.write(': SSE connection established\n\n');
 
   // Send heartbeat every 30 seconds to keep connection alive
-  const heartbeat = setInterval(() => {
+  res._heartbeat = setInterval(() => {
     try {
       res.write(': heartbeat\n\n');
     } catch (error) {
-      clearInterval(heartbeat);
+      clearInterval(res._heartbeat);
     }
   }, 30000);
 
   res.on('close', () => {
-    clearInterval(heartbeat);
+    clearInterval(res._heartbeat);
   });
 
   next();


### PR DESCRIPTION
Closes #265

## Problem
`server/services/sseService.js` had three bugs:

1. `adminClients.delete(client)` was called inside `.forEach()` on the same Set — mutating a Set during iteration causes V8 to silently skip remaining clients, so some healthy clients never received the broadcast.

2. The `close` and `error` event listeners were not clearing the heartbeat interval, creating zombie timers that held references to dead response objects (memory leak).

3. `const heartbeat` was scoped locally, so it could not be accessed or cleared from outside the interval callback.

## Fix
- Collect failed clients in a `dead` array during iteration, then delete them after the loop completes
- Store heartbeat as `res._heartbeat` so it can be accessed from all handlers
- Clear `res._heartbeat` in both `close` and `error` listeners
- Clear `res._heartbeat` inside `dead.forEach` cleanup as well

## Changes
- `server/services/sseService.js`
