### PR TITLE
chore: add standard SECURITY.md vulnerability disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest version of this project is currently supported with security updates. Please ensure you are running the most recent release before reporting any issues.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please do **NOT** open a public issue. Instead, report the vulnerability by emailing the maintainers directly.
+
+Please include the following details in your report:
+- A description of the vulnerability and its potential impact.
+- Step-by-step instructions (or a proof-of-concept script) to reproduce the behavior.
+- Any potential mitigations or fixes.
+
+We will acknowledge receipt of your report within 48 hours and work to resolve the issue as quickly as possible.


### PR DESCRIPTION
## What does this PR do?

This PR introduces a standard security policy (`SECURITY.md`) to the repository root.

## Why is this change needed?

Currently, there is no policy indicating how security vulnerability reports should be privately disclosed, causing security concerns to be raised as public issues.

## What changes were made?

* Created a `SECURITY.md` file setting up the responsible disclosure procedure.

## How to test

1. View the `SECURITY.md` file in the repository.
2. Confirm that the vulnerability disclosure instructions and support window are clear.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes

Closes #341