### PR TITLE
Fix verification email origin normalization

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -23,6 +23,7 @@ import {
   authRateLimiter,
   notificationRateLimiter,
 } from "./middleware/rateLimiter.js";
+import { getPublicAppUrl } from "./utils/publicAppUrl.js";
 
 import { portfolioRepository } from "./repositories/portfolioRepository.js";
 import { Mutex } from "async-mutex";
@@ -141,28 +142,7 @@ function requiredStrongPassword(name) {
 
 const ADMIN_EVENT_PASSWORD = requiredStrongPassword("ADMIN_EVENT_PASSWORD");
 
-if (process.env.PUBLIC_APP_URL) {
-  if (process.env.PUBLIC_APP_URL.includes(",")) {
-    throw new Error(
-      "PUBLIC_APP_URL must be a single URL, not a comma-separated list",
-    );
-  }
-  try {
-    new URL(process.env.PUBLIC_APP_URL);
-  } catch {
-    throw new Error(
-      `PUBLIC_APP_URL must be a valid absolute URL, got: ${process.env.PUBLIC_APP_URL}`,
-    );
-  }
-}
-
-function getPublicAppUrl() {
-  if (process.env.PUBLIC_APP_URL) {
-    return process.env.PUBLIC_APP_URL.replace(/\/+$/, "");
-  }
-  const firstOrigin = process.env.CORS_ORIGIN?.split(",")[0]?.trim();
-  return firstOrigin || "http://localhost:5173";
-}
+getPublicAppUrl();
 
 function normalizePrivateKey(k) {
   return k.includes("\\n") ? k.replace(/\\n/g, "\n") : k;

--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -4,6 +4,7 @@
  */
 
 import logger from '../utils/logger.js';
+import { getPublicAppUrl } from '../utils/publicAppUrl.js';
 
 const adminClients = new Set();
 
@@ -59,7 +60,7 @@ export function getConnectedSSEClientsCount() {
  * SSE middleware setup
  */
 export function setupSSEHeaders(req, res, next) {
-  const allowedOrigin = process.env.PUBLIC_APP_URL || process.env.CORS_ORIGIN?.split(',')[0]?.trim() || 'http://localhost:5173';
+  const allowedOrigin = getPublicAppUrl();
 
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');

--- a/server/test/publicAppUrl.test.js
+++ b/server/test/publicAppUrl.test.js
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { getPublicAppUrl } from '../utils/publicAppUrl.js';
+
+test('getPublicAppUrl uses PUBLIC_APP_URL when configured', () => {
+  assert.equal(
+    getPublicAppUrl({
+      PUBLIC_APP_URL: 'https://app.example.com/',
+      CORS_ORIGIN: 'https://admin.example.com',
+    }),
+    'https://app.example.com'
+  );
+});
+
+test('getPublicAppUrl selects the first configured CORS origin', () => {
+  assert.equal(
+    getPublicAppUrl({
+      CORS_ORIGIN: ' http://localhost:5173, http://127.0.0.1:5173 ',
+    }),
+    'http://localhost:5173'
+  );
+});
+
+test('getPublicAppUrl rejects comma-separated PUBLIC_APP_URL values', () => {
+  assert.throws(
+    () =>
+      getPublicAppUrl({
+        PUBLIC_APP_URL: 'https://app.example.com,https://admin.example.com',
+      }),
+    /PUBLIC_APP_URL must be a single URL/
+  );
+});
+
+test('getPublicAppUrl falls back to the local frontend origin', () => {
+  assert.equal(getPublicAppUrl({}), 'http://localhost:5173');
+});

--- a/server/utils/publicAppUrl.js
+++ b/server/utils/publicAppUrl.js
@@ -1,0 +1,39 @@
+const DEFAULT_PUBLIC_APP_URL = "http://localhost:5173";
+
+function normalizeAbsoluteHttpUrl(value, envName) {
+  try {
+    const url = new URL(value);
+
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error("URL must use http or https");
+    }
+
+    return url.href.replace(/\/+$/, "");
+  } catch {
+    throw new Error(`${envName} must contain a valid absolute HTTP(S) URL`);
+  }
+}
+
+export function getPublicAppUrl(env = process.env) {
+  const publicAppUrl = env.PUBLIC_APP_URL?.trim();
+
+  if (publicAppUrl) {
+    if (publicAppUrl.includes(",")) {
+      throw new Error(
+        "PUBLIC_APP_URL must be a single URL, not a comma-separated list",
+      );
+    }
+
+    return normalizeAbsoluteHttpUrl(publicAppUrl, "PUBLIC_APP_URL");
+  }
+
+  const firstCorsOrigin = env.CORS_ORIGIN?.split(",")
+    .map((origin) => origin.trim())
+    .filter(Boolean)[0];
+
+  if (firstCorsOrigin) {
+    return normalizeAbsoluteHttpUrl(firstCorsOrigin, "CORS_ORIGIN");
+  }
+
+  return DEFAULT_PUBLIC_APP_URL;
+}


### PR DESCRIPTION
## Description

Fixes verification email URL generation when `CORS_ORIGIN` contains multiple comma-separated frontend origins.

This PR adds a shared public app URL normalizer that:
- uses `PUBLIC_APP_URL` when configured
- rejects comma-separated `PUBLIC_APP_URL` values
- falls back to the first valid `CORS_ORIGIN`
- trims trailing slashes before building verification links

It also reuses the same helper for SSE origin handling and adds focused tests.

## Related Issue

Closes #273

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

Not applicable. Backend-only change.

## Validation

```bash
node --test test\publicAppUrl.test.js