### PR TITLE
Wire monitoring and docs routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -16,6 +16,8 @@ import analyticsRouter from "./routes/analytics.js";
 import { initializeSocketIO, emitToRoom, getRoom } from "./config/socket.js";
 import adminStreamRouter from "./routes/adminStream.js";
 import { broadcastSSEEvent } from "./services/sseService.js";
+import documentationRouter from "./routes/documentation.js";
+import monitoringRouter from "./routes/monitoring.js";
 import rateLimit from "express-rate-limit";
 import {
   apiRateLimiter,
@@ -85,6 +87,10 @@ function requestLogger(req, res, next) {
 
 app.use(requestLogger);
 app.use("/api", apiRateLimiter);
+
+// Mount monitoring + API documentation routes (previously implemented but never registered).
+app.use("/api/monitoring", monitoringRouter);
+app.use("/api", documentationRouter);
 
 const adminAuth = adminAuthMiddleware.requireAdmin;
 const adminEvents = new EventEmitter();

--- a/server/utils/sentry.js
+++ b/server/utils/sentry.js
@@ -4,7 +4,16 @@
  */
 
 import * as Sentry from "@sentry/node";
-import { nodeProfilingIntegration } from "@sentry/profiling-node";
+
+let nodeProfilingIntegration = null;
+try {
+  // Optional dependency: native bindings may be unavailable on some platforms.
+  // If profiling cannot be loaded, fall back to Sentry without profiling.
+  const profiling = await import("@sentry/profiling-node");
+  nodeProfilingIntegration = profiling.nodeProfilingIntegration;
+} catch (error) {
+  nodeProfilingIntegration = null;
+}
 
 /**
  * Initialize Sentry for backend monitoring
@@ -29,7 +38,7 @@ function initializeSentry(app) {
         request: true,
         serverName: true,
       }),
-      nodeProfilingIntegration(),
+      ...(nodeProfilingIntegration ? [nodeProfilingIntegration()] : []),
     ],
     tracesSampleRate: isDevelopment ? 1.0 : 0.1,
     profilesSampleRate: isDevelopment ? 1.0 : 0.1,


### PR DESCRIPTION
## Summary
Mounts the already-implemented monitoring and API documentation routers so they are reachable at runtime instead of being dead/unreachable code.

## Changes
- Registered routes in `server/index.js`:
  - `app.use("/api/monitoring", monitoringRouter)`
  - `app.use("/api", documentationRouter)`
- Made Sentry profiling integration optional in `server/utils/sentry.js` so importing monitoring/docs (and their Sentry helpers) doesn’t crash on platforms where native profiling bindings aren’t available.

## Related Issue
Closes #440

## Testing
- Verified the route modules import successfully (`node -e "await import('./routes/monitoring.js'); await import('./routes/documentation.js');"` from `server/`).

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes
