### PR TITLE
fix: replace unsafe `as any` casts in RoadmapBuilder with typed roadmap data

### DIFF
--- a/src/components/roadmaps/RoadmapBuilder.tsx
+++ b/src/components/roadmaps/RoadmapBuilder.tsx
@@ -6,6 +6,7 @@ import { NodeModal } from './NodeModal';
 import { parseStaticRoadmap } from '../../utils/roadmapParser';
 import { exportToJSON, validateRoadmapJSON, downloadSVG, downloadPNG } from '../../utils/exportRoadmap';
 import { roadmapData } from '../../data/roadmapData';
+import type { RoadmapDataMap } from '../../types/roadmap';
 import {
   ArrowLeft, Plus, Download, Upload, RotateCcw,
   Sparkles, Layers, BookOpen, AlertCircle, Edit, Save, Check
@@ -14,7 +15,7 @@ import {
 interface RoadmapBuilderInnerProps {
   onBack: () => void;
 }
-
+const typedRoadmapData = roadmapData as RoadmapDataMap; 
 const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => {
   const {
     nodes,
@@ -65,7 +66,7 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
   // Import static NexaSphere Roadmaps
   const handleImportStatic = (domainKey: string) => {
     if (!domainKey) return;
-    const staticData = (roadmapData as any)[domainKey];
+    const staticData = typedRoadmapData[domainKey];
     if (!staticData) return;
 
     if (
@@ -215,7 +216,7 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
               <option value="" disabled>Import Base Path</option>
               {Object.keys(roadmapData).map((key) => (
                 <option key={key} value={key}>
-                  {(roadmapData as any)[key].title}
+                  {typedRoadmapData[key].title}
                 </option>
               ))}
             </select>

--- a/src/types/roadmap.ts
+++ b/src/types/roadmap.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared roadmap type definitions
+ * Centralizes types used across roadmapParser.ts and RoadmapBuilder.tsx
+ */
+
+export interface StaticResource {
+  title: string;
+  url: string;
+}
+
+export interface StaticNode {
+  id: string;
+  label: string;
+  description: string;
+  concepts?: string[];
+  docs?: string;
+  tutorials?: StaticResource[];
+  practice?: StaticResource[];
+}
+
+export interface StaticRoadmap {
+  title: string;
+  description: string;
+  nodes: StaticNode[];
+}
+
+export type RoadmapDataMap = Record<string, StaticRoadmap>;


### PR DESCRIPTION
## Summary
Closes #524

## Problem
`roadmapData` is imported from an untyped JavaScript file into 
`RoadmapBuilder.tsx`, forcing repeated `as any` casts to access 
its properties — bypassing TypeScript's type safety.

## Changes Made

**Created `src/types/roadmap.ts`:**
- New shared type file with `StaticResource`, `StaticNode`, 
  `StaticRoadmap` and `RoadmapDataMap` interfaces

**Updated `src/components/roadmaps/RoadmapBuilder.tsx`:**
- Imported `RoadmapDataMap` from new type file
- Added single typed cast: `const typedRoadmapData = roadmapData as RoadmapDataMap`
- Replaced all `(roadmapData as any)` usages with `typedRoadmapData`

## Before
```ts
const staticData = (roadmapData as any)[domainKey];
{(roadmapData as any)[key].title}
```

## After
```ts
const typedRoadmapData = roadmapData as RoadmapDataMap;
const staticData = typedRoadmapData[domainKey];
{typedRoadmapData[key].title}
```

## Files Changed
- `src/types/roadmap.ts` ← new file
- `src/components/roadmaps/RoadmapBuilder.tsx` ← 3 lines changed