### PR TITLE
fix(events): prevent data loss in update endpoint by merging fields

### DIFF
--- a/server-java/src/main/java/org/nexasphere/controller/EventsController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/EventsController.java
@@ -39,16 +39,35 @@ public class EventsController {
         return ResponseEntity.status(HttpStatus.CREATED).body(repo.save(event));
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<EventEntity> update(@PathVariable String id, @Valid @RequestBody EventEntity event) {
-        String safeId = Objects.requireNonNull(id, "id must not be null");
-        return repo.findById(safeId).map(existing -> {
-            event.setId(safeId);
-            event.setName(sanitizer.clean(event.getName()));
-            EventEntity saved = repo.save(event);
-            return ResponseEntity.ok(saved);
-        }).orElseGet(() -> ResponseEntity.notFound().build());
-    }
+   @PutMapping("/{id}")
+public ResponseEntity<EventEntity> update(@PathVariable String id,
+                                         @Valid @RequestBody EventEntity event) {
+
+    return repo.findById(id).map(existing -> {
+
+        // merge only non-null fields
+        if (event.getName() != null) {
+            existing.setName(sanitizer.clean(event.getName()));
+        }
+
+        if (event.getDescription() != null) {
+            existing.setDescription(event.getDescription());
+        }
+
+        if (event.getDate() != null) {
+            existing.setDate(event.getDate());
+        }
+
+        if (event.getLocation() != null) {
+            existing.setLocation(event.getLocation());
+        }
+
+        // save merged entity
+        EventEntity saved = repo.save(existing);
+        return ResponseEntity.ok(saved);
+
+    }).orElseGet(() -> ResponseEntity.notFound().build());
+}
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable String id) {


### PR DESCRIPTION
## 📌 Description
This PR fixes a critical issue in the event update API where updating an event was incorrectly overwriting the entire entity, leading to accidental data loss.

The update logic has been improved to ensure only the provided fields are modified while all existing fields in the database remain unchanged. This makes partial updates safe and reliable.

---

## 🐞 Related Issue
Closes #642 

---

## 🔧 Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

---

## ✨ Summary of Fix
- Fixed unsafe full entity overwrite in update endpoint
- Implemented safe merge-based update logic
- Preserved existing database values during partial updates
- Improved backend stability and data integrity

---

## 🧪 Checklist
- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

---

## 🧠 Impact
- Prevents accidental data loss in events
- Enables safe partial updates
- Improves reliability of admin dashboard operations

---

## 📸 Screenshots
Not applicable (backend change)