### PR TITLE
fix: resolve rate limiter syntax error from bad merge and fix imports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -40,15 +40,13 @@ import {
   authRateLimiter,
   formRateLimiter,
   notificationRateLimiter,
-  formRateLimiter,
   activityAuthRateLimiter,
-} from "./middleware/rateLimiter.js";
-
-import { portfolioRepository } from "./repositories/portfolioRepository.js";
-import { Mutex } from "async-mutex";
   portfolioRateLimiter,
   validateLimiters,
 } from './middleware/rateLimiter.js';
+
+import { portfolioRepository } from "./repositories/portfolioRepository.js";
+import { Mutex } from "async-mutex";
 import { getPublicAppUrl } from './utils/publicAppUrl.js';
 
 // Import required controllers and services

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -97,8 +97,6 @@ export const notificationRateLimiter = rateLimit({
 // when the server restarts the IP-level window survives in the rate-limit
 // store.
 export const activityAuthRateLimiter = rateLimit({
-// Portfolio update rate limiter — 10 requests per IP per 15 minutes
-export const portfolioRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
   standardHeaders: true,
@@ -114,6 +112,13 @@ export const portfolioRateLimiter = rateLimit({
     });
   },
 });
+
+// Portfolio update rate limiter — 10 requests per IP per 15 minutes
+export const portfolioRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false,
   message: {
     error:
       "Too many portfolio update attempts from this IP, please try again after 15 minutes.",
@@ -131,6 +136,7 @@ export function validateLimiters() {
     formRateLimiter,
     authRateLimiter,
     notificationRateLimiter,
+    activityAuthRateLimiter,
     portfolioRateLimiter,
   };
 


### PR DESCRIPTION
## Description

`server/middleware/rateLimiter.js` was corrupted by a bad merge: `portfolioRateLimiter` was declared as a nested `export const` inside the `activityAuthRateLimiter` `rateLimit({...})` block, producing a JavaScript `SyntaxError`. The module fails to load entirely, making every rate-limited endpoint unprotected against brute-force and abuse.

**Changes:**

**`server/middleware/rateLimiter.js`:**
- Separated interleaved `export const` declarations — `activityAuthRateLimiter` and `portfolioRateLimiter` are now independent top-level exports with their own complete `rateLimit({...})` configuration
- Added `activityAuthRateLimiter` to `validateLimiters()` so its breakage is caught at startup

**`server/index.js`:**
- Fixed orphaned import fragments — consolidated duplicate/malformed rate limiter imports into a single clean import block including all 6 limiters + `validateLimiters`

## Related Issue

Closes #628

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.