### PR TITLE
fix(search): include event names in global search

### DIFF
--- a/src/__tests__/useSearch.test.ts
+++ b/src/__tests__/useSearch.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { eventMatchesQuery, getEventDisplayTitle } from "../hooks/useSearch";
+
+describe("useSearch event helpers", () => {
+  const event = {
+    id: "kss-153",
+    name: "KSS #153 — Knowledge Sharing Session",
+    shortName: "KSS #153",
+    description: "Peer-to-peer AI learning session",
+    category: "workshop",
+    tags: ["AI", "Learning"],
+  };
+
+  it("matches events by name", () => {
+    expect(eventMatchesQuery(event, "kss")).toBe(true);
+    expect(eventMatchesQuery(event, "knowledge sharing")).toBe(true);
+  });
+
+  it("matches events by shortName when title and name are absent", () => {
+    expect(eventMatchesQuery({ shortName: "Open Source Day" }, "source")).toBe(
+      true
+    );
+  });
+
+  it("returns a non-empty display title from name or shortName", () => {
+    expect(getEventDisplayTitle(event)).toBe(
+      "KSS #153 — Knowledge Sharing Session"
+    );
+    expect(getEventDisplayTitle({ shortName: "Open Source Day" })).toBe(
+      "Open Source Day"
+    );
+  });
+});

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from "react";
 
 /* Debounce hook - delays search until user stops typing */
 function useDebounce(value, delay = 300) {
@@ -10,10 +10,30 @@ function useDebounce(value, delay = 300) {
   return debouncedValue;
 }
 
+function matchesText(value, query) {
+  return typeof value === "string" && value.toLowerCase().includes(query);
+}
+
+export function getEventDisplayTitle(event) {
+  return event?.title || event?.name || event?.shortName || "";
+}
+
+export function eventMatchesQuery(event, query) {
+  return (
+    matchesText(event?.title, query) ||
+    matchesText(event?.name, query) ||
+    matchesText(event?.shortName, query) ||
+    matchesText(event?.description, query) ||
+    matchesText(event?.category, query) ||
+    matchesText(event?.location, query) ||
+    event?.tags?.some?.((tag) => matchesText(tag, query))
+  );
+}
+
 /* Main search hook */
 export function useSearch(activities, events) {
-  const [query,   setQuery]   = useState('');
-  const [filter,  setFilter]  = useState('all'); // 'all' | 'activities' | 'events'
+  const [query, setQuery] = useState("");
+  const [filter, setFilter] = useState("all"); // 'all' | 'activities' | 'events'
   const [results, setResults] = useState([]);
   const debouncedQuery = useDebounce(query, 300);
 
@@ -27,43 +47,42 @@ export function useSearch(activities, events) {
     let all = [];
 
     /* Search activities */
-    if (filter === 'all' || filter === 'activities') {
+    if (filter === "all" || filter === "activities") {
       const actRes = Object.entries(activities || {})
-        .filter(([key, a]) =>
-          key.toLowerCase().includes(q) ||
-          a?.title?.toLowerCase().includes(q) ||
-          a?.description?.toLowerCase().includes(q) ||
-          a?.subtitle?.toLowerCase().includes(q) ||
-          a?.tagline?.toLowerCase().includes(q)
+        .filter(
+          ([key, a]) =>
+            key.toLowerCase().includes(q) ||
+            a?.title?.toLowerCase().includes(q) ||
+            a?.description?.toLowerCase().includes(q) ||
+            a?.subtitle?.toLowerCase().includes(q) ||
+            a?.tagline?.toLowerCase().includes(q)
         )
         .map(([key, a]) => ({
-          id:          key,
-          type:        'activity',
-          title:       a?.title || key,
-          description: a?.description || a?.subtitle || a?.tagline || '',
+          id: key,
+          type: "activity",
+          title: a?.title || key,
+          description: a?.description || a?.subtitle || a?.tagline || "",
           key,
         }));
       all = [...all, ...actRes];
     }
 
     /* Search events */
-    if (filter === 'all' || filter === 'events') {
+    if (filter === "all" || filter === "events") {
       const evRes = (events || [])
-        .filter(ev =>
-          ev?.title?.toLowerCase().includes(q) ||
-          ev?.description?.toLowerCase().includes(q) ||
-          ev?.category?.toLowerCase().includes(q) ||
-          ev?.location?.toLowerCase().includes(q) ||
-          ev?.tags?.some?.(t => t.toLowerCase().includes(q))
-        )
-        .map(ev => ({
-          id:          ev.id || ev.title,
-          type:        'event',
-          title:       ev.title,
-          description: ev.description || ev.location || '',
-          date:        ev.date,
-          event:       ev,
-        }));
+        .filter((ev) => eventMatchesQuery(ev, q))
+        .map((ev) => {
+          const title = getEventDisplayTitle(ev);
+
+          return {
+            id: ev.id || title,
+            type: "event",
+            title,
+            description: ev.description || ev.location || "",
+            date: ev.date,
+            event: ev,
+          };
+        });
       all = [...all, ...evRes];
     }
 
@@ -71,8 +90,8 @@ export function useSearch(activities, events) {
   }, [debouncedQuery, filter, activities, events]);
 
   const clearSearch = useCallback(() => {
-    setQuery('');
-    setFilter('all');
+    setQuery("");
+    setFilter("all");
     setResults([]);
   }, []);
 


### PR DESCRIPTION
## Description

Fixes the global search event field mismatch where current event data uses `name` and `shortName`, while the search hook only looked at `title`. This caused searches for visible event names to be unreliable and could render blank event result headings.

## What

Closes #604. Event search now matches `title`, `name`, `shortName`, description, category, location, and tags, and event result rows use a normalized display title.

## How

Added small helper functions in `src/hooks/useSearch.js` to normalize event display titles and centralize event-query matching. Added focused Vitest coverage for events that only expose `name` / `shortName`.

## Linked Issue

Closes #604

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation update
- [ ] 🎨 UI/Design improvement
- [ ] ♻️ Refactoring (no behaviour change)
- [x] 🧪 Tests
- [ ] 🔧 Chore / config / deps

## Changes Made

- Added event display-title and query-matching helpers to `useSearch`.
- Updated event result mapping to render `title || name || shortName` instead of only `title`.
- Added a focused unit test for event-name and short-name search coverage.

## Screenshots / Demo

Not applicable; this is a search data-mapping fix covered by unit tests.

## Testing

- [x] `npm run test -- src/__tests__/useSearch.test.ts`
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run format:check`
- [x] `git diff --check`
- [ ] `npm run test` — blocked by pre-existing `src/__tests__/HeroSection.test.tsx` failures: `Objects are not valid as a React child (found: [object HTMLImageElement])`.
- [ ] `npm run build` — blocked by pre-existing missing dependencies imported by `src/i18n.js`: `i18next`, `react-i18next`, and `i18next-browser-languagedetector` are absent from `package.json`.

## Risks / Notes

No dependency changes. I also tried to add the `type:bug` label to #604, but GitHub denied label permissions for this fork contributor: `GraphQL: DhruvalBhinsara1 does not have the correct permissions to execute AddLabelsToLabelable`. The issue is assigned to me and still carries the repo-generated `needs-labels` marker for maintainers.

## GSSoC'26 Checklist

- [x] I am officially assigned to the linked issue.
- [x] My branch was created from `main` and is up-to-date with upstream `main`.
- [x] I followed the branch naming convention (`fix/`).
- [x] The commit follows Conventional Commits format.
- [x] The commit has a `Signed-off-by:` line.
- [x] I have read and followed the Contributing Guide.

## Stage 1 Automated Checks

- [x] PR has a non-empty description.
- [x] PR includes `Closes #604`.
- [x] PR has a checklist.
- [x] Commit has DCO sign-off.