### PR TITLE
fix: remove socket lifecycle console logs

### DIFF
--- a/src/utils/socketClient.js
+++ b/src/utils/socketClient.js
@@ -47,20 +47,7 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
 
   // Global event handlers - connection lifecycle monitoring
   socket.on('connect', () => {
-    console.log('[Socket.IO] Connected:', socket.id);
     identifyUser(); // try to identify if user info is available locally
-  });
-
-  socket.on('disconnect', (reason) => {
-    console.log('[Socket.IO] Disconnected:', reason);
-  });
-
-  socket.on('reconnect', (attemptNumber) => {
-    console.log('[Socket.IO] Reconnected after', attemptNumber, 'attempts');
-  });
-
-  socket.on('reconnect_attempt', (attemptNumber) => {
-    console.log('[Socket.IO] Reconnecting attempt:', attemptNumber);
   });
 
   socket.on('reconnect_failed', () => {


### PR DESCRIPTION
## Description

- Removed production `console.log` statements from Socket.IO lifecycle handlers
- Kept user identification on successful socket connection
- Preserved warning/error handling and exception capture for socket failures

## Related Issue

Closes #363 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.
