### PR TITLE
fix: remove unintended Sentry.captureMessage call from addBreadcrumb

### DIFF
--- a/src/utils/errorTracking.js
+++ b/src/utils/errorTracking.js
@@ -97,7 +97,6 @@ export const setUserContext = (user) => {
  * @param {string} level - Level (info, warning, error)
  */
 export const addBreadcrumb = (message, category = "user-action", level = "info") => {
-  Sentry.captureMessage(message, level);
   Sentry.addBreadcrumb({
     message,
     category,


### PR DESCRIPTION
## Summary
Closes #472

## Problem
`addBreadcrumb()` in `src/utils/errorTracking.js` unintentionally
called `Sentry.captureMessage()` before adding the breadcrumb.

**Buggy code:**
```js
export const addBreadcrumb = (message, category, level) => {
  Sentry.captureMessage(message, level); // creates standalone Sentry event
  Sentry.addBreadcrumb({...});
};
```

## Fix
Removed the unintended `Sentry.captureMessage()` call.

**Fixed code:**
```js
export const addBreadcrumb = (message, category, level) => {
  Sentry.addBreadcrumb({...});
};
```

## Impact
- Prevents unintended Sentry events on every breadcrumb call
- Reduces unnecessary Sentry event generation
- Cleaner error monitoring data

## Files Changed
- `src/utils/errorTracking.js` 