### PR TITLE
fix: remove stray closing tokens and undefined setupEventListeners call in socketClient.js

### DIFF
--- a/src/utils/socketClient.js
+++ b/src/utils/socketClient.js
@@ -68,10 +68,6 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
       'Socket.IO reconnect failed:'
     );
   });
-    );
-  });
-  // Setup custom event listeners
-  setupEventListeners();
 
   return socket;
 }


### PR DESCRIPTION
## Summary
Closes #629

## Problem
In `src/utils/socketClient.js`, after the `reconnect_failed` handler 
closes properly at line 70, there were:
- Two stray closing tokens `);` and `});` (lines 71-72)
- An orphaned comment `// Setup custom event listeners`
- A call to `setupEventListeners()` which is never defined anywhere

## Evidence
```js
  }); // ← reconnect_failed properly closes here ✅
    ); // ← stray token ❌
  }); // ← stray token ❌
  // Setup custom event listeners ← orphaned comment ❌
  setupEventListeners(); // ← function never defined ❌
```

## Fix
Removed all 4 problematic lines.

## After Fix
```js
  }); // ← reconnect_failed closes cleanly
  
  return socket;
```

## Impact
- Prevents syntax error on socketClient.js module load
- Restores all real-time features (notifications, live events)

## Files Changed
- `src/utils/socketClient.js` — 4 lines removed