### PR TITLE
fix: remove duplicate navbar actions

### DIFF
--- a/src/shared/Navbar.jsx
+++ b/src/shared/Navbar.jsx
@@ -136,10 +136,6 @@ if (compact) return (
 
 <div className="ns-nav-actions">
   <NotificationBell />
-  <BookmarkToggle onToggle={onToggleBookmarks} />
-
-<div className="ns-nav-actions">
-  <NotificationBell />
 
   <BookmarkToggle onToggle={onToggleBookmarks} />
 


### PR DESCRIPTION
## Description

- Removed the duplicated `ns-nav-actions` wrapper in `src/shared/Navbar.jsx`
- Ensured the notification bell and bookmark toggle render only once in the desktop navbar
- Kept the remaining navbar actions grouped with CTAs, theme toggle, and menu toggle

## Related Issue

Closes #362 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.
