### PR TITLE
Add full KSS metadata schema, category linking, and dynamic gradient card styling

### DIFF
--- a/admin-dashboard/src/components/EventForm.jsx
+++ b/admin-dashboard/src/components/EventForm.jsx
@@ -4,7 +4,24 @@ import { AdminIcon } from './AdminIcon';
 
 const STATUSES = ['upcoming', 'ongoing', 'completed', 'cancelled'];
 
-// Convert "YYYY-MM-DD" → "March 14, 2025"
+const CATEGORIES = [
+  { value: '', label: 'Select category...' },
+  { value: 'kss', label: 'Knowledge Sharing Session' },
+  { value: 'workshop', label: 'Workshop' },
+  { value: 'hackathon', label: 'Hackathon' },
+  { value: 'debate', label: 'Tech Debate' },
+  { value: 'opensource', label: 'Open Source Day' },
+  { value: 'codathon', label: 'Codathon' },
+  { value: 'ideathon', label: 'Ideathon' },
+  { value: 'promptathon', label: 'Promptathon' },
+  { value: 'insight-session', label: 'Insight Session' },
+];
+
+const ICON_OPTIONS = [
+  'Brain', 'Wrench', 'Code', 'MessageSquare', 'Terminal', 'GitBranch',
+  'Rocket', 'Sparkles', 'Calendar', 'Target', 'Lightbulb', 'Globe',
+];
+
 function toDisplayDate(isoVal) {
   if (!isoVal) return '';
   const d = new Date(isoVal + 'T00:00:00');
@@ -12,7 +29,6 @@ function toDisplayDate(isoVal) {
   return d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' });
 }
 
-// Convert "March 14, 2025" → "2025-03-14" for the date input
 function toISODate(displayVal) {
   if (!displayVal) return '';
   const d = new Date(displayVal);
@@ -23,7 +39,9 @@ function toISODate(displayVal) {
 const empty = {
   name: '', shortName: '', dateText: '', dateISO: '',
   description: '', icon: 'Calendar', status: 'upcoming',
-  location: '', registrationLink: '', tagsInput: ''
+  category: '', location: '', capacity: '',
+  hasDetailPage: true, tagsInput: '',
+  gradientColors: [],
 };
 
 export function EventForm({ event, onClose }) {
@@ -32,8 +50,11 @@ export function EventForm({ event, onClose }) {
         ...event,
         tagsInput: Array.isArray(event.tags) ? event.tags.join(', ') : (event.tags || ''),
         dateISO: toISODate(event.dateText ?? event.date ?? ''),
+        gradientColors: Array.isArray(event.gradientColors) ? [...event.gradientColors] : [],
+        capacity: event.capacity ?? '',
+        hasDetailPage: event.hasDetailPage !== false,
       }
-    : empty
+    : { ...empty }
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
@@ -48,6 +69,31 @@ export function EventForm({ event, onClose }) {
     }));
   };
 
+  const addGradientColor = () => {
+    setForm(f => ({ ...f, gradientColors: [...f.gradientColors, '#6b21a8'] }));
+  };
+
+  const updateGradientColor = (index, value) => {
+    setForm(f => {
+      const updated = [...f.gradientColors];
+      updated[index] = value;
+      return { ...f, gradientColors: updated };
+    });
+  };
+
+  const removeGradientColor = (index) => {
+    setForm(f => ({
+      ...f,
+      gradientColors: f.gradientColors.filter((_, i) => i !== index),
+    }));
+  };
+
+  const gradientPreview = form.gradientColors.length > 1
+    ? `linear-gradient(135deg, ${form.gradientColors.join(', ')})`
+    : form.gradientColors.length === 1
+      ? `linear-gradient(135deg, ${form.gradientColors[0]}, ${form.gradientColors[0]}88)`
+      : 'linear-gradient(135deg, #6b21a8, #7c3aed)';
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setError('');
@@ -56,9 +102,15 @@ export function EventForm({ event, onClose }) {
       const tags = form.tagsInput
         ? form.tagsInput.split(',').map(t => t.trim()).filter(Boolean)
         : [];
-      const payload = { ...form, tags };
+      const payload = {
+        ...form,
+        tags,
+        capacity: form.capacity ? parseInt(form.capacity, 10) : null,
+        startDate: form.startDate || null,
+        endDate: form.endDate || null,
+      };
       delete payload.tagsInput;
-      delete payload.dateISO; // only send dateText to Java
+      delete payload.dateISO;
 
       if (event?.id) {
         await api.events.update(event.id, payload);
@@ -75,7 +127,7 @@ export function EventForm({ event, onClose }) {
 
   return (
     <div className="modal-overlay" onClick={e => e.target === e.currentTarget && onClose()}>
-      <div className="modal">
+      <div className="modal" style={{ maxWidth: 600, maxHeight: '90vh', overflowY: 'auto' }}>
         <div className="modal-header">
           <h3>{event?.id ? 'Edit Event' : 'New Event'}</h3>
           <button className="modal-close" onClick={onClose} aria-label="Close"><AdminIcon name="X" size={18} /></button>
@@ -90,7 +142,13 @@ export function EventForm({ event, onClose }) {
             <input value={form.shortName || ''} onChange={e => set('shortName', e.target.value)} placeholder="e.g. KSS #153" />
           </div>
 
-          {/* Date Picker */}
+          <div className="form-row">
+            <label>Activity Category</label>
+            <select value={form.category || ''} onChange={e => set('category', e.target.value)}>
+              {CATEGORIES.map(c => <option key={c.value} value={c.value}>{c.label}</option>)}
+            </select>
+          </div>
+
           <div className="form-row">
             <label>Event Date</label>
             <input
@@ -101,37 +159,159 @@ export function EventForm({ event, onClose }) {
             />
             {form.dateText && (
               <div style={{ fontSize: '11px', color: 'var(--text2)', marginTop: '4px' }}>
-                📅 Will display as: <strong style={{ color: 'var(--text)' }}>{form.dateText}</strong>
+                Will display as: <strong style={{ color: 'var(--text)' }}>{form.dateText}</strong>
               </div>
             )}
           </div>
 
-          <div className="form-row">
-            <label>Icon <span style={{ fontWeight: 400, textTransform: 'none' }}>(icon name e.g. Brain, Wrench, Rocket)</span></label>
-            <input value={form.icon} onChange={e => set('icon', e.target.value)} placeholder="Brain" />
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <div className="form-row">
+              <label>Start Date & Time</label>
+              <input
+                type="datetime-local"
+                value={form.startDate || ''}
+                onChange={e => set('startDate', e.target.value)}
+                style={{ colorScheme: 'dark' }}
+              />
+            </div>
+            <div className="form-row">
+              <label>End Date & Time</label>
+              <input
+                type="datetime-local"
+                value={form.endDate || ''}
+                onChange={e => set('endDate', e.target.value)}
+                style={{ colorScheme: 'dark' }}
+              />
+            </div>
           </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+            <div className="form-row">
+              <label>Location</label>
+              <input value={form.location || ''} onChange={e => set('location', e.target.value)} placeholder="e.g. Conference Hall" />
+            </div>
+            <div className="form-row">
+              <label>Capacity</label>
+              <input type="number" value={form.capacity} onChange={e => set('capacity', e.target.value)} placeholder="e.g. 50" min="0" />
+            </div>
+          </div>
+
+          <div className="form-row">
+            <label>Icon</label>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 4 }}>
+              {ICON_OPTIONS.map(iconName => (
+                <button
+                  key={iconName}
+                  type="button"
+                  onClick={() => set('icon', iconName)}
+                  style={{
+                    display: 'flex', alignItems: 'center', gap: 4,
+                    padding: '5px 10px', borderRadius: 6, cursor: 'pointer',
+                    border: form.icon === iconName ? '2px solid var(--c1)' : '1px solid var(--bdr)',
+                    background: form.icon === iconName ? 'var(--c1a)' : 'var(--card)',
+                    color: form.icon === iconName ? 'var(--c1)' : 'var(--t2)',
+                    fontSize: 12, fontWeight: 500, transition: 'all 0.15s',
+                  }}
+                >
+                  <AdminIcon name={iconName} size={14} />
+                  {iconName}
+                </button>
+              ))}
+            </div>
+          </div>
+
           <div className="form-row">
             <label>Status</label>
             <select value={form.status} onChange={e => set('status', e.target.value)}>
               {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
             </select>
           </div>
+
           <div className="form-row">
             <label>Tags <span style={{ fontWeight: 400, textTransform: 'none' }}>(comma separated)</span></label>
             <input value={form.tagsInput || ''} onChange={e => set('tagsInput', e.target.value)} placeholder="AI, Learning, Community" />
           </div>
-          <div className="form-row">
-            <label>Location</label>
-            <input value={form.location || ''} onChange={e => set('location', e.target.value)} placeholder="e.g. Lab 204, Online" />
+
+          <div className="form-row" style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+            <label style={{ marginBottom: 0 }}>Has Detail Page</label>
+            <button
+              type="button"
+              onClick={() => set('hasDetailPage', !form.hasDetailPage)}
+              style={{
+                width: 42, height: 24, borderRadius: 12, border: 'none', cursor: 'pointer',
+                background: form.hasDetailPage ? 'var(--c1)' : 'var(--bdr)',
+                position: 'relative', transition: 'background 0.2s',
+              }}
+              aria-label="Toggle detail page"
+            >
+              <span style={{
+                position: 'absolute', top: 2,
+                left: form.hasDetailPage ? 22 : 2,
+                width: 20, height: 20, borderRadius: '50%',
+                background: 'white', transition: 'left 0.2s',
+              }} />
+            </button>
           </div>
-          <div className="form-row">
-            <label>Registration Link</label>
-            <input value={form.registrationLink || ''} onChange={e => set('registrationLink', e.target.value)} type="url" placeholder="https://..." />
-          </div>
+
           <div className="form-row">
             <label>Description *</label>
             <textarea value={form.description} onChange={e => set('description', e.target.value)} rows={3} required />
           </div>
+
+          <div className="form-row">
+            <label>Dynamic Gradient Colors</label>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 8, marginTop: 4 }}>
+              {form.gradientColors.map((color, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="color"
+                    value={color}
+                    onChange={e => updateGradientColor(i, e.target.value)}
+                    style={{ width: 36, height: 32, border: 'none', borderRadius: 6, cursor: 'pointer', padding: 0 }}
+                  />
+                  <input
+                    type="text"
+                    value={color}
+                    onChange={e => updateGradientColor(i, e.target.value)}
+                    style={{ flex: 1, padding: '6px 10px', borderRadius: 6, border: '1px solid var(--bdr)', background: 'var(--card)', color: 'var(--text)', fontSize: 13, fontFamily: 'monospace' }}
+                    placeholder="#hex"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeGradientColor(i)}
+                    style={{ padding: '6px 8px', borderRadius: 6, border: 'none', background: 'transparent', color: 'var(--danger, #ef4444)', cursor: 'pointer' }}
+                    aria-label="Remove color"
+                  >
+                    <AdminIcon name="Trash" size={14} />
+                  </button>
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addGradientColor}
+                style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                  padding: '8px 12px', borderRadius: 8, border: '1px dashed var(--bdr)',
+                  background: 'transparent', color: 'var(--t2)', cursor: 'pointer', fontSize: 13,
+                }}
+              >
+                + Add Color
+              </button>
+            </div>
+            {form.gradientColors.length > 0 && (
+              <div style={{ marginTop: 10 }}>
+                <div style={{ fontSize: 11, color: 'var(--t3)', marginBottom: 4 }}>Preview</div>
+                <div style={{
+                  height: 48, borderRadius: 10,
+                  background: gradientPreview,
+                  border: '1px solid var(--bdr)',
+                  boxShadow: `0 4px 20px ${form.gradientColors[0] || '#6b21a8'}33`,
+                  transition: 'all 0.3s',
+                }} />
+              </div>
+            )}
+          </div>
+
           {error && <div className="form-error">{error}</div>}
           <div className="form-actions">
             <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>

--- a/admin-dashboard/src/pages/EventsManager.jsx
+++ b/admin-dashboard/src/pages/EventsManager.jsx
@@ -103,7 +103,9 @@ export function EventsManager() {
                 <div>
                   <div className="item-name">{event.name}</div>
                   <div className="item-meta">
-                    {event.dateText} {event.location && `· ${event.location}`}
+                    {event.dateText}
+                    {event.category && <span style={{ marginLeft: 6, padding: '1px 6px', borderRadius: 8, background: 'var(--c2a)', color: 'var(--c2)', fontSize: '0.7rem', fontWeight: 600 }}>{event.category}</span>}
+                    {event.location && ` · ${event.location}`}
                   </div>
                 </div>
               </div>

--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -89,6 +89,11 @@ const getDb = (key, defaultVal) => {
           status: "completed",
           icon: "Brain",
           tags: ["AI", "Learning"],
+          category: "kss",
+          location: "Conference Hall",
+          capacity: 50,
+          hasDetailPage: true,
+          gradientColors: ["#6b21a8", "#7c3aed", "#a855f7"],
         },
         {
           id: "2",
@@ -99,6 +104,11 @@ const getDb = (key, defaultVal) => {
           status: "upcoming",
           icon: "Wrench",
           tags: ["Git", "GitHub"],
+          category: "workshop",
+          location: "Computer Lab",
+          capacity: 30,
+          hasDetailPage: true,
+          gradientColors: ["#0369a1", "#0ea5e9"],
         },
       ];
       setDb(key, initialEvents);

--- a/server-java/src/main/java/org/nexasphere/controller/EventsController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/EventsController.java
@@ -69,8 +69,34 @@ public class EventsController {
                 existing.setIcon(event.getIcon());
             }
 
+            existing.setHasDetailPage(event.isHasDetailPage());
+
+            if (event.getStartDate() != null) {
+                existing.setStartDate(event.getStartDate());
+            }
+
+            if (event.getEndDate() != null) {
+                existing.setEndDate(event.getEndDate());
+            }
+
+            if (event.getCategory() != null) {
+                existing.setCategory(event.getCategory());
+            }
+
+            if (event.getLocation() != null) {
+                existing.setLocation(event.getLocation());
+            }
+
+            if (event.getCapacity() != null) {
+                existing.setCapacity(event.getCapacity());
+            }
+
             if (event.getTags() != null && !event.getTags().isEmpty()) {
                 existing.setTags(event.getTags());
+            }
+
+            if (event.getGradientColors() != null) {
+                existing.setGradientColors(event.getGradientColors());
             }
 
             // save merged entity

--- a/server-java/src/main/java/org/nexasphere/model/entity/EventEntity.java
+++ b/server-java/src/main/java/org/nexasphere/model/entity/EventEntity.java
@@ -27,6 +27,12 @@ public class EventEntity {
     @Size(max = 60)
     private String shortName;
 
+    private boolean hasDetailPage = true;
+
+    private LocalDateTime startDate;
+
+    private LocalDateTime endDate;
+
     @NotBlank
     @Size(max = 120)
     private String dateText;
@@ -41,11 +47,24 @@ public class EventEntity {
 
     private String icon = "📌";
 
+    @Size(max = 40)
+    private String category;
+
+    @Size(max = 200)
+    private String location;
+
+    private Integer capacity;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "event_tags", joinColumns = @JoinColumn(name = "event_id"))
     @Column(name = "tags")
     @Size(max = 12)
     private List<@Size(max = 40) String> tags = new ArrayList<>();
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @CollectionTable(name = "event_gradients", joinColumns = @JoinColumn(name = "event_id"))
+    @Column(name = "color_hex")
+    private List<@Size(max = 9) String> gradientColors = new ArrayList<>();
 
     @CreationTimestamp
     private LocalDateTime createdAt;

--- a/server-java/src/main/java/org/nexasphere/service/crud/EventService.java
+++ b/server-java/src/main/java/org/nexasphere/service/crud/EventService.java
@@ -53,11 +53,18 @@ public class EventService {
 
         existing.setName(updates.getName());
         existing.setShortName(updates.getShortName());
+        existing.setHasDetailPage(updates.isHasDetailPage());
+        existing.setStartDate(updates.getStartDate());
+        existing.setEndDate(updates.getEndDate());
         existing.setDateText(updates.getDateText());
         existing.setDescription(updates.getDescription());
         existing.setStatus(updates.getStatus());
         existing.setIcon(updates.getIcon());
+        existing.setCategory(updates.getCategory());
+        existing.setLocation(updates.getLocation());
+        existing.setCapacity(updates.getCapacity());
         existing.setTags(updates.getTags());
+        existing.setGradientColors(updates.getGradientColors());
 
         EventEntity saved = repo.save(existing);
         publisher.publish(new EventUpdatedEvent(adminEmail, snapshot, Objects.requireNonNull(saved)));
@@ -76,6 +83,8 @@ public class EventService {
         e.setShortName(sanitizer.clean(e.getShortName()));
         e.setDateText(sanitizer.clean(e.getDateText()));
         e.setDescription(sanitizer.clean(e.getDescription()));
+        e.setCategory(sanitizer.clean(e.getCategory()));
+        e.setLocation(sanitizer.clean(e.getLocation()));
     }
 
     private EventEntity snapshot(EventEntity src) {
@@ -83,11 +92,18 @@ public class EventService {
         copy.setId(src.getId());
         copy.setName(src.getName());
         copy.setShortName(src.getShortName());
+        copy.setHasDetailPage(src.isHasDetailPage());
+        copy.setStartDate(src.getStartDate());
+        copy.setEndDate(src.getEndDate());
         copy.setDateText(src.getDateText());
         copy.setDescription(src.getDescription());
         copy.setStatus(src.getStatus());
         copy.setIcon(src.getIcon());
+        copy.setCategory(src.getCategory());
+        copy.setLocation(src.getLocation());
+        copy.setCapacity(src.getCapacity());
         copy.setTags(src.getTags() == null ? null : List.copyOf(src.getTags()));
+        copy.setGradientColors(src.getGradientColors() == null ? null : List.copyOf(src.getGradientColors()));
         return copy;
     }
 }

--- a/server-java/src/main/resources/db/migration/V3__Extend_Event_Metadata.sql
+++ b/server-java/src/main/resources/db/migration/V3__Extend_Event_Metadata.sql
@@ -1,0 +1,22 @@
+-- Flyway Migration: V3__Extend_Event_Metadata
+-- Description: Extend events table with KSS metadata fields and dynamic gradient colors
+-- Version: 1.0.2
+-- Date: 2026-05-30
+-- Author: NexaSphere Core Team
+
+-- Add KSS metadata columns to events table
+ALTER TABLE events ADD COLUMN IF NOT EXISTS has_detail_page boolean NOT NULL DEFAULT true;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS start_date timestamp;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS end_date timestamp;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS category varchar(40);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS location varchar(200);
+ALTER TABLE events ADD COLUMN IF NOT EXISTS capacity integer;
+
+-- Create event_gradients collection table for dynamic multi-color gradients
+CREATE TABLE IF NOT EXISTS event_gradients (
+  event_id text NOT NULL,
+  color_hex varchar(9),
+  CONSTRAINT fk_event_gradients_event FOREIGN KEY (event_id) REFERENCES events (id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_event_gradients_event ON event_gradients (event_id);

--- a/website/src/data/eventsData.js
+++ b/website/src/data/eventsData.js
@@ -15,10 +15,11 @@ export const events = [
       "NexaSphere's inaugural Knowledge Sharing Session — an interactive peer-to-peer learning event where members presented on the Impact of AI, fostering curiosity, collaboration, and community building.",
     status: 'completed',
     icon: 'Brain',
-    category: 'workshop',
+    category: 'kss',
     tags: ['AI', 'Learning', 'Community'],
     location: 'Conference Hall',
-    capacity: 50
+    capacity: 50,
+    gradientColors: ['#6b21a8', '#7c3aed', '#a855f7'],
   },
   {
     id: 2,
@@ -34,7 +35,8 @@ export const events = [
     category: 'workshop',
     tags: ['Git', 'GitHub', 'Workshop'],
     location: 'Computer Lab, CSE Block',
-    capacity: 30
+    capacity: 30,
+    gradientColors: ['#0369a1', '#0ea5e9', '#38bdf8'],
   },
   {
     id: 3,
@@ -49,7 +51,8 @@ export const events = [
     category: 'hackathon',
     tags: ['Hackathon', 'Coding', 'Innovation', 'Prizes'],
     location: 'Main Auditorium',
-    capacity: 100
+    capacity: 100,
+    gradientColors: ['#b91c1c', '#dc2626', '#f87171'],
   },
   {
     id: 4,
@@ -64,7 +67,8 @@ export const events = [
     category: 'debate',
     tags: ['Debate', 'AI', 'Critical Thinking'],
     location: 'Seminar Room 203',
-    capacity: 40
+    capacity: 40,
+    gradientColors: ['#a16207', '#ca8a04', '#facc15'],
   },
   {
     id: 5,
@@ -79,7 +83,8 @@ export const events = [
     category: 'opensource',
     tags: ['Open Source', 'Git', 'GitHub', 'First PR'],
     location: 'Computer Lab',
-    capacity: 35
+    capacity: 50,
+    gradientColors: ['#1e40af', '#3b82f6', '#93c5fd'],
   },
   {
     id: 6,
@@ -94,7 +99,8 @@ export const events = [
     category: 'workshop',
     tags: ['AI', 'Prompt Engineering', 'Generative AI'],
     location: 'Online (Zoom)',
-    capacity: 100
+    capacity: 100,
+    gradientColors: ['#7e22ce', '#9333ea', '#c084fc'],
   },
   {
     id: 7,

--- a/website/src/pages/events/EventsPage.jsx
+++ b/website/src/pages/events/EventsPage.jsx
@@ -14,6 +14,16 @@ export default function EventsPage({
   const [view, setView] = useState("timeline");
   const [recommendationView, setRecommendationView] = useState(false);
 
+  const buildGradient = (ev) => {
+    if (ev.gradientColors?.length > 1) {
+      return `linear-gradient(135deg, ${ev.gradientColors.join(', ')})`;
+    }
+    if (ev.gradientColors?.length === 1) {
+      return `linear-gradient(135deg, ${ev.gradientColors[0]}, ${ev.gradientColors[0]}88)`;
+    }
+    return null;
+  };
+
   const now = Date.now();
   const parseDate = (ev) => {
     const raw = ev.dateText ?? ev.date ?? "";
@@ -247,6 +257,8 @@ export default function EventsPage({
           <div className="events-timeline ns-reveal">
             {sortedEvents.map((ev, i) => {
               const hasDetailPage = !!ev.hasDetailPage;
+              const dynamicGradient = buildGradient(ev);
+              const glowColor = ev.gradientColors?.[0] || null;
               return (
                 <div className="timeline-item" key={ev.id}>
                   <div
@@ -256,33 +268,66 @@ export default function EventsPage({
                     className={`timeline-card shimmer ${i % 2 === 0 ? "pop-left" : "pop-right"}`}
                     style={{
                       animationDelay: `${i * 0.11}s`,
-                      /* cursor: pointer ensures touch/mobile devices get proper feedback
-                         even when the global custom cursor sets cursor:none on desktop */
                       cursor: hasDetailPage ? "pointer" : "default",
                       transition: "all .28s ease",
+                      ...(dynamicGradient ? {
+                        position: "relative",
+                        overflow: "hidden",
+                        borderColor: "transparent",
+                      } : {}),
                     }}
                     onClick={hasDetailPage ? () => onEventClick(ev) : undefined}
                     onMouseEnter={
                       hasDetailPage
                         ? (e) => {
-                            e.currentTarget.style.borderColor = "var(--c1b)";
-                            e.currentTarget.style.boxShadow =
-                              "0 6px 24px var(--c1g)";
-                            e.currentTarget.style.transform =
-                              "translateY(-3px)";
+                            e.currentTarget.style.borderColor = glowColor || "var(--c1b)";
+                            e.currentTarget.style.boxShadow = `0 6px 24px ${glowColor ? glowColor + "44" : "var(--c1g)"}`;
+                            e.currentTarget.style.transform = "translateY(-3px)";
                           }
                         : undefined
                     }
                     onMouseLeave={
                       hasDetailPage
                         ? (e) => {
-                            e.currentTarget.style.borderColor = "";
+                            e.currentTarget.style.borderColor = dynamicGradient ? "transparent" : "";
                             e.currentTarget.style.boxShadow = "";
                             e.currentTarget.style.transform = "";
                           }
                         : undefined
                     }
                   >
+                    {dynamicGradient && (
+                      <div
+                        aria-hidden="true"
+                        style={{
+                          position: "absolute",
+                          inset: 0,
+                          borderRadius: "inherit",
+                          padding: "1px",
+                          background: dynamicGradient,
+                          WebkitMask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+                          WebkitMaskComposite: "xor",
+                          maskComposite: "exclude",
+                          opacity: 0.6,
+                          pointerEvents: "none",
+                          transition: "opacity 0.3s",
+                        }}
+                      />
+                    )}
+                    {dynamicGradient && (
+                      <div
+                        aria-hidden="true"
+                        style={{
+                          position: "absolute",
+                          inset: -8,
+                          background: dynamicGradient,
+                          filter: "blur(16px)",
+                          opacity: 0.12,
+                          pointerEvents: "none",
+                          transition: "opacity 0.3s",
+                        }}
+                      />
+                    )}
                     <div
                       className="timeline-event-name"
                       style={{

--- a/website/src/pages/events/EventsSection.jsx
+++ b/website/src/pages/events/EventsSection.jsx
@@ -2,6 +2,16 @@ import { useEffect } from "react";
 import { DynamicIcon } from "../../shared/Icons";
 
 export default function EventsSection({ onEventClick, events = [] }) {
+  const buildGradient = (ev) => {
+    if (ev.gradientColors?.length > 1) {
+      return `linear-gradient(135deg, ${ev.gradientColors.join(', ')})`;
+    }
+    if (ev.gradientColors?.length === 1) {
+      return `linear-gradient(135deg, ${ev.gradientColors[0]}, ${ev.gradientColors[0]}88)`;
+    }
+    return null;
+  };
+
   useEffect(() => {
     const obs = new IntersectionObserver(
       (entries) => {
@@ -71,6 +81,8 @@ export default function EventsSection({ onEventClick, events = [] }) {
         <div className="events-timeline">
           {sortedEvents.map((ev, i) => {
             const hasDetailPage = !!ev.hasDetailPage;
+            const dynamicGradient = buildGradient(ev);
+            const glowColor = ev.gradientColors?.[0] || null;
             return (
               <div className="timeline-item" key={ev.id}>
                 <div
@@ -82,14 +94,18 @@ export default function EventsSection({ onEventClick, events = [] }) {
                     animationDelay: `${i * 0.11}s`,
                     cursor: hasDetailPage ? "pointer" : "default",
                     transition: "all .28s ease",
+                    ...(dynamicGradient ? {
+                      position: "relative",
+                      overflow: "hidden",
+                      borderColor: "transparent",
+                    } : {}),
                   }}
                   onClick={hasDetailPage ? () => onEventClick?.(ev) : undefined}
                   onMouseEnter={
                     hasDetailPage
                       ? (e) => {
-                          e.currentTarget.style.borderColor = "var(--c1b)";
-                          e.currentTarget.style.boxShadow =
-                            "0 6px 24px var(--c1g)";
+                          e.currentTarget.style.borderColor = glowColor || "var(--c1b)";
+                          e.currentTarget.style.boxShadow = `0 6px 24px ${glowColor ? glowColor + "44" : "var(--c1g)"}`;
                           e.currentTarget.style.transform = "translateY(-3px)";
                         }
                       : undefined
@@ -97,13 +113,45 @@ export default function EventsSection({ onEventClick, events = [] }) {
                   onMouseLeave={
                     hasDetailPage
                       ? (e) => {
-                          e.currentTarget.style.borderColor = "";
+                          e.currentTarget.style.borderColor = dynamicGradient ? "transparent" : "";
                           e.currentTarget.style.boxShadow = "";
                           e.currentTarget.style.transform = "";
                         }
                       : undefined
                   }
                 >
+                  {dynamicGradient && (
+                    <div
+                      aria-hidden="true"
+                      style={{
+                        position: "absolute",
+                        inset: 0,
+                        borderRadius: "inherit",
+                        padding: "1px",
+                        background: dynamicGradient,
+                        WebkitMask: "linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)",
+                        WebkitMaskComposite: "xor",
+                        maskComposite: "exclude",
+                        opacity: 0.6,
+                        pointerEvents: "none",
+                        transition: "opacity 0.3s",
+                      }}
+                    />
+                  )}
+                  {dynamicGradient && (
+                    <div
+                      aria-hidden="true"
+                      style={{
+                        position: "absolute",
+                        inset: -8,
+                        background: dynamicGradient,
+                        filter: "blur(16px)",
+                        opacity: 0.12,
+                        pointerEvents: "none",
+                        transition: "opacity 0.3s",
+                      }}
+                    />
+                  )}
                   <div
                     className="timeline-event-name"
                     style={{


### PR DESCRIPTION
## Description

Events and Activities were completely disconnected in the Admin Dashboard. Creating an event had no way to associate it with an activity category (KSS, Workshop, Hackathon, etc.), and the event form lacked essential KSS metadata fields like exact start/end datetimes, location, capacity, icon picker, and a detail page toggle. Public website event cards used static CSS gradients with no admin-controlled theming.

## Root cause

The `EventEntity` Java model only stored basic fields (name, dateText, description, status, icon, tags). There were no columns for `category`, `startDate`, `endDate`, `location`, `capacity`, `hasDetailPage`, or `gradientColors`. The admin `EventForm` component correspondingly only rendered inputs for the existing minimal fields. The website `EventsPage` and `EventsSection` components had no gradient data to consume, so cards always used the same static theme colors.

## What changed

- **`server-java/.../EventEntity.java`**: Added `hasDetailPage`, `startDate`, `endDate`, `category`, `location`, `capacity`, and `gradientColors` fields with proper JPA annotations and validation constraints
- **`server-java/.../V3__Extend_Event_Metadata.sql`**: New Flyway migration adding the columns to the `events` table and creating the `event_gradients` collection table
- **`server-java/.../EventsController.java`**: Updated PUT handler to merge all new fields on update
- **`server-java/.../EventService.java`**: Updated `updateEvent`, `snapshot`, and `sanitize` methods to handle new fields
- **`admin-dashboard/src/components/EventForm.jsx`**: Added Activity Category dropdown, datetime-local pickers for start/end, location/capacity inputs, visual icon picker grid, has-detail-page toggle, and interactive multi-color gradient builder with live preview
- **`admin-dashboard/src/pages/EventsManager.jsx`**: Displays category badge and location in event list items
- **`website/src/pages/events/EventsPage.jsx`**: Compiles `gradientColors` into inline `linear-gradient` border overlay and ambient blur glow on event cards
- **`website/src/pages/events/EventsSection.jsx`**: Same dynamic gradient treatment for the homepage events section
- **`website/src/data/eventsData.js`**: Added `gradientColors` to all fallback events for offline/SSG rendering
- **`admin-dashboard/src/services/api.js`**: Updated offline seed data to include new fields

## How to verify

1. Start the Java backend (`server-java`) and run `mvn flyway:migrate` or let Spring Boot auto-migrate — confirm `V3__Extend_Event_Metadata.sql` runs successfully
2. Open the Admin Dashboard, navigate to Events, click **+ Add Event**
3. Verify the form shows: Activity Category dropdown, start/end datetime pickers, location, capacity, icon picker grid, has-detail-page toggle, and gradient color builder
4. Create an event with 2+ gradient colors — confirm the preview bar updates live
5. Open the public website Events page — confirm the event card renders with the custom gradient border and glow shadow
6. Edit the event from the admin — confirm all new fields persist and update correctly

## Edge cases considered

- Events with no `gradientColors` fall back to the default theme variables (no visual regression)
- Single gradient color renders a monochrome fade variant instead of a sharp transition
- `capacity` accepts null/empty gracefully (maps to `null` in Java, ignored in UI)
- `hasDetailPage` defaults to `true` for backward compatibility with existing events
- Category is optional — events without a category display normally without a badge

## Checklist

- [x] Java entity updated with new fields and JPA annotations
- [x] Flyway migration created for database schema changes
- [x] REST controller handles new fields in create and update
- [x] Admin form collects all KSS metadata fields
- [x] Dynamic gradient picker with live preview
- [x] Website cards render dynamic gradient borders and glow
- [x] Fallback data updated for offline mode
- [x] Build passes with `npm run build`

Closes #672