### PR TITLE
fix: correct operator precedence in LTTB data decimation

### DIFF
--- a/src/utils/dataDecimation.ts
+++ b/src/utils/dataDecimation.ts
@@ -27,8 +27,8 @@ export function decimateData<T>(
 
   let a = 0; // Initially a is the first point in the triangle
   let maxAreaPoint = {} as T;
-  let maxArea = 0;
-  let area = 0;
+  let maxArea;
+  let area;
   let nextA = 0;
 
   sampled[sampledIndex++] = data[a]; // Always add the first point
@@ -59,13 +59,13 @@ export function decimateData<T>(
     const pointAX = Number(data[a][xKey]) || 0;
     const pointAY = Number(data[a][yKey]) || 0;
 
-    maxArea = area = -1;
+    maxArea = -1;
 
     for (; rangeOffs < rangeTo; rangeOffs++) {
       // Calculate triangle area over three buckets
       area =
         Math.abs(
-          (pointAX - avgX) * (Number(data[rangeOffs][yKey]) || 0 - pointAY) -
+          (pointAX - avgX) * ((Number(data[rangeOffs][yKey]) || 0) - pointAY) -
             (pointAX - (Number(data[rangeOffs][xKey]) || 0)) * (avgY - pointAY)
         ) * 0.5;
       if (area > maxArea) {
@@ -79,13 +79,13 @@ export function decimateData<T>(
     a = nextA; // This a is the next a (chosen b)
   }
 
-  sampled[sampledIndex++] = data[dataLength - 1]; // Always add last
+  sampled[sampledIndex] = data[dataLength - 1]; // Always add last
 
   return sampled;
 }
 
 /**
- * A simpler linear decimation to quickly reduce large datasets 
+ * A simpler linear decimation to quickly reduce large datasets
  * where LTTB might be too heavy or axes aren't strictly numeric.
  */
 export function linearDecimate<T>(data: T[], threshold: number): T[] {


### PR DESCRIPTION
## What does this PR do?

Fixes an operator precedence bug in the Largest-Triangle-Three-Buckets (LTTB) algorithm used for chart downsampling in `src/utils/dataDecimation.ts`. It also cleans up a few useless assignments to pass ESLint checks.

## Why is this change needed?

In `decimateData`, the triangle area calculation fallback for missing/zero y-values was missing parentheses:
```ts
(pointAX - avgX) * (Number(data[rangeOffs][yKey]) || 0 - pointAY)
```
Because `-` has higher precedence than `||`, a data point with a y-value of exactly `0` would bypass the `|| 0` fallback entirely and subtract `pointAY` instead. This incorrectly calculated the triangle area, causing visually less significant data points to be selected and degrading the accuracy of the downsampled chart.

## What changes were made?

- **`src/utils/dataDecimation.ts`**: Wrapped the fallback logic `Number(data[rangeOffs][yKey]) || 0` in parentheses on line 68. Removed useless initializations and assignments for variables like `area`, `maxArea`, and `sampledIndex` that were caught by ESLint `no-useless-assignment`.

## How to test

1. Review `src/utils/dataDecimation.ts`
2. Verify the area calculation logic accurately reflects the LTTB algorithm and operator precedence is correct.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes
* [x] Prettier + ESLint passed via lint-staged on commit

Closes #463
```