### PR TITLE
chore: add .editorconfig (Fixes #493)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
This pull request adds the missing `.editorconfig` file.

Closes #493.