### PR TITLE
Fix unsafe trailRef access and optimize glowRef handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -153,14 +153,6 @@ function Cursor() {
         glowRef.current.style.left    = s.mx + 'px';
         glowRef.current.style.top     = s.my + 'px';
         glowRef.current.style.opacity = s.visible ? 1 : 0;
-        trailRef.current.style.left = s.ox + 'px';
-        trailRef.current.style.top = s.oy + s.floatY * 0.4 + 'px';
-        trailRef.current.style.opacity = s.visible ? (s.hovering ? 0 : 0.35) : 0; 
-      }
-      if (glowRef.current) {
-        glowRef.current.style.left = s.mx + 'px';
-        glowRef.current.style.top = s.my + 'px';
-        glowRef.current.style.opacity = s.visible ? 1 : 0; 
       }
       s.raf = requestAnimationFrame(tick);
     };


### PR DESCRIPTION
This pull request makes a small cleanup in the `Cursor` function in `src/App.jsx`, removing a redundant conditional block that duplicated logic for updating the styles of `glowRef` and `trailRef`. The change helps simplify the code and avoid unnecessary repetition.

- Removed a duplicated `if (glowRef.current)` block that set style properties for `glowRef` and `trailRef`, ensuring style updates are handled in a single place.


Closes #250 