### PR TITLE
chore: configure Dependabot for automated dependency updates (#347)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Description

This PR introduces automated dependency management by configuring GitHub Dependabot. Falling behind on minor versions or security patches can lead to vulnerabilities and broken builds. By setting the ecosystem to `npm` and the schedule to `weekly`, we ensure our packages stay up-to-date automatically without overwhelming the PR queue.

## Related Issue

Closes #347

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

*(N/A - CI/CD configuration change)*