### PR TITLE
[SECURITY] Hide production error stack traces and consolidate error boundary handling

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -6,75 +6,29 @@
 import React from "react";
 import * as Sentry from "@sentry/react";
 import { captureHandledException } from "../utils/errorTracking";
+import ErrorFallback from "./common/ErrorFallback";
 
-const ErrorBoundaryFallback = ({ error, resetError }) => (
-  <div
-    style={{
-      display: "flex",
-      flexDirection: "column",
-      justifyContent: "center",
-      alignItems: "center",
-      height: "100vh",
-      backgroundColor: "#f5f5f5",
-      fontFamily: "Arial, sans-serif",
-      color: "#333",
-    }}
-  >
-    <h1 style={{ fontSize: "2rem", marginBottom: "1rem" }}>Oops! Something went wrong</h1>
-    <p style={{ fontSize: "1rem", marginBottom: "2rem", maxWidth: "500px", textAlign: "center" }}>
-      We've been notified of the issue and are working to fix it. Please try refreshing the page.
-    </p>
-    <details
-      style={{
-        whiteSpace: "pre-wrap",
-        backgroundColor: "#fff",
-        padding: "1rem",
-        borderRadius: "4px",
-        maxWidth: "600px",
-        marginBottom: "2rem",
-        fontSize: "0.85rem",
-        fontFamily: "monospace",
-      }}
-    >
-      <summary style={{ cursor: "pointer", fontWeight: "bold", marginBottom: "1rem" }}>
-        Error Details
-      </summary>
-      <p>{error?.toString()}</p>
-      <p>{error?.stack}</p>
-    </details>
-    <button
-      onClick={resetError}
-      style={{
-        padding: "0.75rem 1.5rem",
-        fontSize: "1rem",
-        backgroundColor: "#007bff",
-        color: "#fff",
-        border: "none",
-        borderRadius: "4px",
-        cursor: "pointer",
-        marginRight: "1rem",
-      }}
-    >
-      Refresh Page
-    </button>
-    <a
-      href="/"
-      style={{
-        padding: "0.75rem 1.5rem",
-        fontSize: "1rem",
-        backgroundColor: "#6c757d",
-        color: "#fff",
-        border: "none",
-        borderRadius: "4px",
-        cursor: "pointer",
-        textDecoration: "none",
-        display: "inline-block",
-      }}
-    >
-      Go Home
-    </a>
-  </div>
-);
+const ErrorBoundaryFallback = ({ error, resetError }) => {
+  const handleRefresh = () => {
+    if (typeof resetError === "function") {
+      resetError();
+      return;
+    }
+    window.location.reload();
+  };
+
+  return (
+    <ErrorFallback
+      error={error}
+      fullPage
+      showGoHome
+      onRefresh={handleRefresh}
+      onGoHome={() => window.location.assign("/")}
+      title="Oops! Something went wrong"
+      message="We've been notified of the issue and are working to fix it."
+    />
+  );
+};
 
 class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -88,7 +42,10 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, errorInfo) {
     // Log error to Sentry
-    captureHandledException(error, `React Error Boundary: ${errorInfo.componentStack}`);
+    captureHandledException(
+      error,
+      `React Error Boundary: ${errorInfo.componentStack}`
+    );
 
     // Log to console in development
     if (import.meta.env.DEV) {
@@ -104,7 +61,12 @@ class ErrorBoundary extends React.Component {
 
   render() {
     if (this.state.hasError) {
-      return <ErrorBoundaryFallback error={this.state.error} resetError={this.resetError} />;
+      return (
+        <ErrorBoundaryFallback
+          error={this.state.error}
+          resetError={this.resetError}
+        />
+      );
     }
 
     return this.props.children;

--- a/src/components/GlobalErrorBoundary.jsx
+++ b/src/components/GlobalErrorBoundary.jsx
@@ -1,32 +1,34 @@
-import React from 'react';
-import './GlobalErrorBoundary.css';
+import React from "react";
+import ErrorFallback from "./common/ErrorFallback";
 
 class GlobalErrorBoundary extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { hasError: false };
+    this.state = { hasError: false, error: null };
   }
 
   static getDerivedStateFromError(error) {
     // Update state so the next render will show the fallback UI.
-    return { hasError: true };
+    return { hasError: true, error };
   }
 
   componentDidCatch(error, errorInfo) {
     // Log errors using console.error as required
-    console.error('GlobalErrorBoundary caught an error:', error, errorInfo);
+    console.error("GlobalErrorBoundary caught an error:", error, errorInfo);
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div className="global-error-boundary">
-          <div className="global-error-content">
-            <h1>Something went wrong</h1>
-            <p>Please refresh the page and try again.</p>
-            <button onClick={() => window.location.reload()}>Refresh</button>
-          </div>
-        </div>
+        <ErrorFallback
+          error={this.state.error}
+          fullPage
+          showGoHome
+          onRefresh={() => window.location.reload()}
+          onGoHome={() => window.location.assign("/")}
+          title="Something went wrong"
+          message="An unexpected error occurred. Please refresh the page or return to home."
+        />
       );
     }
 

--- a/src/components/common/ErrorBoundary.jsx
+++ b/src/components/common/ErrorBoundary.jsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { DynamicIcon } from '../../shared/Icons';
+import React from "react";
+import ErrorFallback from "./ErrorFallback";
 
 export class ErrorBoundary extends React.Component {
   constructor(props) {
@@ -12,35 +12,20 @@ export class ErrorBoundary extends React.Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    console.error('ErrorBoundary caught an error:', error, errorInfo);
+    console.error("ErrorBoundary caught an error:", error, errorInfo);
   }
 
   render() {
     if (this.state.hasError) {
       return (
-        <div style={{
-          minHeight: '400px', display: 'flex', flexDirection: 'column',
-          alignItems: 'center', justifyContent: 'center', textAlign: 'center',
-          padding: '40px 24px', background: 'var(--bg)', borderRadius: '12px',
-          border: '1px solid rgba(255,68,68,0.2)', margin: '20px'
-        }}>
-          <div style={{ color: '#ff4444', marginBottom: '16px' }}>
-            <DynamicIcon name="AlertTriangle" size={48} />
-          </div>
-          <h2 style={{ fontFamily: "'Orbitron', monospace", fontSize: '1.5rem', fontWeight: 700, color: 'var(--t1)', marginBottom: '12px' }}>
-            Something went wrong
-          </h2>
-          <p style={{ color: 'var(--t2)', fontSize: '0.95rem', maxWidth: '420px', lineHeight: 1.6, marginBottom: '24px' }}>
-            We encountered an unexpected issue while loading this content. Please try reloading the page.
-          </p>
-          <button 
-            className="btn btn-primary" 
-            onClick={() => window.location.reload()} 
-            style={{ cursor: 'pointer', display: 'flex', alignItems: 'center', gap: '8px' }}
-          >
-            <DynamicIcon name="RefreshCw" size={16} /> Reload Page
-          </button>
-        </div>
+        <ErrorFallback
+          error={this.state.error}
+          showGoHome
+          onRefresh={() => window.location.reload()}
+          onGoHome={() => window.location.assign("/")}
+          title="Something went wrong"
+          message="We encountered an unexpected issue while loading this content."
+        />
       );
     }
     return this.props.children;

--- a/src/components/common/ErrorFallback.jsx
+++ b/src/components/common/ErrorFallback.jsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { DynamicIcon } from "../../shared/Icons";
+
+const fullPageStyles = {
+  wrapper: {
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    minHeight: "100vh",
+    width: "100%",
+    padding: "24px",
+    background: "var(--bg)",
+    boxSizing: "border-box",
+  },
+  card: {
+    width: "100%",
+    maxWidth: "560px",
+    background: "var(--card)",
+    border: "1px solid rgba(255,68,68,0.2)",
+    borderRadius: "12px",
+    padding: "32px 24px",
+    textAlign: "center",
+    boxShadow: "0 10px 25px rgba(0, 0, 0, 0.18)",
+  },
+};
+
+const sectionStyles = {
+  wrapper: {
+    minHeight: "400px",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    textAlign: "center",
+    padding: "40px 24px",
+    background: "var(--bg)",
+    borderRadius: "12px",
+    border: "1px solid rgba(255,68,68,0.2)",
+    margin: "20px",
+  },
+  card: {
+    width: "100%",
+    maxWidth: "560px",
+    boxSizing: "border-box",
+  },
+};
+
+const titleStyles = {
+  marginBottom: "12px",
+  color: "var(--t1)",
+  fontFamily: "'Orbitron', monospace",
+  fontWeight: 700,
+};
+
+const messageStyles = {
+  color: "var(--t2)",
+  fontSize: "0.95rem",
+  lineHeight: 1.6,
+  marginBottom: "24px",
+  maxWidth: "460px",
+};
+
+const buttonRowStyles = {
+  display: "flex",
+  gap: "10px",
+  justifyContent: "center",
+  flexWrap: "wrap",
+};
+
+const secondaryButtonStyles = {
+  border: "1px solid var(--bdr)",
+  background: "transparent",
+  color: "var(--t2)",
+  padding: "10px 16px",
+  borderRadius: "8px",
+  cursor: "pointer",
+  fontWeight: 600,
+};
+
+const detailsStyles = {
+  width: "100%",
+  textAlign: "left",
+  border: "1px solid var(--bdr)",
+  borderRadius: "8px",
+  padding: "10px 12px",
+  background: "rgba(0,0,0,0.12)",
+  marginBottom: "20px",
+  boxSizing: "border-box",
+};
+
+const stackStyles = {
+  marginTop: "10px",
+  maxHeight: "220px",
+  overflow: "auto",
+  whiteSpace: "pre-wrap",
+  wordBreak: "break-word",
+  fontSize: "0.78rem",
+  lineHeight: 1.5,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  color: "var(--t2)",
+};
+
+export default function ErrorFallback({
+  error,
+  title = "Something went wrong",
+  message = "We encountered an unexpected issue. Please refresh the page and try again.",
+  fullPage = false,
+  showGoHome = true,
+  onRefresh,
+  onGoHome,
+}) {
+  const isDevelopment = import.meta.env.DEV;
+  const styles = fullPage ? fullPageStyles : sectionStyles;
+
+  const handleRefresh = () => {
+    if (typeof onRefresh === "function") {
+      onRefresh();
+      return;
+    }
+    window.location.reload();
+  };
+
+  const handleGoHome = () => {
+    if (typeof onGoHome === "function") {
+      onGoHome();
+      return;
+    }
+    window.location.assign("/");
+  };
+
+  return (
+    <div style={styles.wrapper}>
+      <div style={styles.card}>
+        <div style={{ color: "#ff4444", marginBottom: "14px" }}>
+          <DynamicIcon name="AlertTriangle" size={52} />
+        </div>
+
+        {fullPage ? (
+          <h1 style={{ ...titleStyles, fontSize: "2rem" }}>{title}</h1>
+        ) : (
+          <h2 style={{ ...titleStyles, fontSize: "1.5rem" }}>{title}</h2>
+        )}
+
+        <p style={messageStyles}>{message}</p>
+
+        {isDevelopment && error && (
+          <details style={detailsStyles}>
+            <summary
+              style={{ cursor: "pointer", fontWeight: 700, color: "var(--t1)" }}
+            >
+              Developer Error Details
+            </summary>
+            <div
+              style={{
+                marginTop: "10px",
+                color: "var(--t2)",
+                fontSize: "0.88rem",
+              }}
+            >
+              {error?.toString?.() || "Unknown error"}
+            </div>
+            {error?.stack && <pre style={stackStyles}>{error.stack}</pre>}
+          </details>
+        )}
+
+        <div style={buttonRowStyles}>
+          <button
+            className="btn btn-primary"
+            onClick={handleRefresh}
+            style={{ cursor: "pointer" }}
+          >
+            Refresh Page
+          </button>
+          {showGoHome && (
+            <button onClick={handleGoHome} style={secondaryButtonStyles}>
+              Go Home
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Fixes issue #226 by making frontend crash fallbacks secure and consistent across the app.

This PR:
•  Hides technical error details (message/stack trace) in production fallback UI.
•  Shows developer error details only in development mode.
•  Adds a clean, reusable fallback UI with recovery actions.
•  Keeps user recovery options (Refresh Page, Go Home).
•  Preserves existing error logging behavior (console.error and Sentry capture paths).
•  Aligns duplicate error-boundary behavior across global and section-level boundaries.

Related issue
Closes #226

Testing
I ran dependency install locally (npm install)
I verified issue-related boundary changes compile in the modified files
I verified recovery actions remain available in fallback UI
npm run build (currently fails due pre-existing virtual:pwa-register resolution in src/main.jsx)
npm run test (currently fails due pre-existing issues in src/pages/events/EventsPage.jsx (viewMode undefined) and test localStorage setup)

Screenshots / recordings
N/A

Notes
•  Added shared fallback component: src/components/common/ErrorFallback.jsx
•  Updated and aligned boundaries:
◦  src/components/ErrorBoundary.jsx
◦  src/components/GlobalErrorBoundary.jsx
◦  src/components/common/ErrorBoundary.jsx
•  Branch: fix/issue-226-error-boundary-security
•  Commit: 8cf1e67
•  Co-Authored-By: Oz <oz-agent@warp.dev>