### PR TITLE
fix: declare missing isMounted variable in useSocket hook

### DIFF
--- a/src/hooks/useSocket.js
+++ b/src/hooks/useSocket.js
@@ -3,15 +3,17 @@
  * Provides reactive access to Socket.IO connections, room subscriptions, and event emitters
  */
 
-import { useEffect, useState, useCallback } from 'react';
-import socketClient from '../utils/socketClient';
-import { getSocketServerUrl } from '../utils/runtimeConfig';
+import { useEffect, useState, useCallback } from "react";
+import socketClient from "../utils/socketClient";
+import { getSocketServerUrl } from "../utils/runtimeConfig";
 
 export function useSocket(serverUrl) {
   const [connected, setConnected] = useState(false);
   const [socketId, setSocketId] = useState(null);
 
   useEffect(() => {
+    let isMounted = true;
+
     // Initialize socket connection if not already done
     const base = serverUrl || getSocketServerUrl();
     const socket = socketClient.initializeSocket(base);
@@ -34,8 +36,8 @@ export function useSocket(serverUrl) {
     };
 
     // Listen to standard connection events using socket directly
-    socket.on('connect', onConnect);
-    socket.on('disconnect', onDisconnect);
+    socket.on("connect", onConnect);
+    socket.on("disconnect", onDisconnect);
 
     // Sync initial state
     setConnected(socket.connected || false);
@@ -43,11 +45,10 @@ export function useSocket(serverUrl) {
 
     return () => {
       isMounted = false;
-      socket.off('connect', onConnect);
-      socket.off('disconnect', onDisconnect);
+      socket.off("connect", onConnect);
+      socket.off("disconnect", onDisconnect);
     };
   }, [serverUrl]);
-
 
   /**
    * Identify authenticated user to the WebSocket room
@@ -86,7 +87,6 @@ export function useSocket(serverUrl) {
   const off = useCallback((eventName, handler) => {
     socketClient.off(eventName, handler);
   }, []);
-
 
   /**
    * Emit event to the socket server


### PR DESCRIPTION
## What does this PR do?

Fixes a silent `ReferenceError` in `src/hooks/useSocket.js` where the `isMounted` variable was used inside event handlers but never declared in the closure.

## Why is this change needed?

When the `useSocket` hook initialized a connection, it attached `onConnect` and `onDisconnect` handlers that checked `if (!isMounted) return;`. However, because `isMounted` was never declared with `let isMounted = true;`, these handlers threw `ReferenceError: isMounted is not defined` internally whenever the socket connected or disconnected. 

Socket.IO silently swallows these errors, but it caused the React state updates (`setConnected` and `setSocketId`) to never execute. As a result, the hook was permanently stuck reporting `connected: false` and `socketId: null` even when the connection was active.

## What changes were made?

- **`src/hooks/useSocket.js`**: Added `let isMounted = true;` at the beginning of the `useEffect` body to correctly initialize the closure variable, mirroring the pattern already used correctly in `src/hooks/useNotifications.js`.

## How to test

1. Open a component that uses the `useSocket` hook
2. Check the browser console during the initial load — no `ReferenceError` should be thrown
3. The hook should now correctly return `connected: true` and the real `socketId` once connected

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes
* [x] Prettier + ESLint passed via lint-staged on commit

Closes #464 