### PR TITLE
fix: sanitize title and description in buildStandaloneSVG to prevent XSS

### DIFF
--- a/src/utils/exportRoadmap.ts
+++ b/src/utils/exportRoadmap.ts
@@ -1,16 +1,22 @@
-import { RoadmapNode } from '../context/RoadmapBuilderContext';
+import { RoadmapNode } from "../context/RoadmapBuilderContext";
 
 /**
  * Validates a parsed JSON object to ensure it strictly matches the Roadmap schema.
  * Throws a specific descriptive error if anything is malformed.
  */
-export const validateRoadmapJSON = (data: any): { title: string; description: string; nodes: RoadmapNode[] } => {
-  if (!data || typeof data !== 'object') {
-    throw new Error('Import failed: Data is not a valid JSON object.');
+export const validateRoadmapJSON = (
+  data: any
+): { title: string; description: string; nodes: RoadmapNode[] } => {
+  if (!data || typeof data !== "object") {
+    throw new Error("Import failed: Data is not a valid JSON object.");
   }
 
-  const title = typeof data.title === 'string' ? data.title : 'Imported Custom Path';
-  const description = typeof data.description === 'string' ? data.description : 'Custom imported path.';
+  const title =
+    typeof data.title === "string" ? data.title : "Imported Custom Path";
+  const description =
+    typeof data.description === "string"
+      ? data.description
+      : "Custom imported path.";
 
   if (!data.nodes || !Array.isArray(data.nodes)) {
     throw new Error('Import failed: The file must contain a "nodes" array.');
@@ -19,29 +25,44 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
   const validatedNodes: RoadmapNode[] = [];
 
   data.nodes.forEach((node: any, index: number) => {
-    if (!node.id || typeof node.id !== 'string') {
-      throw new Error(`Node validation failed at index ${index}: "id" is missing or is not a string.`);
+    if (!node.id || typeof node.id !== "string") {
+      throw new Error(
+        `Node validation failed at index ${index}: "id" is missing or is not a string.`
+      );
     }
-    if (!node.title || typeof node.title !== 'string') {
-      throw new Error(`Node validation failed (ID: ${node.id || index}): "title" is missing or is not a string.`);
+    if (!node.title || typeof node.title !== "string") {
+      throw new Error(
+        `Node validation failed (ID: ${node.id || index}): "title" is missing or is not a string.`
+      );
     }
-    if (typeof node.description !== 'string') {
-      node.description = '';
+    if (typeof node.description !== "string") {
+      node.description = "";
     }
-    if (typeof node.x !== 'number' || typeof node.y !== 'number') {
-      throw new Error(`Node validation failed (ID: ${node.id}): Coordinates "x" or "y" must be numbers.`);
+    if (typeof node.x !== "number" || typeof node.y !== "number") {
+      throw new Error(
+        `Node validation failed (ID: ${node.id}): Coordinates "x" or "y" must be numbers.`
+      );
     }
 
-    const validStatuses = ['Not Started', 'In Progress', 'Completed', 'Stuck'];
-    const status = validStatuses.includes(node.status) ? node.status : 'Not Started';
+    const validStatuses = ["Not Started", "In Progress", "Completed", "Stuck"];
+    const status = validStatuses.includes(node.status)
+      ? node.status
+      : "Not Started";
 
     if (node.resources && !Array.isArray(node.resources)) {
       node.resources = [];
     }
 
     const resources = (node.resources || []).map((r: any, rIdx: number) => {
-      if (!r.title || typeof r.title !== 'string' || !r.url || typeof r.url !== 'string') {
-        throw new Error(`Node "${node.title}" resource at index ${rIdx} is malformed. Resources need a "title" and a "url".`);
+      if (
+        !r.title ||
+        typeof r.title !== "string" ||
+        !r.url ||
+        typeof r.url !== "string"
+      ) {
+        throw new Error(
+          `Node "${node.title}" resource at index ${rIdx} is malformed. Resources need a "title" and a "url".`
+        );
       }
       return { title: r.title, url: r.url };
     });
@@ -50,7 +71,9 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
       node.prerequisites = [];
     }
 
-    const prerequisites = (node.prerequisites || []).filter((p: any) => typeof p === 'string');
+    const prerequisites = (node.prerequisites || []).filter(
+      (p: any) => typeof p === "string"
+    );
 
     validatedNodes.push({
       id: node.id,
@@ -59,9 +82,9 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
       x: node.x,
       y: node.y,
       status: status as any,
-      notes: typeof node.notes === 'string' ? node.notes : '',
+      notes: typeof node.notes === "string" ? node.notes : "",
       resources,
-      prerequisites
+      prerequisites,
     });
   });
 
@@ -70,7 +93,7 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
   const visited = new Set<string>();
   const adj = new Map<string, string[]>();
 
-  validatedNodes.forEach(node => adj.set(node.id, node.prerequisites));
+  validatedNodes.forEach((node) => adj.set(node.id, node.prerequisites));
 
   const hasCycle = (nodeId: string): boolean => {
     visiting.add(nodeId);
@@ -89,7 +112,9 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
   for (const node of validatedNodes) {
     if (!visited.has(node.id)) {
       if (hasCycle(node.id)) {
-        throw new Error('Validation failed: The imported roadmap contains circular prerequisite dependencies (loops).');
+        throw new Error(
+          "Validation failed: The imported roadmap contains circular prerequisite dependencies (loops)."
+        );
       }
     }
   }
@@ -100,13 +125,17 @@ export const validateRoadmapJSON = (data: any): { title: string; description: st
 /**
  * Exports the workspace state to a downloadable JSON file.
  */
-export const exportToJSON = (title: string, description: string, nodes: RoadmapNode[]) => {
+export const exportToJSON = (
+  title: string,
+  description: string,
+  nodes: RoadmapNode[]
+) => {
   const dataStr = JSON.stringify({ title, description, nodes }, null, 2);
-  const dataBlob = new Blob([dataStr], { type: 'application/json' });
+  const dataBlob = new Blob([dataStr], { type: "application/json" });
   const url = URL.createObjectURL(dataBlob);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
-  link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-roadmap.json`;
+  link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-roadmap.json`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -120,15 +149,21 @@ export const buildStandaloneSVG = (
   title: string,
   description: string,
   nodes: RoadmapNode[],
-  theme: 'dark' | 'light'
+  theme: "dark" | "light"
 ): string => {
   // 1. Calculate boundaries of the canvas
-  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  let minX = Infinity,
+    minY = Infinity,
+    maxX = -Infinity,
+    maxY = -Infinity;
 
   if (nodes.length === 0) {
-    minX = 100; minY = 100; maxX = 500; maxY = 300;
+    minX = 100;
+    minY = 100;
+    maxX = 500;
+    maxY = 300;
   } else {
-    nodes.forEach(n => {
+    nodes.forEach((n) => {
       if (n.x < minX) minX = n.x;
       if (n.y < minY) minY = n.y;
       if (n.x > maxX) maxX = n.x;
@@ -144,26 +179,31 @@ export const buildStandaloneSVG = (
   const width = maxX - minX;
   const height = maxY - minY;
 
-  const bgHex = theme === 'dark' ? '#0A0A0A' : '#FFFFFF';
-  const textHex = theme === 'dark' ? '#FFFFFF' : '#1A1A1A';
-  const descHex = theme === 'dark' ? '#B0B0B0' : '#4A4A4A';
-  const borderHex = theme === 'dark' ? 'rgba(230, 57, 70, 0.15)' : 'rgba(26, 26, 26, 0.08)';
+  const bgHex = theme === "dark" ? "#0A0A0A" : "#FFFFFF";
+  const textHex = theme === "dark" ? "#FFFFFF" : "#1A1A1A";
+  const descHex = theme === "dark" ? "#B0B0B0" : "#4A4A4A";
+  const borderHex =
+    theme === "dark" ? "rgba(230, 57, 70, 0.15)" : "rgba(26, 26, 26, 0.08)";
 
   // Style helper for nodes status
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'In Progress': return '#FFC107'; // amber
-      case 'Completed': return '#4CAF50'; // emerald
-      case 'Stuck': return '#E63946'; // ruby
-      default: return theme === 'dark' ? '#6B6B6B' : '#8A8A8A';
+      case "In Progress":
+        return "#FFC107"; // amber
+      case "Completed":
+        return "#4CAF50"; // emerald
+      case "Stuck":
+        return "#E63946"; // ruby
+      default:
+        return theme === "dark" ? "#6B6B6B" : "#8A8A8A";
     }
   };
 
   // Compile SVGs and Lines
-  let linePaths = '';
-  nodes.forEach(node => {
-    node.prerequisites.forEach(preId => {
-      const fromNode = nodes.find(n => n.id === preId);
+  let linePaths = "";
+  nodes.forEach((node) => {
+    node.prerequisites.forEach((preId) => {
+      const fromNode = nodes.find((n) => n.id === preId);
       if (fromNode) {
         // Center offsets
         const x1 = fromNode.x + 110 - minX;
@@ -180,16 +220,24 @@ export const buildStandaloneSVG = (
     });
   });
 
-  let nodeCards = '';
-  nodes.forEach(node => {
+  let nodeCards = "";
+  nodes.forEach((node) => {
     const rx = node.x - minX;
     const ry = node.y - minY;
     const statusColor = getStatusColor(node.status);
-    const cardBgHex = theme === 'dark' ? '#1E1E1E' : '#F9F9F9';
+    const cardBgHex = theme === "dark" ? "#1E1E1E" : "#F9F9F9";
 
     // Safe XML text
-    const safeTitle = node.title.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    const safeDesc = node.description.substring(0, 80).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') + (node.description.length > 80 ? '...' : '');
+    const safeTitle = node.title
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+    const safeDesc =
+      node.description
+        .substring(0, 80)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;") + (node.description.length > 80 ? "..." : "");
 
     nodeCards += `
       <g transform="translate(${rx}, ${ry})">
@@ -227,15 +275,15 @@ export const buildStandaloneSVG = (
       <!-- Subtle grid patterns -->
       <defs>
         <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-          <path d="M 40 0 L 0 0 0 40" fill="none" stroke="${theme === 'dark' ? 'rgba(230,57,70,0.03)' : 'rgba(0,0,0,0.02)'}" stroke-width="1" />
+          <path d="M 40 0 L 0 0 0 40" fill="none" stroke="${theme === "dark" ? "rgba(230,57,70,0.03)" : "rgba(0,0,0,0.02)"}" stroke-width="1" />
         </pattern>
       </defs>
       <rect width="100%" height="100%" fill="url(#grid)" />
       
       <!-- Title Block -->
       <g transform="translate(40, 50)">
-        <text x="0" y="0" font-family="'Orbitron', sans-serif" font-weight="900" font-size="24" fill="${textHex}">${title.replace(/&/g, '&amp;')}</text>
-        <text x="0" y="24" font-family="sans-serif" font-size="12" fill="${descHex}">${description.replace(/&/g, '&amp;')}</text>
+        <text x="0" y="0" font-family="'Orbitron', sans-serif" font-weight="900" font-size="24" fill="${textHex}">${title.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</text>
+        <text x="0" y="24" font-family="sans-serif" font-size="12" fill="${descHex}">${description.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;")}</text>
       </g>
       
       <!-- Graph content offset below title -->
@@ -255,13 +303,18 @@ export const buildStandaloneSVG = (
 /**
  * Triggers client-side browser download of vector SVG image.
  */
-export const downloadSVG = (title: string, description: string, nodes: RoadmapNode[], theme: 'dark' | 'light') => {
+export const downloadSVG = (
+  title: string,
+  description: string,
+  nodes: RoadmapNode[],
+  theme: "dark" | "light"
+) => {
   const svgStr = buildStandaloneSVG(title, description, nodes, theme);
-  const svgBlob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+  const svgBlob = new Blob([svgStr], { type: "image/svg+xml;charset=utf-8" });
   const url = URL.createObjectURL(svgBlob);
-  const link = document.createElement('a');
+  const link = document.createElement("a");
   link.href = url;
-  link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-canvas.svg`;
+  link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-canvas.svg`;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
@@ -271,31 +324,36 @@ export const downloadSVG = (title: string, description: string, nodes: RoadmapNo
 /**
  * Converts roadmap SVG to a rasterized PNG file and downloads it in the user's browser.
  */
-export const downloadPNG = (title: string, description: string, nodes: RoadmapNode[], theme: 'dark' | 'light') => {
+export const downloadPNG = (
+  title: string,
+  description: string,
+  nodes: RoadmapNode[],
+  theme: "dark" | "light"
+) => {
   const svgStr = buildStandaloneSVG(title, description, nodes, theme);
 
   // Parse width and height from the SVG
   const parser = new DOMParser();
-  const doc = parser.parseFromString(svgStr, 'image/svg+xml');
+  const doc = parser.parseFromString(svgStr, "image/svg+xml");
   const svgEl = doc.documentElement;
-  const width = parseFloat(svgEl.getAttribute('width') || '1200');
-  const height = parseFloat(svgEl.getAttribute('height') || '1000');
+  const width = parseFloat(svgEl.getAttribute("width") || "1200");
+  const height = parseFloat(svgEl.getAttribute("height") || "1000");
 
   // Convert SVG string to Data URL
-  const svgBlob = new Blob([svgStr], { type: 'image/svg+xml;charset=utf-8' });
+  const svgBlob = new Blob([svgStr], { type: "image/svg+xml;charset=utf-8" });
   const url = URL.createObjectURL(svgBlob);
 
   const image = new Image();
   image.onload = () => {
-    const canvas = document.createElement('canvas');
+    const canvas = document.createElement("canvas");
     // Set high-resolution output scaling
     canvas.width = width * 1.5;
     canvas.height = height * 1.5;
 
-    const ctx = canvas.getContext('2d');
+    const ctx = canvas.getContext("2d");
     if (ctx) {
       // Clear canvas
-      ctx.fillStyle = theme === 'dark' ? '#0A0A0A' : '#FFFFFF';
+      ctx.fillStyle = theme === "dark" ? "#0A0A0A" : "#FFFFFF";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
       // Render scaling
@@ -304,15 +362,15 @@ export const downloadPNG = (title: string, description: string, nodes: RoadmapNo
 
       // Export as Data URL
       try {
-        const pngUrl = canvas.toDataURL('image/png');
-        const link = document.createElement('a');
+        const pngUrl = canvas.toDataURL("image/png");
+        const link = document.createElement("a");
         link.href = pngUrl;
-        link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}-canvas.png`;
+        link.download = `${title.toLowerCase().replace(/[^a-z0-9]+/g, "-")}-canvas.png`;
         document.body.appendChild(link);
         link.click();
         document.body.removeChild(link);
       } catch (err) {
-        console.error('PNG canvas security or export error:', err);
+        console.error("PNG canvas security or export error:", err);
       }
     }
     URL.revokeObjectURL(url);


### PR DESCRIPTION
## What does this PR do?

Fixes a Stored/Reflected Cross-Site Scripting (XSS) vulnerability in `src/utils/exportRoadmap.ts` by properly sanitizing the roadmap `title` and `description` fields before embedding them into the downloaded SVG.

## Why is this change needed?

Previously, `buildStandaloneSVG` only escaped the ampersand (`&`) character for the main `title` and `description` fields, leaving them vulnerable to HTML/XML injection. Because SVGs can execute JavaScript when opened in a browser, a malicious user could craft a roadmap with a `<script>` payload in the title. Exporting and opening that SVG would immediately execute the arbitrary JavaScript.

## What changes were made?

- **`src/utils/exportRoadmap.ts`**: Added HTML entity encoding for `<` and `>` (`.replace(/</g, '&lt;').replace(/>/g, '&gt;')`) to the main `title` and `description` fields inside the `buildStandaloneSVG` template, mirroring the existing robust sanitization used for individual node fields (`safeTitle` and `safeDesc`).

## How to test

1. Create a roadmap and set the title to `</text><script>alert('XSS')</script><text>`
2. Export the roadmap to SVG.
3. Open the downloaded `.svg` file directly in a modern web browser.
4. Verify that the JavaScript payload is safely escaped as plain text and does not execute an alert box.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes
* [x] Prettier + ESLint passed via lint-staged on commit

Closes #488 