### PR TITLE
fix(ui): resolve mismatched JSX closing tags in Navbar breaking local compilation

### DIFF
--- a/src/shared/Navbar.jsx
+++ b/src/shared/Navbar.jsx
@@ -132,6 +132,7 @@ if (compact) return (
             <div className="ns-nav-divider"/>
             <span className="ns-nav-brand">NexaSphere</span>
           </div>
+        </div>
 
 <div className="ns-nav-actions">
   <NotificationBell />


### PR DESCRIPTION
## Description

Resolved a critical JSX syntax error inside the shared Navbar component (`src/shared/Navbar.jsx`). An inverted tag sequence (`<div>` nested inside a `<nav>`, but closing the `</nav>` tag first) was causing `esbuild` parsing failures, completely breaking local development initialization (`npm run dev`) and production compilation.

## Related Issue

Closes #356 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

N/A (Purely structural syntax correction)
