### PR TITLE
fix: isValid now requires touched fields before returning true in useFormValidation

### DIFF
--- a/src/hooks/useFormValidation.js
+++ b/src/hooks/useFormValidation.js
@@ -209,8 +209,8 @@ export default function useFormValidation(
    * Form-wide validation state check.
    */
   const isValid = useMemo(() => {
-    return Object.keys(errors).length === 0;
-  }, [errors]);
+    return Object.keys(errors).length === 0 && Object.keys(touched).length > 0;
+  }, [errors, touched]);
 
   return {
     values,


### PR DESCRIPTION
## Summary
Closes #630

## Problem
In `src/hooks/useFormValidation.js` line 212, `isValid` was computed 
solely as `Object.keys(errors).length === 0`. Since `errors` is 
initialized as `{}`, `isValid` was `true` from the very start — 
before the user touches any field.

## Evidence
```js
// Before fix:
const isValid = useMemo(() => {
  return Object.keys(errors).length === 0; // true on fresh form!
}, [errors]);
```

## Impact
- Submit buttons enabled before user fills anything
- Forms appear valid before any validation occurs

## Fix
Added `touched` check so `isValid` only returns `true` after 
user has interacted with at least one field:

```js
// After fix:
const isValid = useMemo(() => {
  return Object.keys(errors).length === 0 && Object.keys(touched).length > 0;
}, [errors, touched]);
```

## Files Changed
- `src/hooks/useFormValidation.js` — 2 lines changed