### PR TITLE
test: set up Playwright for End-to-End (E2E) testing (#428)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@next/bundle-analyzer": "^16.2.6",
-        "@playwright/test": "^1.40.0",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.1.4",
         "@testing-library/react": "^14.0.0",
         "@types/react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
+    "test:e2e": "playwright test",
     "lint": "echo \"Lint skipped\"",
     "lint:fix": "eslint . --fix",
     "e2e": "playwright test",
@@ -45,7 +46,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@next/bundle-analyzer": "^16.2.6",
-    "@playwright/test": "^1.40.0",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.1.4",
     "@testing-library/react": "^14.0.0",
     "@types/react": "^18.2.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,16 +1,10 @@
-import { defineConfig, devices } from '@playwright/test';
-
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// require('dotenv').config();
+import { defineConfig, devices } from "@playwright/test";
 
 /**
  * Playwright configuration for E2E testing
  */
 export default defineConfig({
-  testDir: './e2e',
+  testDir: "./tests",
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
@@ -20,35 +14,34 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: "html",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:5175',
-    trace: 'on-first-retry',
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
   },
 
   /* Configure projects for major browsers */
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
     },
     {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
     },
     {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
     },
   ],
 
   /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run dev',
-  //   url: 'http://localhost:5173',
-  //   reuseExistingServer: true,
-  // },
-  // NOTE: Start dev server manually with: npm run dev
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+  },
 });

--- a/tests/home.spec.ts
+++ b/tests/home.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Home Page Sanity Test", () => {
+  test("should load successfully and display the correct title", async ({
+    page,
+  }) => {
+    // Navigate to the homepage
+    await page.goto("/");
+
+    // Expect the page to have the correct title
+    await expect(page).toHaveTitle(/NexaSphere/);
+  });
+});


### PR DESCRIPTION
## Description

This PR establishes an automated End-to-End (E2E) testing foundation for NexaSphere using Playwright. Relying purely on manual testing scales poorly; this pipeline allows us to automatically test critical user journeys in a real browser environment. A foundational sanity test for the homepage has been included, and `playwright.config.ts` is configured to spin up the local dev server automatically when running `npm run test:e2e`.

## Related Issue

Closes #428

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

*(N/A - testing infrastructure setup. Verified locally by running `npm run test:e2e` and observing a passing test).*