### PR TITLE
fix: add maxLength and url validation rules to useFormValidation hook

### DIFF
--- a/src/__tests__/useFormValidation.test.ts
+++ b/src/__tests__/useFormValidation.test.ts
@@ -1,0 +1,342 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import useFormValidation from "../hooks/useFormValidation";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Runs a single-field validation and returns the resulting errors object. */
+function validateSingleField(
+  fieldName: string,
+  value: unknown,
+  rules: Record<string, unknown>
+) {
+  const { result } = renderHook(() =>
+    useFormValidation({ [fieldName]: value }, { [fieldName]: rules })
+  );
+
+  let isValid: boolean;
+  act(() => {
+    isValid = result.current.validateForm([fieldName]);
+  });
+
+  return result.current.errors;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("useFormValidation", () => {
+  // -------------------------------------------------------------------------
+  // required
+  // -------------------------------------------------------------------------
+  describe("required rule", () => {
+    it("reports error for empty string", () => {
+      const errors = validateSingleField("name", "", { required: true });
+      expect(errors.name).toBe("This field is required");
+    });
+
+    it("reports error for whitespace-only string", () => {
+      const errors = validateSingleField("name", "   ", { required: true });
+      expect(errors.name).toBe("This field is required");
+    });
+
+    it("passes for non-empty string", () => {
+      const errors = validateSingleField("name", "Nexasphere", {
+        required: true,
+      });
+      expect(errors.name).toBeUndefined();
+    });
+
+    it("accepts a custom requiredMessage", () => {
+      const errors = validateSingleField("name", "", {
+        required: true,
+        requiredMessage: "Name is mandatory",
+      });
+      expect(errors.name).toBe("Name is mandatory");
+    });
+
+    it("reports error for empty array", () => {
+      const errors = validateSingleField("tags", [], { required: true });
+      expect(errors.tags).toBe("This field is required");
+    });
+
+    it("passes for non-empty array", () => {
+      const errors = validateSingleField("tags", ["open-source"], {
+        required: true,
+      });
+      expect(errors.tags).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // email
+  // -------------------------------------------------------------------------
+  describe("email rule", () => {
+    it("reports error for invalid email", () => {
+      const errors = validateSingleField("email", "not-an-email", {
+        email: true,
+      });
+      expect(errors.email).toBe("Please enter a valid email address");
+    });
+
+    it("passes for valid email", () => {
+      const errors = validateSingleField("email", "user@nexasphere.dev", {
+        email: true,
+      });
+      expect(errors.email).toBeUndefined();
+    });
+
+    it("does not error for empty value when not required", () => {
+      const errors = validateSingleField("email", "", { email: true });
+      expect(errors.email).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // phone
+  // -------------------------------------------------------------------------
+  describe("phone rule", () => {
+    it("reports error for phone shorter than 10 digits", () => {
+      const errors = validateSingleField("phone", "12345", { phone: true });
+      expect(errors.phone).toBe("Phone number must be exactly 10 digits");
+    });
+
+    it("reports error for phone with non-digit characters", () => {
+      const errors = validateSingleField("phone", "9876-54321", {
+        phone: true,
+      });
+      expect(errors.phone).toBe("Phone number must be exactly 10 digits");
+    });
+
+    it("passes for exactly 10 digits", () => {
+      const errors = validateSingleField("phone", "9876543210", {
+        phone: true,
+      });
+      expect(errors.phone).toBeUndefined();
+    });
+
+    it("does not error for empty value when not required", () => {
+      const errors = validateSingleField("phone", "", { phone: true });
+      expect(errors.phone).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // minLength
+  // -------------------------------------------------------------------------
+  describe("minLength rule", () => {
+    it("reports error when value is shorter than minLength", () => {
+      const errors = validateSingleField("bio", "Hi", { minLength: 10 });
+      expect(errors.bio).toBe("Minimum length is 10 characters");
+    });
+
+    it("passes when value meets minLength", () => {
+      const errors = validateSingleField("bio", "Hello World", {
+        minLength: 10,
+      });
+      expect(errors.bio).toBeUndefined();
+    });
+
+    it("does not error for empty value when not required", () => {
+      // empty string skips the minLength guard (`if (strVal && ...)`)
+      const errors = validateSingleField("bio", "", { minLength: 5 });
+      expect(errors.bio).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // maxLength  (new rule — previously missing)
+  // -------------------------------------------------------------------------
+  describe("maxLength rule", () => {
+    it("reports error when value exceeds maxLength", () => {
+      const errors = validateSingleField("username", "a".repeat(21), {
+        maxLength: 20,
+      });
+      expect(errors.username).toBe("Maximum length is 20 characters");
+    });
+
+    it("passes when value is exactly maxLength", () => {
+      const errors = validateSingleField("username", "a".repeat(20), {
+        maxLength: 20,
+      });
+      expect(errors.username).toBeUndefined();
+    });
+
+    it("passes when value is shorter than maxLength", () => {
+      const errors = validateSingleField("username", "nexasphere", {
+        maxLength: 20,
+      });
+      expect(errors.username).toBeUndefined();
+    });
+
+    it("does not error for empty value when not required", () => {
+      const errors = validateSingleField("username", "", { maxLength: 20 });
+      expect(errors.username).toBeUndefined();
+    });
+
+    it("accepts a custom maxLengthMessage", () => {
+      const errors = validateSingleField("username", "a".repeat(21), {
+        maxLength: 20,
+        maxLengthMessage: "Username cannot exceed 20 characters",
+      });
+      expect(errors.username).toBe("Username cannot exceed 20 characters");
+    });
+
+    it("works together with minLength on the same field", () => {
+      const rules = { minLength: 3, maxLength: 10 };
+
+      const tooShort = validateSingleField("username", "ab", rules);
+      expect(tooShort.username).toBe("Minimum length is 3 characters");
+
+      const tooLong = validateSingleField("username", "a".repeat(11), rules);
+      expect(tooLong.username).toBe("Maximum length is 10 characters");
+
+      const justRight = validateSingleField("username", "nexasphere", rules);
+      expect(justRight.username).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // url  (new rule — previously missing)
+  // -------------------------------------------------------------------------
+  describe("url rule", () => {
+    it("reports error for a plain string without a protocol", () => {
+      const errors = validateSingleField("website", "example.com", {
+        url: true,
+      });
+      expect(errors.website).toBe(
+        "Please enter a valid URL (e.g. https://example.com)"
+      );
+    });
+
+    it("reports error for a completely malformed URL", () => {
+      const errors = validateSingleField("website", "not a url!!", {
+        url: true,
+      });
+      expect(errors.website).toBe(
+        "Please enter a valid URL (e.g. https://example.com)"
+      );
+    });
+
+    it("passes for a valid https URL", () => {
+      const errors = validateSingleField("website", "https://nexasphere.dev", {
+        url: true,
+      });
+      expect(errors.website).toBeUndefined();
+    });
+
+    it("passes for a valid http URL", () => {
+      const errors = validateSingleField(
+        "website",
+        "http://nexasphere.dev/path?q=1",
+        { url: true }
+      );
+      expect(errors.website).toBeUndefined();
+    });
+
+    it("does not error for empty value when not required", () => {
+      const errors = validateSingleField("website", "", { url: true });
+      expect(errors.website).toBeUndefined();
+    });
+
+    it("accepts a custom urlMessage", () => {
+      const errors = validateSingleField("website", "bad", {
+        url: true,
+        urlMessage: "Enter a full URL including https://",
+      });
+      expect(errors.website).toBe("Enter a full URL including https://");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // custom
+  // -------------------------------------------------------------------------
+  describe("custom rule", () => {
+    it("reports the error returned by the custom function", () => {
+      const errors = validateSingleField("password", "abc", {
+        custom: (v: string) => (v.length < 8 ? "Too weak" : ""),
+      });
+      expect(errors.password).toBe("Too weak");
+    });
+
+    it("passes when the custom function returns empty string", () => {
+      const errors = validateSingleField("password", "str0ngPass!", {
+        custom: (v: string) => (v.length < 8 ? "Too weak" : ""),
+      });
+      expect(errors.password).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // handleChange / live re-validation
+  // -------------------------------------------------------------------------
+  describe("handleChange live re-validation", () => {
+    it("clears the error once the user fixes the value", () => {
+      const { result } = renderHook(() =>
+        useFormValidation(
+          { username: "" },
+          { username: { required: true, maxLength: 10 } }
+        )
+      );
+
+      // Touch the field so re-validation is active
+      act(() => {
+        result.current.validateForm(["username"]);
+      });
+      expect(result.current.errors.username).toBe("This field is required");
+
+      // User types a valid value
+      act(() => {
+        result.current.handleChange("username", "Nexasphere");
+      });
+      expect(result.current.errors.username).toBeUndefined();
+    });
+
+    it("shows maxLength error as soon as the user exceeds the limit", () => {
+      const { result } = renderHook(() =>
+        useFormValidation(
+          { username: "valid" },
+          { username: { maxLength: 10 } }
+        )
+      );
+
+      // Touch first
+      act(() => {
+        result.current.handleBlur("username");
+      });
+
+      act(() => {
+        result.current.handleChange("username", "a".repeat(11));
+      });
+      expect(result.current.errors.username).toBe(
+        "Maximum length is 10 characters"
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // resetForm
+  // -------------------------------------------------------------------------
+  describe("resetForm", () => {
+    it("clears values, errors, and touched state", () => {
+      const { result } = renderHook(() =>
+        useFormValidation({ name: "" }, { name: { required: true } })
+      );
+
+      act(() => {
+        result.current.validateForm();
+      });
+      expect(result.current.errors.name).toBeDefined();
+
+      act(() => {
+        result.current.resetForm();
+      });
+      expect(result.current.errors).toEqual({});
+      expect(result.current.touched).toEqual({});
+      expect(result.current.values).toEqual({ name: "" });
+    });
+  });
+});

--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -1,12 +1,15 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback, useMemo } from "react";
 
 /**
  * Reusable React Hook for multi-step form validation, state management, and accessible error handling.
- * 
+ *
  * @param {Object} initialValues - The initial fields and values of the form.
  * @param {Object} validationRules - Map of field names to their validation constraints.
  */
-export default function useFormValidation(initialValues = {}, validationRules = {}) {
+export default function useFormValidation(
+  initialValues = {},
+  validationRules = {}
+) {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState({});
   const [touched, setTouched] = useState({});
@@ -14,147 +17,184 @@ export default function useFormValidation(initialValues = {}, validationRules = 
   /**
    * Helper function to validate a single field value against its constraints.
    */
-  const validateField = useCallback((name, value, rules = {}) => {
-    let error = '';
+  const validateField = useCallback(
+    (name, value, rules = {}) => {
+      let error = "";
 
-    if (rules.required) {
-      if (Array.isArray(value)) {
-        if (value.length === 0) {
-          error = rules.requiredMessage || 'This field is required';
-        }
-      } else if (typeof value === 'object' && value !== null) {
-        // e.g. declarations object: all values must be true (or custom behavior)
-        const allChecked = Object.values(value).every(v => !!v);
-        if (!allChecked) {
-          error = rules.requiredMessage || 'Please agree to all declarations';
-        }
-      } else if (!String(value || '').trim()) {
-        error = rules.requiredMessage || 'This field is required';
-      }
-    }
-
-    if (!error && rules.email) {
-      const emailStr = String(value || '').trim();
-      if (emailStr) {
-        if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailStr)) {
-          error = rules.emailMessage || 'Please enter a valid email address';
+      if (rules.required) {
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            error = rules.requiredMessage || "This field is required";
+          }
+        } else if (typeof value === "object" && value !== null) {
+          // e.g. declarations object: all values must be true (or custom behavior)
+          const allChecked = Object.values(value).every((v) => !!v);
+          if (!allChecked) {
+            error = rules.requiredMessage || "Please agree to all declarations";
+          }
+        } else if (!String(value || "").trim()) {
+          error = rules.requiredMessage || "This field is required";
         }
       }
-    }
 
-    if (!error && rules.phone) {
-      const phoneStr = String(value || '').trim();
-      if (phoneStr && !/^\d{10}$/.test(phoneStr)) {
-        error = rules.phoneMessage || 'Phone number must be exactly 10 digits';
+      if (!error && rules.email) {
+        const emailStr = String(value || "").trim();
+        if (emailStr) {
+          if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(emailStr)) {
+            error = rules.emailMessage || "Please enter a valid email address";
+          }
+        }
       }
-    }
 
-    if (!error && rules.minLength) {
-      const strVal = String(value || '');
-      if (strVal && strVal.length < rules.minLength) {
-        error = rules.minLengthMessage || `Minimum length is ${rules.minLength} characters`;
+      if (!error && rules.phone) {
+        const phoneStr = String(value || "").trim();
+        if (phoneStr && !/^\d{10}$/.test(phoneStr)) {
+          error =
+            rules.phoneMessage || "Phone number must be exactly 10 digits";
+        }
       }
-    }
 
-    if (!error && rules.custom) {
-      error = rules.custom(value, values) || '';
-    }
+      if (!error && rules.minLength) {
+        const strVal = String(value || "");
+        if (strVal && strVal.length < rules.minLength) {
+          error =
+            rules.minLengthMessage ||
+            `Minimum length is ${rules.minLength} characters`;
+        }
+      }
 
-    return error;
-  }, [values]);
+      if (!error && rules.maxLength) {
+        const strVal = String(value || "");
+        if (strVal && strVal.length > rules.maxLength) {
+          error =
+            rules.maxLengthMessage ||
+            `Maximum length is ${rules.maxLength} characters`;
+        }
+      }
+
+      if (!error && rules.url) {
+        const urlStr = String(value || "").trim();
+        if (urlStr) {
+          try {
+            new URL(urlStr);
+          } catch {
+            error =
+              rules.urlMessage ||
+              "Please enter a valid URL (e.g. https://example.com)";
+          }
+        }
+      }
+
+      if (!error && rules.custom) {
+        error = rules.custom(value, values) || "";
+      }
+
+      return error;
+    },
+    [values]
+  );
 
   /**
    * Universal change handler that updates the value and validates the field dynamically.
    */
-  const handleChange = useCallback((name, value) => {
-    setValues(prev => {
-      const nextValues = { ...prev, [name]: value };
+  const handleChange = useCallback(
+    (name, value) => {
+      setValues((prev) => {
+        const nextValues = { ...prev, [name]: value };
 
-      // Re-validate field on the fly if it has already been touched or had an error
-      if (touched[name] || errors[name]) {
-        const rules = validationRules[name];
-        if (rules) {
-          // Note: we pass the updated nextValues to validateField so co-dependent rules have fresh state
-          const error = validateField(name, value, rules);
-          setErrors(prevErrors => {
-            const nextErrors = { ...prevErrors };
-            if (error) {
-              nextErrors[name] = error;
-            } else {
-              delete nextErrors[name];
-            }
-            return nextErrors;
-          });
+        // Re-validate field on the fly if it has already been touched or had an error
+        if (touched[name] || errors[name]) {
+          const rules = validationRules[name];
+          if (rules) {
+            // Note: we pass the updated nextValues to validateField so co-dependent rules have fresh state
+            const error = validateField(name, value, rules);
+            setErrors((prevErrors) => {
+              const nextErrors = { ...prevErrors };
+              if (error) {
+                nextErrors[name] = error;
+              } else {
+                delete nextErrors[name];
+              }
+              return nextErrors;
+            });
+          }
         }
-      }
 
-      return nextValues;
-    });
-  }, [validationRules, validateField, touched, errors]);
+        return nextValues;
+      });
+    },
+    [validationRules, validateField, touched, errors]
+  );
 
   /**
    * Universal blur handler that marks a field as touched and validates it.
    */
-  const handleBlur = useCallback((name) => {
-    setTouched(prev => {
-      if (prev[name]) return prev;
-      return { ...prev, [name]: true };
-    });
-
-    const rules = validationRules[name];
-    if (rules) {
-      const val = values[name];
-      const error = validateField(name, val, rules);
-      setErrors(prev => {
-        const next = { ...prev };
-        if (error) {
-          next[name] = error;
-        } else {
-          delete next[name];
-        }
-        return next;
+  const handleBlur = useCallback(
+    (name) => {
+      setTouched((prev) => {
+        if (prev[name]) return prev;
+        return { ...prev, [name]: true };
       });
-    }
-  }, [values, validationRules, validateField]);
 
-  /**
-   * Run validation on a specific set of fields (for multi-step) or the entire form.
-   * 
-   * @param {Array|null} fieldsToValidate - Specific fields to check. If null, validates all.
-   * @returns {boolean} Whether the fields/form are valid.
-   */
-  const validateForm = useCallback((fieldsToValidate = null) => {
-    const targets = fieldsToValidate || Object.keys(validationRules);
-    const newErrors = {};
-    const newTouched = {};
-
-    targets.forEach(name => {
-      newTouched[name] = true;
       const rules = validationRules[name];
       if (rules) {
         const val = values[name];
         const error = validateField(name, val, rules);
-        if (error) {
-          newErrors[name] = error;
-        }
+        setErrors((prev) => {
+          const next = { ...prev };
+          if (error) {
+            next[name] = error;
+          } else {
+            delete next[name];
+          }
+          return next;
+        });
       }
-    });
+    },
+    [values, validationRules, validateField]
+  );
 
-    setTouched(prev => ({ ...prev, ...newTouched }));
-    setErrors(prev => {
-      const next = fieldsToValidate ? { ...prev } : {};
-      targets.forEach(name => {
-        if (newErrors[name]) {
-          next[name] = newErrors[name];
-        } else {
-          delete next[name];
+  /**
+   * Run validation on a specific set of fields (for multi-step) or the entire form.
+   *
+   * @param {Array|null} fieldsToValidate - Specific fields to check. If null, validates all.
+   * @returns {boolean} Whether the fields/form are valid.
+   */
+  const validateForm = useCallback(
+    (fieldsToValidate = null) => {
+      const targets = fieldsToValidate || Object.keys(validationRules);
+      const newErrors = {};
+      const newTouched = {};
+
+      targets.forEach((name) => {
+        newTouched[name] = true;
+        const rules = validationRules[name];
+        if (rules) {
+          const val = values[name];
+          const error = validateField(name, val, rules);
+          if (error) {
+            newErrors[name] = error;
+          }
         }
       });
-      return next;
-    });
 
-    return Object.keys(newErrors).length === 0;
-  }, [values, validationRules, validateField]);
+      setTouched((prev) => ({ ...prev, ...newTouched }));
+      setErrors((prev) => {
+        const next = fieldsToValidate ? { ...prev } : {};
+        targets.forEach((name) => {
+          if (newErrors[name]) {
+            next[name] = newErrors[name];
+          } else {
+            delete next[name];
+          }
+        });
+        return next;
+      });
+
+      return Object.keys(newErrors).length === 0;
+    },
+    [values, validationRules, validateField]
+  );
 
   /**
    * Reset form values and clear error/touched tracking states.


### PR DESCRIPTION
## What does this PR do?

Adds two missing validation rules to `src/hooks/useFormValidation.js` and introduces the first unit test suite for the hook with 33 tests.

## Why is this change needed?

The hook supported `minLength` but completely ignored `maxLength` — any field configured with `{ maxLength: N }` had its constraint silently skipped with no error returned. There was also no `url` rule, forcing every URL field to reimplement the same logic via `custom`. The hook had zero unit tests, so this gap went undetected.

## What changes were made?

- **`src/hooks/useFormValidation.js`**: Added `maxLength` guard block mirroring `minLength`. Added `url` guard using the native `URL` constructor. Both support custom message overrides (`maxLengthMessage`, `urlMessage`) consistent with the existing API pattern.
- **`src/__tests__/useFormValidation.test.ts`** *(new)*: 33 unit tests covering `required`, `email`, `phone`, `minLength`, `maxLength` (new), `url` (new), `custom`, live re-validation via `handleChange`, and `resetForm`.

## How to test

```bash
.\node_modules\.bin\vitest.cmd run src/__tests__/useFormValidation.test.ts --reporter=verbose
# Expected: 33 passed (33)
```

## Checklist

* [x] Code follows project style
* [x] Tested locally (33/33 tests pass)
* [x] No breaking changes
* [x] Prettier + ESLint passed via lint-staged on commit

Closes #460 
