### PR TITLE
fix: replace dangling comma concatenation with array join in generatePortfolioMeta

### DIFF
--- a/src/utils/seoUtils.js
+++ b/src/utils/seoUtils.js
@@ -34,13 +34,15 @@ export function generatePortfolioMeta(userData) {
   
   // Generate description based on available data
   let desc = `Explore ${name}'s developer portfolio showcasing`;
+  const parts = [];
   if (skills && skills.length > 0) {
-    desc += ` ${skills.slice(0, 3).join(', ')},`;
+    parts.push(skills.slice(0, 3).join(', '));
   }
   if (projectCount > 0) {
-    desc += ` ${projectCount} projects,`;
+    parts.push(`${projectCount} projects`);
   }
-  desc += ` and technical expertise on NexaSphere.`;
+  parts.push('technical expertise on NexaSphere');
+  desc += ` ${parts.join(', ')}.`;
   if (bio) {
     desc = `${desc} ${bio.slice(0, 100)}${bio.length > 100 ? '...' : ''}`;
   }


### PR DESCRIPTION
## Summary
Closes #631

## Problem
In `src/utils/seoUtils.js`, commas were always appended after 
skills and project count, producing a grammatically broken 
meta description like:
`"...React, Vue, 3 projects, and technical expertise..."`

## Evidence
```js
// Before fix:
desc += ` ${skills.slice(0, 3).join(', ')},`; // always adds comma
desc += ` ${projectCount} projects,`;          // always adds comma
desc += ` and technical expertise on NexaSphere.`; // comma before "and"
```

## Impact
- Malformed `<meta name="description">` and OpenGraph tags
- Hurts SEO ranking
- Looks unprofessional in search results

## Fix
Built description parts as array and joined cleanly:

```js
// After fix:
const parts = [];
if (skills && skills.length > 0) parts.push(skills.slice(0, 3).join(', '));
if (projectCount > 0) parts.push(`${projectCount} projects`);
parts.push('technical expertise on NexaSphere');
desc += ` ${parts.join(', ')}.`;
```

## Result
Before: "...React, Vue, 3 projects, and technical expertise..."
After:  "...React, Vue, 3 projects, technical expertise on NexaSphere."

## Files Changed
- `src/utils/seoUtils.js` — 5 lines changed