### PR TITLE
fix: add auth and configurable URL for Java-to-Python service communication

### DIFF
--- a/server-java/src/main/java/org/nexasphere/service/crud/CollaborationService.java
+++ b/server-java/src/main/java/org/nexasphere/service/crud/CollaborationService.java
@@ -5,6 +5,9 @@ import org.nexasphere.model.entity.JoinRequestEntity;
 import org.nexasphere.repository.CollaborationTeamRepository;
 import org.nexasphere.repository.JoinRequestRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -22,7 +25,12 @@ public class CollaborationService {
     private JoinRequestRepository requestRepository;
 
     private final RestTemplate restTemplate = new RestTemplate();
-    private final String PYTHON_SERVICE_URL = "http://localhost:8000/notify/join-request";
+
+    @Value("${INTERNAL_SERVICE_URL:http://localhost:8000}")
+    private String internalServiceUrl;
+
+    @Value("${INTERNAL_SERVICE_SECRET:}")
+    private String internalServiceSecret;
 
     public List<CollaborationTeamEntity> getAllTeams() {
         return teamRepository.findAll();
@@ -39,7 +47,13 @@ public class CollaborationService {
 
         // Notify via Python microservice
         try {
-            restTemplate.postForObject(PYTHON_SERVICE_URL, saved, String.class);
+            String url = internalServiceUrl + "/notify/join-request";
+            HttpHeaders headers = new HttpHeaders();
+            if (internalServiceSecret != null && !internalServiceSecret.isEmpty()) {
+                headers.set("X-Service-Auth", internalServiceSecret);
+            }
+            HttpEntity<JoinRequestEntity> request = new HttpEntity<>(saved, headers);
+            restTemplate.postForObject(url, request, String.class);
         } catch (Exception e) {
             // Log error, continue execution
             System.err.println("Failed to notify python microservice: " + e.getMessage());

--- a/server-python/routers/notifications.py
+++ b/server-python/routers/notifications.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter
+import os
+import hmac
+from typing import Optional
+from fastapi import APIRouter, Depends, Header, HTTPException
 from pydantic import BaseModel
 from services.notification_service import notify_team_leader
 
@@ -10,8 +13,22 @@ class JoinRequestPayload(BaseModel):
     skills: str
     github: str
 
+INTERNAL_SERVICE_SECRET = os.getenv("INTERNAL_SERVICE_SECRET", "")
+
+
+def _verify_service_auth(x_service_auth: Optional[str] = Header(default=None)) -> None:
+    """Dependency that validates the internal service auth header."""
+    if not INTERNAL_SERVICE_SECRET:
+        return
+    if not x_service_auth or not hmac.compare_digest(x_service_auth, INTERNAL_SERVICE_SECRET):
+        raise HTTPException(status_code=401, detail="Unauthorized: invalid service auth")
+
+
 @router.post("/join-request")
-async def handle_join_request_notification(payload: JoinRequestPayload):
+async def handle_join_request_notification(
+    payload: JoinRequestPayload,
+    _: None = Depends(_verify_service_auth),
+):
     """
     Webhook endpoint called by the Java backend when a new join request is created.
     """


### PR DESCRIPTION
## Description

The Java backend sends collaboration join request data to the Python microservice with zero authentication. The Python endpoint accepts any POST body without validating the source.

**Java (`CollaborationService.java`):**
- Made Python service URL configurable via `INTERNAL_SERVICE_URL` env var (defaults to `http://localhost:8000`) instead of hardcoded
- Added `X-Service-Auth` header with shared secret from `INTERNAL_SERVICE_SECRET` env var
- Uses `HttpEntity` with headers when posting to the Python microservice

**Python (`notifications.py`):**
- Added `_verify_service_auth` dependency using `hmac.compare_digest` (same pattern as `certificates.py:46-49`)
- Validates `X-Service-Auth` header against `INTERNAL_SERVICE_SECRET` env var
- Auth check is skipped when secret is not set (development mode)

## Related Issue

Closes #627

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.