### PR TITLE
perf: throttle mousemove handler and fix stale node closures

### DIFF
--- a/src/hooks/useInteractionEffects.js
+++ b/src/hooks/useInteractionEffects.js
@@ -1,71 +1,97 @@
-import { useEffect } from 'react';
+import { useEffect } from "react";
 
 const MAGNETIC_DIST_THRESHOLD = 88;
 const MAGNETIC_INTENSITY = 0.32;
 const ACTIVITY_CARD_PARALLAX_MAX = 6;
 const ACTIVITY_CARD_DIST_RATIO = 0.9;
 const INTERSECTION_THRESHOLD = 0.09;
-const ROOT_MARGIN_BOTTOM = '0px 0px -36px 0px';
+const ROOT_MARGIN_BOTTOM = "0px 0px -36px 0px";
 
 export function useInteractionEffects(cinDone, page) {
   useEffect(() => {
     if (!cinDone) return;
 
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('fired');
-          observer.unobserve(entry.target);
-        }
-      });
-    }, { threshold: INTERSECTION_THRESHOLD, rootMargin: ROOT_MARGIN_BOTTOM });
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add("fired");
+            observer.unobserve(entry.target);
+          }
+        });
+      },
+      { threshold: INTERSECTION_THRESHOLD, rootMargin: ROOT_MARGIN_BOTTOM }
+    );
 
-    document.querySelectorAll('.pop-in, .pop-left, .pop-right, .pop-scale, .pop-flip, .pop-word, .pop-num')
-      .forEach(el => observer.observe(el));
+    document
+      .querySelectorAll(
+        ".pop-in, .pop-left, .pop-right, .pop-scale, .pop-flip, .pop-word, .pop-num"
+      )
+      .forEach((el) => observer.observe(el));
 
-    const magneticButtons = document.querySelectorAll('.mag-btn');
-    const activityCards = document.querySelectorAll('.activity-card');
+    let ticking = false;
 
-    const handleMouseMove = e => {
-      magneticButtons.forEach(btn => {
-        const rect = btn.getBoundingClientRect();
-        const dx = e.clientX - (rect.left + rect.width / 2);
-        const dy = e.clientY - (rect.top + rect.height / 2);
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        
-        if (dist < MAGNETIC_DIST_THRESHOLD) {
-          const factor = (MAGNETIC_DIST_THRESHOLD - dist) / MAGNETIC_DIST_THRESHOLD * MAGNETIC_INTENSITY;
-          btn.style.transform = `translate(${dx * factor}px, ${dy * factor}px)`;
-        } else {
-          btn.style.transform = '';
-        }
-      });
+    const handleMouseMove = (e) => {
+      if (!ticking) {
+        window.requestAnimationFrame(() => {
+          // Query fresh elements to ensure dynamically rendered cards are included
+          const magneticButtons = document.querySelectorAll(".mag-btn");
+          const activityCards = document.querySelectorAll(".activity-card");
 
-      activityCards.forEach(card => {
-        const rect = card.getBoundingClientRect();
-        const cx = rect.left + rect.width / 2;
-        const cy = rect.top + rect.height / 2;
-        const dx = e.clientX - cx;
-        const dy = e.clientY - cy;
-        const dist = Math.sqrt(dx * dx + dy * dy);
-        const maxDist = Math.max(rect.width, rect.height) * ACTIVITY_CARD_DIST_RATIO;
-        
-        if (dist < maxDist) {
-          const intensity = (1 - dist / maxDist) * ACTIVITY_CARD_PARALLAX_MAX;
-          card.style.setProperty('--rx', (dx / rect.width * intensity).toFixed(2));
-          card.style.setProperty('--ry', (-dy / rect.height * intensity).toFixed(2));
-        } else {
-          card.style.setProperty('--rx', '0');
-          card.style.setProperty('--ry', '0');
-        }
-      });
+          magneticButtons.forEach((btn) => {
+            const rect = btn.getBoundingClientRect();
+            const dx = e.clientX - (rect.left + rect.width / 2);
+            const dy = e.clientY - (rect.top + rect.height / 2);
+            const dist = Math.sqrt(dx * dx + dy * dy);
+
+            if (dist < MAGNETIC_DIST_THRESHOLD) {
+              const factor =
+                ((MAGNETIC_DIST_THRESHOLD - dist) / MAGNETIC_DIST_THRESHOLD) *
+                MAGNETIC_INTENSITY;
+              btn.style.transform = `translate(${dx * factor}px, ${dy * factor}px)`;
+            } else {
+              btn.style.transform = "";
+            }
+          });
+
+          activityCards.forEach((card) => {
+            const rect = card.getBoundingClientRect();
+            const cx = rect.left + rect.width / 2;
+            const cy = rect.top + rect.height / 2;
+            const dx = e.clientX - cx;
+            const dy = e.clientY - cy;
+            const dist = Math.sqrt(dx * dx + dy * dy);
+            const maxDist =
+              Math.max(rect.width, rect.height) * ACTIVITY_CARD_DIST_RATIO;
+
+            if (dist < maxDist) {
+              const intensity =
+                (1 - dist / maxDist) * ACTIVITY_CARD_PARALLAX_MAX;
+              card.style.setProperty(
+                "--rx",
+                ((dx / rect.width) * intensity).toFixed(2)
+              );
+              card.style.setProperty(
+                "--ry",
+                ((-dy / rect.height) * intensity).toFixed(2)
+              );
+            } else {
+              card.style.setProperty("--rx", "0");
+              card.style.setProperty("--ry", "0");
+            }
+          });
+
+          ticking = false;
+        });
+        ticking = true;
+      }
     };
 
-    window.addEventListener('mousemove', handleMouseMove, { passive: true });
+    window.addEventListener("mousemove", handleMouseMove, { passive: true });
 
     return () => {
       observer.disconnect();
-      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener("mousemove", handleMouseMove);
     };
   }, [cinDone, page]);
 }


### PR DESCRIPTION
## What does this PR do?

Resolves a severe main-thread bottleneck (layout thrashing) and a stale closure bug in the `useInteractionEffects` React hook.

## Why is this change needed?

The original implementation attached an unthrottled `mousemove` event listener that fired on every pixel of movement (often 60-120 times per second). For every event, it iterated over all `.mag-btn` and `.activity-card` elements, calling `.getBoundingClientRect()`. This forced synchronous layout recalculations and blocked the main thread, causing significant UI jank.

Furthermore, it queried the DOM for these elements only *once* when the effect mounted. If any cards were rendered dynamically after mount (via infinite scrolling, pagination, or tab switching), the effect had no awareness of them, and those elements never received the 3D parallax effects.

## What changes were made?

- **`src/hooks/useInteractionEffects.js`**: 
  - Wrapped the logic inside `handleMouseMove` in a `window.requestAnimationFrame` (rAF) callback using a `ticking` lock to decouple DOM read/writes from high-frequency mouse events.
  - Moved the `document.querySelectorAll` calls *inside* the animation frame so that the hook always operates on the freshest DOM nodes, solving the stale closure issue for dynamically injected elements.

## How to test

1. Load the application on a page with multiple activity cards.
2. Open Chrome DevTools > Performance and record a trace while moving the mouse rapidly.
3. Observe that layout thrashing is eliminated and the framerate remains consistently high.
4. Dynamically load more cards (or switch tabs) and confirm the parallax effect still applies to the newly rendered cards.

## Checklist

* [x] Code follows project style
* [x] Tested locally
* [x] No breaking changes
* [x] Prettier + ESLint passed via lint-staged on commit

Closes #489 