### PR TITLE
fix: wrap application root in ThemeProvider to resolve context crash

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ import { useDeveloperMode } from './hooks/useDeveloperMode';
 import { BookmarkProvider } from './context/BookmarkContext';
 import BookmarksDrawer from './components/bookmarks/BookmarksDrawer';
 import { useTheme } from './hooks/useTheme';
+import { useInteractionEffects } from './hooks/useInteractionEffects';
 
 import MoveToTop from "./shared/MoveToTop";
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -13,11 +13,13 @@ import { HelmetProvider } from 'react-helmet-async';
 registerSW({ immediate: true });
 
 createRoot(document.getElementById('root')).render(
-  <StrictMode>
+ <StrictMode>
     <HelmetProvider>
-      <GlobalErrorBoundary>
-        <App />
-      </GlobalErrorBoundary>
+      <ThemeProvider>
+        <GlobalErrorBoundary>
+          <App />
+        </GlobalErrorBoundary>
+      </ThemeProvider>
     </HelmetProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Description

Resolved a critical runtime application crash caused by a missing global context layout. The application layout components utilize the `useTheme` hook, which requires a bounding context provider. By wrapping the root application tree in `src/main.jsx` with `<ThemeProvider>`, the broadcasting context signal is restored, clearing the fatal context reference error.

## Related Issue

Closes #342

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

 ## Screenshots <img width="1248" height="217" alt="image" src="https://github.com/user-attachments/assets/1b63b452-5530-4a02-a050-12d59ebfa2de" /> 
- Component stack trace confirming ThemeProvider is cleanly mounted and active in the layout tree.