### PR TITLE
fix(events): prevent data loss in update endpoint by merging fields

### DIFF
--- a/server-java/src/main/java/org/nexasphere/controller/EventsController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/EventsController.java
@@ -39,16 +39,35 @@ public class EventsController {
         return ResponseEntity.status(HttpStatus.CREATED).body(repo.save(event));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<EventEntity> update(@PathVariable String id, @Valid @RequestBody EventEntity event) {
-        String safeId = Objects.requireNonNull(id, "id must not be null");
-        return repo.findById(safeId).map(existing -> {
-            event.setId(safeId);
-            event.setName(sanitizer.clean(event.getName()));
-            EventEntity saved = repo.save(event);
-            return ResponseEntity.ok(saved);
-        }).orElseGet(() -> ResponseEntity.notFound().build());
-    }
+   @PutMapping("/{id}")
+public ResponseEntity<EventEntity> update(@PathVariable String id,
+                                         @Valid @RequestBody EventEntity event) {
+
+    return repo.findById(id).map(existing -> {
+
+        // merge only non-null fields
+        if (event.getName() != null) {
+            existing.setName(sanitizer.clean(event.getName()));
+        }
+
+        if (event.getDescription() != null) {
+            existing.setDescription(event.getDescription());
+        }
+
+        if (event.getDate() != null) {
+            existing.setDate(event.getDate());
+        }
+
+        if (event.getLocation() != null) {
+            existing.setLocation(event.getLocation());
+        }
+
+        // save merged entity
+        EventEntity saved = repo.save(existing);
+        return ResponseEntity.ok(saved);
+
+    }).orElseGet(() -> ResponseEntity.notFound().build());
+}
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id) {


### PR DESCRIPTION
# 🔧 Fix: Event Update Endpoint Data Loss Issue

---

## 📌 Overview
This PR fixes a critical backend bug in the `EventsController` where updating an event was causing existing data to be overwritten with `null` values.

The issue happened because the API was directly saving the incoming request body instead of safely updating only the changed fields.

---

## 🚨 Problem

Earlier, the update endpoint worked like this:

- Frontend sends partial data (only some fields)
- Backend directly saves the received object
- Missing fields become `null` in database

### ❌ Example

Request:

{
  "name": "Hackathon 2026"
}


### Database after update:

{
  "name": "Hackathon 2026",
  "description": null,
  "date": null,
  "location": null
}

👉 This caused accidental data loss

## 🎯 Expected Behavior

When only some fields are sent:

Only those fields should be updated
All other existing fields should remain unchanged
✅ Correct Behavior
{
  "name": "Hackathon 2026",
  "description": "Old value stays",
  "date": "Old value stays",
  "location": "Old value stays"
}

## 🧠 Root Cause

The issue was in this line:

repo.save(event);

Instead of:

fetching existing entity
merging changes
saving updated entity

The system directly overwrote the database record.


## 🔧 Solution Implemented

We replaced full overwrite logic with a safe merge-based update approach:

Step-by-step logic:
Fetch existing event from database using ID
Check each field from request
Update only fields that are not null
Keep existing values for all other fields
Save the merged entity back to DB