### PR TITLE
feat: Add Prompt Export Button to Chatbot UI and Fix exportPrompts Cross-Browser Bugs

### DIFF
--- a/src/lib/promptStore.js
+++ b/src/lib/promptStore.js
@@ -3,10 +3,10 @@
  * Handles: save, load, search, delete, and workspace organization of prompts
  */
 
-import logger from './logger';
+import logger from "./logger";
 
-const DB_NAME = 'NexaSphereDB';
-const STORE_NAME = 'prompts';
+const DB_NAME = "NexaSphereDB";
+const STORE_NAME = "prompts";
 const DB_VERSION = 1;
 
 let db = null;
@@ -31,12 +31,15 @@ export const initializeDB = async () => {
 
     request.onupgradeneeded = (event) => {
       const database = event.target.result;
-      
+
       if (!database.objectStoreNames.contains(STORE_NAME)) {
-        const store = database.createObjectStore(STORE_NAME, { keyPath: 'id', autoIncrement: true });
-        store.createIndex('timestamp', 'timestamp', { unique: false });
-        store.createIndex('workspace', 'workspace', { unique: false });
-        store.createIndex('pinned', 'pinned', { unique: false });
+        const store = database.createObjectStore(STORE_NAME, {
+          keyPath: "id",
+          autoIncrement: true,
+        });
+        store.createIndex("timestamp", "timestamp", { unique: false });
+        store.createIndex("workspace", "workspace", { unique: false });
+        store.createIndex("pinned", "pinned", { unique: false });
       }
     };
   });
@@ -45,10 +48,10 @@ export const initializeDB = async () => {
 /**
  * Save a prompt-response pair to storage
  */
-export const savePrompt = async (prompt, response, workspace = 'default') => {
+export const savePrompt = async (prompt, response, workspace = "default") => {
   try {
     const database = await initializeDB();
-    
+
     const promptEntry = {
       userPrompt: prompt,
       botResponse: response,
@@ -59,7 +62,7 @@ export const savePrompt = async (prompt, response, workspace = 'default') => {
     };
 
     return new Promise((resolve, reject) => {
-      const transaction = database.transaction([STORE_NAME], 'readwrite');
+      const transaction = database.transaction([STORE_NAME], "readwrite");
       const store = transaction.objectStore(STORE_NAME);
       const request = store.add(promptEntry);
 
@@ -67,7 +70,7 @@ export const savePrompt = async (prompt, response, workspace = 'default') => {
       request.onsuccess = () => resolve(request.result);
     });
   } catch (error) {
-    logger.error('Error saving prompt to IndexedDB:', error);
+    logger.error("Error saving prompt to IndexedDB:", error);
     // Fallback to localStorage
     savePromptToLocalStorage(prompt, response, workspace);
   }
@@ -81,12 +84,12 @@ export const getAllPrompts = async (workspace = null) => {
     const database = await initializeDB();
 
     return new Promise((resolve, reject) => {
-      const transaction = database.transaction([STORE_NAME], 'readonly');
+      const transaction = database.transaction([STORE_NAME], "readonly");
       const store = transaction.objectStore(STORE_NAME);
-      
+
       let request;
       if (workspace) {
-        const index = store.index('workspace');
+        const index = store.index("workspace");
         request = index.getAll(workspace);
       } else {
         request = store.getAll();
@@ -94,12 +97,14 @@ export const getAllPrompts = async (workspace = null) => {
 
       request.onerror = () => reject(request.error);
       request.onsuccess = () => {
-        const results = request.result.sort((a, b) => b.timestamp - a.timestamp);
+        const results = request.result.sort(
+          (a, b) => b.timestamp - a.timestamp
+        );
         resolve(results);
       };
     });
   } catch (error) {
-    logger.error('Error retrieving prompts from IndexedDB:', error);
+    logger.error("Error retrieving prompts from IndexedDB:", error);
     return getPromptsFromLocalStorage(workspace);
   }
 };
@@ -118,7 +123,7 @@ export const searchPrompts = async (keyword, workspace = null) => {
         p.botResponse.toLowerCase().includes(lowerKeyword)
     );
   } catch (error) {
-    logger.error('Error searching prompts:', error);
+    logger.error("Error searching prompts:", error);
     return [];
   }
 };
@@ -131,9 +136,9 @@ export const getPinnedPrompts = async (workspace = null) => {
     const database = await initializeDB();
 
     return new Promise((resolve, reject) => {
-      const transaction = database.transaction([STORE_NAME], 'readonly');
+      const transaction = database.transaction([STORE_NAME], "readonly");
       const store = transaction.objectStore(STORE_NAME);
-      const index = store.index('pinned');
+      const index = store.index("pinned");
       const request = index.getAll(true);
 
       request.onerror = () => reject(request.error);
@@ -146,7 +151,7 @@ export const getPinnedPrompts = async (workspace = null) => {
       };
     });
   } catch (error) {
-    logger.error('Error retrieving pinned prompts:', error);
+    logger.error("Error retrieving pinned prompts:", error);
     return [];
   }
 };
@@ -159,7 +164,7 @@ export const togglePinPrompt = async (id, pinned) => {
     const database = await initializeDB();
 
     return new Promise((resolve, reject) => {
-      const transaction = database.transaction([STORE_NAME], 'readwrite');
+      const transaction = database.transaction([STORE_NAME], "readwrite");
       const store = transaction.objectStore(STORE_NAME);
       const getRequest = store.get(id);
 
@@ -177,7 +182,7 @@ export const togglePinPrompt = async (id, pinned) => {
       getRequest.onerror = () => reject(getRequest.error);
     });
   } catch (error) {
-    logger.error('Error toggling pin status:', error);
+    logger.error("Error toggling pin status:", error);
   }
 };
 
@@ -189,7 +194,7 @@ export const deletePrompt = async (id) => {
     const database = await initializeDB();
 
     return new Promise((resolve, reject) => {
-      const transaction = database.transaction([STORE_NAME], 'readwrite');
+      const transaction = database.transaction([STORE_NAME], "readwrite");
       const store = transaction.objectStore(STORE_NAME);
       const request = store.delete(id);
 
@@ -197,14 +202,14 @@ export const deletePrompt = async (id) => {
       request.onsuccess = () => resolve(true);
     });
   } catch (error) {
-    logger.error('Error deleting prompt:', error);
+    logger.error("Error deleting prompt:", error);
   }
 };
 
 /**
  * Clear all prompts in a workspace
  */
-export const clearWorkspace = async (workspace = 'default') => {
+export const clearWorkspace = async (workspace = "default") => {
   try {
     const database = await initializeDB();
     const allPrompts = await getAllPrompts(workspace);
@@ -214,7 +219,7 @@ export const clearWorkspace = async (workspace = 'default') => {
     }
     return true;
   } catch (error) {
-    logger.error('Error clearing workspace:', error);
+    logger.error("Error clearing workspace:", error);
   }
 };
 
@@ -226,18 +231,18 @@ export const getRecentPrompts = async (limit = 10, workspace = null) => {
     const allPrompts = await getAllPrompts(workspace);
     return allPrompts.slice(0, limit);
   } catch (error) {
-    logger.error('Error retrieving recent prompts:', error);
+    logger.error("Error retrieving recent prompts:", error);
     return [];
   }
 };
 
 // ===== FALLBACK: LocalStorage Functions =====
 
-const LOCALSTORAGE_KEY = 'nexasphere_prompts';
+const LOCALSTORAGE_KEY = "nexasphere_prompts";
 
-const savePromptToLocalStorage = (prompt, response, workspace = 'default') => {
+const savePromptToLocalStorage = (prompt, response, workspace = "default") => {
   try {
-    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || "[]");
     stored.push({
       id: Date.now(),
       userPrompt: prompt,
@@ -248,19 +253,19 @@ const savePromptToLocalStorage = (prompt, response, workspace = 'default') => {
     });
     localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(stored));
   } catch (error) {
-    logger.error('Error saving to localStorage:', error);
+    logger.error("Error saving to localStorage:", error);
   }
 };
 
 const getPromptsFromLocalStorage = (workspace = null) => {
   try {
-    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || "[]");
     if (workspace) {
       return stored.filter((p) => p.workspace === workspace);
     }
     return stored.sort((a, b) => b.timestamp - a.timestamp);
   } catch (error) {
-    logger.error('Error retrieving from localStorage:', error);
+    logger.error("Error retrieving from localStorage:", error);
     return [];
   }
 };
@@ -268,13 +273,15 @@ const getPromptsFromLocalStorage = (workspace = null) => {
 export const exportPrompts = async (workspace = null) => {
   const prompts = await getAllPrompts(workspace);
   const dataStr = JSON.stringify(prompts, null, 2);
-  const dataBlob = new Blob([dataStr], { type: 'application/json' });
+  const dataBlob = new Blob([dataStr], { type: "application/json" });
   const url = URL.createObjectURL(dataBlob);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
   link.download = `nexasphere-prompts-${Date.now()}.json`;
+  document.body.appendChild(link);
   link.click();
-  URL.revokeObjectURL(url);
+  document.body.removeChild(link);
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 };
 
 export const importPrompts = async (file) => {
@@ -284,7 +291,11 @@ export const importPrompts = async (file) => {
       try {
         const prompts = JSON.parse(e.target.result);
         for (const prompt of prompts) {
-          await savePrompt(prompt.userPrompt, prompt.botResponse, prompt.workspace);
+          await savePrompt(
+            prompt.userPrompt,
+            prompt.botResponse,
+            prompt.workspace
+          );
         }
         resolve(prompts.length);
       } catch (error) {

--- a/src/shared/Chatbot.jsx
+++ b/src/shared/Chatbot.jsx
@@ -1,21 +1,24 @@
-import React, { useState, useRef, useEffect } from 'react';
-import '../styles/chatbot.css';
-import PromptHistorySidebar from '../components/history/PromptHistorySidebar';
-import SearchBar from '../components/history/SearchBar';
-import PinnedChats from '../components/history/PinnedChats';
-import { savePrompt } from '../lib/promptStore';
-import { initializeWorkspaces } from '../lib/workspaceService';
-import { buildUrl, getAiApiBase } from '../utils/runtimeConfig';
+import React, { useState, useRef, useEffect } from "react";
+import "../styles/chatbot.css";
+import PromptHistorySidebar from "../components/history/PromptHistorySidebar";
+import SearchBar from "../components/history/SearchBar";
+import PinnedChats from "../components/history/PinnedChats";
+import { savePrompt, exportPrompts } from "../lib/promptStore";
+import { initializeWorkspaces } from "../lib/workspaceService";
+import { buildUrl, getAiApiBase } from "../utils/runtimeConfig";
 
 const Chatbot = () => {
   const [isOpen, setIsOpen] = useState(false);
-  const [input, setInput] = useState('');
+  const [input, setInput] = useState("");
   const [isSending, setIsSending] = useState(false);
   const [messages, setMessages] = useState([
-    { role: 'bot', text: 'Nexa-Intelligence Online. How can I assist your journey?' }
+    {
+      role: "bot",
+      text: "Nexa-Intelligence Online. How can I assist your journey?",
+    },
   ]);
   const [showSidebar, setShowSidebar] = useState(false);
-  const [currentWorkspace, setCurrentWorkspace] = useState('default');
+  const [currentWorkspace, setCurrentWorkspace] = useState("default");
   const scrollRef = useRef(null);
 
   // Initialize workspaces on mount
@@ -33,8 +36,10 @@ const Chatbot = () => {
   // Auto-save last prompt-response pair when new bot message arrives
   useEffect(() => {
     if (messages.length >= 2) {
-      const lastBotMsg = [...messages].reverse().find((m) => m.role === 'bot');
-      const lastUserMsg = [...messages].reverse().find((m) => m.role === 'user');
+      const lastBotMsg = [...messages].reverse().find((m) => m.role === "bot");
+      const lastUserMsg = [...messages]
+        .reverse()
+        .find((m) => m.role === "user");
 
       if (lastBotMsg && lastUserMsg) {
         const lastBotIndex = messages.indexOf(lastBotMsg);
@@ -42,9 +47,11 @@ const Chatbot = () => {
 
         // Only save if the bot message is more recent than the last saved one
         if (lastBotIndex > lastUserIndex) {
-          savePrompt(lastUserMsg.text, lastBotMsg.text, currentWorkspace).catch((err) => {
-            console.error('Error saving prompt:', err);
-          });
+          savePrompt(lastUserMsg.text, lastBotMsg.text, currentWorkspace).catch(
+            (err) => {
+              console.error("Error saving prompt:", err);
+            }
+          );
         }
       }
     }
@@ -52,18 +59,21 @@ const Chatbot = () => {
 
   const handleSend = async () => {
     if (!input.trim() || isSending) return;
-    const userMsg = { role: 'user', text: input };
-    setMessages(prev => [...prev, userMsg]);
+    const userMsg = { role: "user", text: input };
+    setMessages((prev) => [...prev, userMsg]);
     const currentInput = input;
-    setInput('');
+    setInput("");
     setIsSending(true);
 
-    const aiChatUrl = buildUrl(getAiApiBase(), '/ai/chat');
+    const aiChatUrl = buildUrl(getAiApiBase(), "/ai/chat");
 
     if (!aiChatUrl) {
-      setMessages(prev => [
+      setMessages((prev) => [
         ...prev,
-        { role: 'bot', text: 'Nexa-AI is offline right now. The AI service URL is not configured for this deployment.' }
+        {
+          role: "bot",
+          text: "Nexa-AI is offline right now. The AI service URL is not configured for this deployment.",
+        },
       ]);
       setIsSending(false);
       return;
@@ -73,27 +83,37 @@ const Chatbot = () => {
       const controller = new AbortController();
       const timeoutId = window.setTimeout(() => controller.abort(), 12000);
       const response = await fetch(aiChatUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message: currentInput }),
         signal: controller.signal,
       });
       window.clearTimeout(timeoutId);
 
       if (!response.ok) {
-        throw new Error(`AI chat request failed with status ${response.status}`);
+        throw new Error(
+          `AI chat request failed with status ${response.status}`
+        );
       }
 
       const data = await response.json();
-      setMessages(prev => [
+      setMessages((prev) => [
         ...prev,
-        { role: 'bot', text: data.reply || 'Nexa-AI received the request, but the reply came back empty. Please try again.' }
+        {
+          role: "bot",
+          text:
+            data.reply ||
+            "Nexa-AI received the request, but the reply came back empty. Please try again.",
+        },
       ]);
     } catch (e) {
-      console.error('AI chat request failed', e);
-      setMessages(prev => [
+      console.error("AI chat request failed", e);
+      setMessages((prev) => [
         ...prev,
-        { role: 'bot', text: 'Nexa-AI: Core link unavailable right now. Please try again in a moment.' }
+        {
+          role: "bot",
+          text: "Nexa-AI: Core link unavailable right now. Please try again in a moment.",
+        },
       ]);
     } finally {
       setIsSending(false);
@@ -102,9 +122,12 @@ const Chatbot = () => {
 
   const handleSelectPrompt = (prompt) => {
     setMessages([
-      { role: 'bot', text: 'Nexa-Intelligence Online. How can I assist your journey?' },
-      { role: 'user', text: prompt.userPrompt },
-      { role: 'bot', text: prompt.botResponse },
+      {
+        role: "bot",
+        text: "Nexa-Intelligence Online. How can I assist your journey?",
+      },
+      { role: "user", text: prompt.userPrompt },
+      { role: "bot", text: prompt.botResponse },
     ]);
     setShowSidebar(false);
   };
@@ -124,7 +147,7 @@ const Chatbot = () => {
             currentWorkspace={currentWorkspace}
           />
 
-          <div className={`chat-main ${showSidebar ? 'sidebar-open' : ''}`}>
+          <div className={`chat-main ${showSidebar ? "sidebar-open" : ""}`}>
             <div className="chat-header">
               <button
                 className="history-toggle-btn"
@@ -133,11 +156,20 @@ const Chatbot = () => {
               >
                 📋
               </button>
+              <button
+                className="export-btn"
+                onClick={() => exportPrompts(currentWorkspace)}
+                title="Export chat history"
+              >
+                ⬇
+              </button>
               <div className="header-status">
                 <span className="status-dot"></span>
                 <span>NEXA-AI</span>
               </div>
-              <button className="close-btn" onClick={() => setIsOpen(false)}>×</button>
+              <button className="close-btn" onClick={() => setIsOpen(false)}>
+                ×
+              </button>
             </div>
 
             <div className="chat-content">
@@ -173,12 +205,16 @@ const Chatbot = () => {
               <input
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => e.key === 'Enter' && handleSend()}
-                placeholder={isSending ? 'Transmitting...' : 'Query system...'}
+                onKeyDown={(e) => e.key === "Enter" && handleSend()}
+                placeholder={isSending ? "Transmitting..." : "Query system..."}
                 disabled={isSending}
               />
-              <button onClick={handleSend} className="send-btn" disabled={isSending}>
-                {isSending ? '...' : '🚀'}
+              <button
+                onClick={handleSend}
+                className="send-btn"
+                disabled={isSending}
+              >
+                {isSending ? "..." : "🚀"}
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
Closes #458

## Problem
`exportPrompts()` in `src/lib/promptStore.js` had two cross-browser bugs
and was never connected to any UI element.

**Bug 1:** `link` was never appended to DOM before `link.click()`
- Caused silent download failure in Firefox

**Bug 2:** `URL.revokeObjectURL()` called immediately after `link.click()`
- Revoked URL before download completed in Safari/Chrome

## Changes Made
- Fixed both bugs in `src/lib/promptStore.js`
- Added `exportPrompts` import to `src/shared/Chatbot.jsx`
- Wired export button (⬇) to Chatbot UI header

## Files Changed
- `src/lib/promptStore.js`
- `src/shared/Chatbot.jsx`

## Testing Note
Local dev server has a pre-existing unrelated PWA plugin
misconfiguration (`virtual:pwa-register` not resolved).
Changes are isolated and verified via code review.