### PR TITLE
seo: generate dynamic sitemap and robots.txt (#352)

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: ['/api/', '/dashboard/', '/settings/'],
+    },
+    sitemap: `${baseUrl}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,27 @@
+import { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000';
+  const now = new Date();
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: now,
+      changeFrequency: 'daily',
+      priority: 1.0,
+    },
+    {
+      url: `${baseUrl}/about`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: now,
+      changeFrequency: 'weekly',
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
## Description

This PR implements Next.js native dynamic routing for SEO metadata. By utilizing the App Router's `sitemap.ts` and `robots.ts` conventions, we ensure search engine crawlers can properly discover and index our public-facing pages. Additionally, the `robots.txt` configuration explicitly restricts crawlers from accessing private application paths (such as `/api`, `/dashboard`, and `/settings`), protecting sensitive routes and conserving crawl budget.

## Related Issue

Closes #352

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

*(N/A - SEO metadata changes. Verified locally by navigating to `/sitemap.xml` and `/robots.txt` to confirm valid text/xml outputs).*