### PR TITLE
Fix/socket event duplication 495

### DIFF
--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -11,7 +11,10 @@ const TYPE_CONFIG = {
 };
 
 function timeAgo(isoString) {
-  const diff = Math.floor((Date.now() - new Date(isoString)) / 1000);
+  if (!isoString) return 'just now';
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return 'just now';
+  const diff = Math.floor((Date.now() - date) / 1000);
   if (diff < 60)   return `${diff}s ago`;
   if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
   if (diff < 86400)return `${Math.floor(diff / 3600)}h ago`;

--- a/src/utils/socketClient.js
+++ b/src/utils/socketClient.js
@@ -31,7 +31,7 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
 
   if (socket) {
     socket.disconnect();
-  }
+  } 
 
   currentSocketUrl = resolvedUrl;
   socket = io(resolvedUrl, {
@@ -49,20 +49,23 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
     identifyUser(); // try to identify if user info is available locally
   });
 
+  socket.on('connect_error', (error) => {
+    console.error('[Socket.IO] Connection Error:', error);
+    captureHandledException(error, 'Socket.IO connect_error:');
+  });
   
-
- 
   socket.on('error', (error) => {
     console.error('[Socket.IO] Error:', error);
     captureHandledException(error, 'Socket.IO error:');
   });
-
-
-
+  
   socket.on('reconnect_failed', () => {
-    captureHandledException(new Error('Socket.IO reconnect attempts exhausted'), 'Socket.IO reconnect failed:');
+    console.error('[Socket.IO] Reconnection failed after max attempts');
+    captureHandledException(
+      new Error('Socket.IO reconnect attempts exhausted'),
+      'Socket.IO reconnect failed:'
+    );
   });
-
   // Setup custom event listeners
   setupEventListeners();
 

--- a/src/utils/socketClient.js
+++ b/src/utils/socketClient.js
@@ -37,7 +37,6 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
   socket = io(resolvedUrl, {
     path: getSocketPath(),
     reconnection: true,
-    reconnectionAttempts: 10,
     reconnectionDelay: 1000,
     reconnectionDelayMax: 5000,
     reconnectionAttempts: 8,
@@ -50,23 +49,15 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
     identifyUser(); // try to identify if user info is available locally
   });
 
-  socket.on('reconnect_failed', () => {
-    console.error('[Socket.IO] Reconnection failed');
-  });
+  
 
-  socket.on('connect_error', (error) => {
-    console.error('[Socket.IO] Connection Error:', error);
-    captureHandledException(error, 'Socket.IO connect_error:');
-  });
-
+ 
   socket.on('error', (error) => {
     console.error('[Socket.IO] Error:', error);
     captureHandledException(error, 'Socket.IO error:');
   });
 
-  socket.on('connect_error', (error) => {
-    captureHandledException(error, 'Socket.IO connection error:');
-  });
+
 
   socket.on('reconnect_failed', () => {
     captureHandledException(new Error('Socket.IO reconnect attempts exhausted'), 'Socket.IO reconnect failed:');


### PR DESCRIPTION

closes #495

This PR fixes issue #495 by refactoring the Socket.IO client to remove duplicate event listeners and ensure consistent, single-source error handling across all connection lifecycle events. Previously, connect_error and reconnect_failed were registered multiple times with separate responsibilities for logging and Sentry capture, which resulted in duplicate error reporting and inconsistent behavior. Additionally, reconnectionAttempts was defined more than once in the configuration, causing a silent override and unclear socket retry behavior. This update consolidates all event handling into unified handlers that both log errors and report them to Sentry, while also cleaning up redundant configuration to ensure a single authoritative value for reconnection attempts. As a result, socket behavior is now predictable, error tracking is accurate, and unnecessary noise in logging and monitoring systems has been eliminated without affecting core functionality.

Tested locally by simulating connection failures and reconnection scenarios, and verified that each event (connect_error and reconnect_failed) triggers only once with no duplicate logs or Sentry reports. Also confirmed that the socket reconnect behavior works correctly with a single defined reconnectionAttempts value, and all existing features including user identification, room join/leave, and event emission continue to work as expected.