### PR TITLE
feat: add certificate management system with templates, issuance, and verification

### DIFF
--- a/admin-dashboard/src/pages/CertificateManager.jsx
+++ b/admin-dashboard/src/pages/CertificateManager.jsx
@@ -1,68 +1,941 @@
 /**
  * CertificateManager — Admin Dashboard page
  *
- * Allows admins to generate bulk certificates for completed events.
- * Isolated new page — does not modify EventsManager or other managers.
- *
- * Features:
- * - Input event details (ID, name, date)
- * - Bulk student list (CSV-style: one "ID,Name" per line)
- * - Template style selector
- * - Progress and result feedback
- * - Links to generated verification URLs
- * - Copy-to-clipboard for individual verify links
+ * Full-featured certificate management system with 3 tabs:
+ * 1. Template Builder — create/edit HTML/CSS or image overlay templates
+ * 2. Issue Certificate — select event, fetch participants, bulk generate
+ * 3. Issued Logs — search, view, revoke issued certificates
  */
 
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { api } from '../services/api';
 
-const API_BASE = import.meta?.env?.VITE_PYTHON_API_BASE?.replace(/\/+$/, '') || 'http://localhost:8000';
-const ADMIN_SECRET = import.meta?.env?.VITE_ADMIN_SECRET || 'nexasphere-admin-secret';
+const TABS = [
+  { key: 'templates', label: 'Template Builder', icon: '🎨' },
+  { key: 'issue', label: 'Issue Certificate', icon: '🎓' },
+  { key: 'logs', label: 'Issued Logs', icon: '📋' },
+];
 
-function parseStudents(rawText) {
-  return rawText
-    .split('\n')
-    .map(line => line.trim())
-    .filter(Boolean)
-    .map((line, idx) => {
-      const parts = line.split(',').map(p => p.trim());
-      return {
-        student_id: parts[0] || `student-${idx + 1}`,
-        student_name: parts.slice(1).join(' ').trim() || parts[0] || `Student ${idx + 1}`,
+const DEFAULT_TEMPLATES = [
+  {
+    id: 'default',
+    name: 'Default (Red)',
+    type: 'PRESET',
+    gradient: 'linear-gradient(135deg, #CC1111, #880000)',
+  },
+  {
+    id: 'gold',
+    name: 'Gold',
+    type: 'PRESET',
+    gradient: 'linear-gradient(135deg, #f59e0b, #b45309)',
+  },
+  {
+    id: 'silver',
+    name: 'Silver',
+    type: 'PRESET',
+    gradient: 'linear-gradient(135deg, #94a3b8, #475569)',
+  },
+];
+
+// ── Shared styles ───────────────────────────────────────────────────────
+
+const tabBtn = (active) => ({
+  background: active ? 'rgba(204,17,17,0.15)' : 'transparent',
+  border: `1px solid ${active ? 'rgba(204,17,17,0.4)' : 'rgba(255,255,255,0.08)'}`,
+  color: active ? '#fff' : 'rgba(255,255,255,0.6)',
+  borderRadius: '10px',
+  padding: '10px 20px',
+  cursor: 'pointer',
+  fontSize: '0.82rem',
+  fontWeight: active ? 700 : 500,
+  transition: 'all 0.2s',
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  fontFamily: "'Rajdhani', sans-serif",
+});
+
+const inputStyle = {
+  width: '100%',
+  padding: '10px 14px',
+  background: 'rgba(255,255,255,0.04)',
+  border: '1px solid rgba(255,255,255,0.1)',
+  borderRadius: '8px',
+  color: '#fff',
+  fontSize: '0.85rem',
+  fontFamily: "'Inter', sans-serif",
+  outline: 'none',
+  transition: 'border 0.2s',
+};
+
+const sectionTitle = {
+  fontSize: '0.75rem',
+  fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  opacity: 0.5,
+  marginBottom: '14px',
+};
+
+// ── Template Builder Tab ────────────────────────────────────────────────
+
+function TemplateBuilder({ onNotify }) {
+  const [templates, setTemplates] = useState([]);
+  const [selectedTemplate, setSelectedTemplate] = useState(null);
+  const [name, setName] = useState('');
+  const [type, setType] = useState('HTML_CSS');
+  const [content, setContent] = useState('');
+  const [placeholdersJson, setPlaceholdersJson] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [previewBg, setPreviewBg] = useState('');
+  const [previewCoords, setPreviewCoords] = useState({
+    nameX: 50,
+    nameY: 45,
+    eventX: 50,
+    eventY: 55,
+    dateX: 50,
+    dateY: 65,
+  });
+
+  const loadTemplates = useCallback(async () => {
+    try {
+      const data = await api.certificates.getTemplates();
+      setTemplates(data?.templates || []);
+    } catch {
+      /* offline */
+    }
+  }, []);
+
+  useEffect(() => {
+    loadTemplates();
+  }, [loadTemplates]);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      onNotify('error', 'Template name is required');
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: name.trim(),
+        type,
+        content,
+        placeholdersJson: JSON.stringify(previewCoords),
       };
-    });
+      if (selectedTemplate?.id) {
+        await api.certificates.updateTemplate(selectedTemplate.id, payload);
+      } else {
+        await api.certificates.createTemplate(payload);
+      }
+      loadTemplates();
+      onNotify('success', 'Template saved');
+      setName('');
+      setContent('');
+      setSelectedTemplate(null);
+    } catch (e) {
+      onNotify('error', e.message || 'Failed to save template');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm('Delete this template?')) return;
+    try {
+      await api.certificates.deleteTemplate(id);
+      loadTemplates();
+    } catch {
+      /* */
+    }
+  };
+
+  const handleSelectPreset = (preset) => {
+    setSelectedTemplate(preset);
+    setPreviewBg(preset.gradient);
+    setType('PRESET');
+    setName(preset.name);
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '28px' }}>
+      {/* Left: Editor */}
+      <div>
+        <div style={sectionTitle}>Template Name</div>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Gold Achievement Certificate"
+          style={inputStyle}
+        />
+
+        <div style={{ ...sectionTitle, marginTop: '20px' }}>Template Type</div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+          {['HTML_CSS', 'IMAGE_OVERLAY'].map((t) => (
+            <button
+              key={t}
+              onClick={() => setType(t)}
+              style={{
+                ...tabBtn(type === t),
+                padding: '8px 14px',
+                fontSize: '0.78rem',
+              }}
+            >
+              {t === 'HTML_CSS' ? 'HTML/CSS' : 'Image Overlay'}
+            </button>
+          ))}
+        </div>
+
+        {type === 'HTML_CSS' ? (
+          <>
+            <div style={sectionTitle}>HTML/CSS Content</div>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={12}
+              placeholder={
+                '<div class="cert">\n  <h1>{{student_name}}</h1>\n  <p>{{event_name}}</p>\n  <p>{{issue_date}}</p>\n</div>'
+              }
+              style={{
+                ...inputStyle,
+                fontFamily: "'Fira Code', monospace",
+                fontSize: '0.8rem',
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ fontSize: '0.72rem', opacity: 0.4, marginTop: '6px' }}>
+              Placeholders: {'{{student_name}}'}, {'{{event_name}}'}, {'{{certificate_id}}'},{' '}
+              {'{{issue_date}}'}
+            </div>
+          </>
+        ) : (
+          <>
+            <div style={sectionTitle}>Background Image URL</div>
+            <input
+              value={previewBg}
+              onChange={(e) => setPreviewBg(e.target.value)}
+              placeholder="https://example.com/certificate-bg.jpg"
+              style={inputStyle}
+            />
+            <div style={{ ...sectionTitle, marginTop: '16px' }}>Text Placement (percentages)</div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: '8px' }}>
+              {[
+                { label: 'Name X', key: 'nameX' },
+                { label: 'Name Y', key: 'nameY' },
+                { label: 'Event X', key: 'eventX' },
+                { label: 'Event Y', key: 'eventY' },
+                { label: 'Date X', key: 'dateX' },
+                { label: 'Date Y', key: 'dateY' },
+              ].map(({ label, key }) => (
+                <div key={key}>
+                  <label style={{ fontSize: '0.7rem', opacity: 0.5 }}>{label}</label>
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={previewCoords[key]}
+                    onChange={(e) => setPreviewCoords((p) => ({ ...p, [key]: +e.target.value }))}
+                    style={{ ...inputStyle, padding: '6px 8px', fontSize: '0.8rem' }}
+                  />
+                </div>
+              ))}
+            </div>
+          </>
+        )}
+
+        <div style={{ display: 'flex', gap: '10px', marginTop: '20px' }}>
+          <button
+            className="btn-primary"
+            onClick={handleSave}
+            disabled={saving}
+            style={{ opacity: saving ? 0.6 : 1 }}
+          >
+            {saving ? 'Saving…' : '💾 Save Template'}
+          </button>
+          {selectedTemplate?.id && (
+            <button
+              onClick={() => {
+                setSelectedTemplate(null);
+                setName('');
+                setContent('');
+              }}
+              style={{ ...tabBtn(false), padding: '8px 16px' }}
+            >
+              Cancel Edit
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Right: Preview + Presets */}
+      <div>
+        <div style={sectionTitle}>Live Preview</div>
+        <div
+          style={{
+            background: previewBg || 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.1)',
+            borderRadius: '12px',
+            padding: '40px 32px',
+            minHeight: '260px',
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            textAlign: 'center',
+            position: 'relative',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "'Orbitron', monospace",
+              fontSize: '1.2rem',
+              fontWeight: 900,
+              color: '#fff',
+              marginBottom: '8px',
+            }}
+          >
+            Student Name
+          </div>
+          <div style={{ fontSize: '0.85rem', color: 'rgba(255,255,255,0.7)', marginBottom: '4px' }}>
+            Knowledge Sharing Session #153
+          </div>
+          <div style={{ fontSize: '0.75rem', color: 'rgba(255,255,255,0.5)' }}>
+            NS-CERT-XXXXXXXXXXXX
+          </div>
+          <div style={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.3)', marginTop: '12px' }}>
+            March 15, 2025
+          </div>
+        </div>
+
+        <div style={{ ...sectionTitle, marginTop: '24px' }}>Preset Templates</div>
+        <div style={{ display: 'flex', gap: '10px', flexWrap: 'wrap' }}>
+          {DEFAULT_TEMPLATES.map((preset) => (
+            <button
+              key={preset.id}
+              onClick={() => handleSelectPreset(preset)}
+              style={{
+                background: preset.gradient,
+                border:
+                  selectedTemplate?.id === preset.id
+                    ? '2px solid #fff'
+                    : '1px solid rgba(255,255,255,0.15)',
+                borderRadius: '10px',
+                padding: '12px 18px',
+                color: '#fff',
+                cursor: 'pointer',
+                fontSize: '0.8rem',
+                fontWeight: 600,
+                transition: 'all 0.2s',
+              }}
+            >
+              {preset.name}
+            </button>
+          ))}
+        </div>
+
+        <div style={{ ...sectionTitle, marginTop: '24px' }}>Saved Templates</div>
+        {templates.length === 0 ? (
+          <div style={{ fontSize: '0.8rem', opacity: 0.4 }}>No custom templates saved yet.</div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {templates.map((t) => (
+              <div
+                key={t.id}
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  padding: '10px 14px',
+                  background: 'rgba(255,255,255,0.03)',
+                  borderRadius: '8px',
+                  border: '1px solid rgba(255,255,255,0.06)',
+                }}
+              >
+                <div>
+                  <div style={{ fontWeight: 600, color: '#fff', fontSize: '0.85rem' }}>
+                    {t.name}
+                  </div>
+                  <div style={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.4)' }}>
+                    {t.type}
+                  </div>
+                </div>
+                <div style={{ display: 'flex', gap: '6px' }}>
+                  <button
+                    onClick={() => {
+                      setSelectedTemplate(t);
+                      setName(t.name);
+                      setType(t.type);
+                      setContent(t.content || '');
+                    }}
+                    style={{ ...tabBtn(false), padding: '4px 10px', fontSize: '0.72rem' }}
+                  >
+                    Edit
+                  </button>
+                  <button
+                    onClick={() => handleDelete(t.id)}
+                    style={{
+                      ...tabBtn(false),
+                      padding: '4px 10px',
+                      fontSize: '0.72rem',
+                      color: '#ef4444',
+                    }}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
+
+// ── Issue Certificate Tab ───────────────────────────────────────────────
+
+function IssueCertificate({ onNotify }) {
+  const [events, setEvents] = useState([]);
+  const [selectedEvent, setSelectedEvent] = useState(null);
+  const [participants, setParticipants] = useState([]);
+  const [selectedIds, setSelectedIds] = useState(new Set());
+  const [templateStyle, setTemplateStyle] = useState('default');
+  const [manualName, setManualName] = useState('');
+  const [manualEmail, setManualEmail] = useState('');
+  const [manualRoll, setManualRoll] = useState('');
+  const [source, setSource] = useState('event');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState(null);
+
+  useEffect(() => {
+    api.events
+      .getAll()
+      .then((data) => setEvents(data?.events || []))
+      .catch(() => {});
+  }, []);
+
+  const fetchParticipants = async (eventId) => {
+    setSelectedEvent(eventId);
+    setParticipants([]);
+    setSelectedIds(new Set());
+    try {
+      const data = await api.certificates.getParticipants(eventId);
+      setParticipants(data?.participants || []);
+    } catch {
+      /* */
+    }
+  };
+
+  const toggleSelect = (id) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const toggleAll = () => {
+    if (selectedIds.size === participants.length) {
+      setSelectedIds(new Set());
+    } else {
+      setSelectedIds(new Set(participants.map((p) => p.id)));
+    }
+  };
+
+  const handleGenerate = async () => {
+    setLoading(true);
+    setResult(null);
+    try {
+      const ev = events.find((e) => e.id === selectedEvent);
+      let students;
+
+      if (source === 'event') {
+        const attended = participants.filter((p) => selectedIds.has(p.id));
+        students = attended.map((p) => ({
+          name: p.fullName,
+          email: p.email,
+          rollNumber: p.rollNumber,
+        }));
+      } else {
+        if (!manualName.trim() || !manualEmail.trim()) {
+          onNotify('error', 'Name and email are required');
+          setLoading(false);
+          return;
+        }
+        students = [
+          { name: manualName.trim(), email: manualEmail.trim(), rollNumber: manualRoll.trim() },
+        ];
+      }
+
+      if (students.length === 0) {
+        onNotify('error', 'No students selected');
+        setLoading(false);
+        return;
+      }
+
+      const data = await api.certificates.generate({
+        eventId: selectedEvent,
+        eventName: ev?.name || selectedEvent,
+        templateStyle,
+        students,
+      });
+      setResult(data);
+      onNotify('success', `Generated ${data.generated} certificate(s)`);
+    } catch (e) {
+      onNotify('error', e.message || 'Generation failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={{ maxWidth: '800px' }}>
+      {/* Event selector */}
+      <div style={sectionTitle}>Select Event</div>
+      <select
+        value={selectedEvent || ''}
+        onChange={(e) => fetchParticipants(e.target.value)}
+        style={{ ...inputStyle, width: '300px', marginBottom: '20px' }}
+      >
+        <option value="">Choose an event…</option>
+        {events.map((ev) => (
+          <option key={ev.id} value={ev.id}>
+            {ev.name} ({ev.status})
+          </option>
+        ))}
+      </select>
+
+      {/* Source toggle */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '16px' }}>
+        {[
+          { k: 'event', l: 'From Event Participants' },
+          { k: 'manual', l: 'Manual Entry' },
+        ].map((s) => (
+          <button key={s.k} onClick={() => setSource(s.k)} style={tabBtn(source === s.k)}>
+            {s.l}
+          </button>
+        ))}
+      </div>
+
+      {/* Template style */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '20px' }}>
+        {['default', 'gold', 'silver'].map((s) => (
+          <button key={s} onClick={() => setTemplateStyle(s)} style={tabBtn(templateStyle === s)}>
+            {s.charAt(0).toUpperCase() + s.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {source === 'event' ? (
+        <>
+          {participants.length > 0 && (
+            <>
+              <div
+                style={{
+                  display: 'flex',
+                  justifyContent: 'space-between',
+                  alignItems: 'center',
+                  marginBottom: '12px',
+                }}
+              >
+                <div style={{ fontSize: '0.82rem', color: 'rgba(255,255,255,0.6)' }}>
+                  {selectedIds.size} of {participants.length} selected
+                </div>
+                <button
+                  onClick={toggleAll}
+                  style={{ ...tabBtn(false), padding: '4px 12px', fontSize: '0.75rem' }}
+                >
+                  {selectedIds.size === participants.length ? 'Deselect All' : 'Select All'}
+                </button>
+              </div>
+              <div
+                style={{
+                  maxHeight: '300px',
+                  overflowY: 'auto',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  gap: '4px',
+                }}
+              >
+                {participants.map((p) => (
+                  <label
+                    key={p.id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '12px',
+                      padding: '10px 14px',
+                      background: selectedIds.has(p.id)
+                        ? 'rgba(34,197,94,0.06)'
+                        : 'rgba(255,255,255,0.02)',
+                      border: `1px solid ${selectedIds.has(p.id) ? 'rgba(34,197,94,0.25)' : 'rgba(255,255,255,0.06)'}`,
+                      borderRadius: '8px',
+                      cursor: 'pointer',
+                      fontSize: '0.85rem',
+                      transition: 'all 0.15s',
+                    }}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedIds.has(p.id)}
+                      onChange={() => toggleSelect(p.id)}
+                      style={{ accentColor: '#22c55e' }}
+                    />
+                    <div>
+                      <div style={{ fontWeight: 600, color: '#fff' }}>{p.fullName}</div>
+                      <div style={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.4)' }}>
+                        {p.email} · {p.rollNumber}
+                      </div>
+                    </div>
+                    <div
+                      style={{
+                        marginLeft: 'auto',
+                        fontSize: '0.7rem',
+                        color: 'rgba(255,255,255,0.3)',
+                      }}
+                    >
+                      {p.status}
+                    </div>
+                  </label>
+                ))}
+              </div>
+            </>
+          )}
+          {selectedEvent && participants.length === 0 && (
+            <div style={{ fontSize: '0.82rem', opacity: 0.5, padding: '20px 0' }}>
+              No participants found for this event. Add participants via the Participants API or use
+              Manual Entry.
+            </div>
+          )}
+        </>
+      ) : (
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: '1fr 1fr 1fr',
+            gap: '12px',
+            marginBottom: '20px',
+          }}
+        >
+          <div>
+            <label
+              style={{ display: 'block', fontSize: '0.75rem', opacity: 0.5, marginBottom: '4px' }}
+            >
+              Student Name *
+            </label>
+            <input
+              value={manualName}
+              onChange={(e) => setManualName(e.target.value)}
+              placeholder="Full Name"
+              style={inputStyle}
+            />
+          </div>
+          <div>
+            <label
+              style={{ display: 'block', fontSize: '0.75rem', opacity: 0.5, marginBottom: '4px' }}
+            >
+              Email *
+            </label>
+            <input
+              value={manualEmail}
+              onChange={(e) => setManualEmail(e.target.value)}
+              placeholder="student@example.com"
+              style={inputStyle}
+            />
+          </div>
+          <div>
+            <label
+              style={{ display: 'block', fontSize: '0.75rem', opacity: 0.5, marginBottom: '4px' }}
+            >
+              Roll Number
+            </label>
+            <input
+              value={manualRoll}
+              onChange={(e) => setManualRoll(e.target.value)}
+              placeholder="STU001"
+              style={inputStyle}
+            />
+          </div>
+        </div>
+      )}
+
+      <button
+        className="btn-primary"
+        onClick={handleGenerate}
+        disabled={loading || !selectedEvent}
+        style={{ opacity: loading || !selectedEvent ? 0.5 : 1, marginTop: '12px' }}
+      >
+        {loading ? 'Generating…' : '🎓 Generate Certificate(s)'}
+      </button>
+
+      {/* Results */}
+      {result && (
+        <div style={{ marginTop: '24px' }}>
+          <div
+            style={{
+              background: 'rgba(34,197,94,0.06)',
+              border: '1px solid rgba(34,197,94,0.2)',
+              borderRadius: '10px',
+              padding: '14px 18px',
+              display: 'flex',
+              gap: '24px',
+              fontSize: '0.85rem',
+            }}
+          >
+            <span style={{ color: '#22c55e', fontWeight: 700 }}>
+              ✓ Generated: {result.generated}
+            </span>
+            {result.skipped > 0 && (
+              <span style={{ color: 'rgba(255,255,255,0.6)' }}>⟳ Skipped: {result.skipped}</span>
+            )}
+          </div>
+          {result.certificates?.map((c) => (
+            <CertRow key={c.certificate_id} cert={c} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Issued Logs Tab ─────────────────────────────────────────────────────
+
+function IssuedLogs({ onNotify }) {
+  const [certificates, setCertificates] = useState([]);
+  const [search, setSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  const loadCerts = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await api.certificates.getAll();
+      setCertificates(data?.certificates || []);
+    } catch {
+      /* */
+    }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadCerts();
+  }, [loadCerts]);
+
+  const filtered = certificates.filter((c) => {
+    const q = search.toLowerCase();
+    return (
+      !q ||
+      c.studentName?.toLowerCase().includes(q) ||
+      c.studentEmail?.toLowerCase().includes(q) ||
+      c.studentRollNumber?.toLowerCase().includes(q) ||
+      c.eventName?.toLowerCase().includes(q) ||
+      c.certificateId?.toLowerCase().includes(q)
+    );
+  });
+
+  const handleRevoke = async (id) => {
+    if (!confirm('Revoke this certificate?')) return;
+    try {
+      await api.certificates.revoke(id);
+      loadCerts();
+    } catch {
+      /* */
+    }
+  };
+
+  return (
+    <div>
+      <div style={{ marginBottom: '16px' }}>
+        <input
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name, email, roll number, event, or cert ID…"
+          style={{ ...inputStyle, maxWidth: '400px' }}
+        />
+      </div>
+
+      {loading ? (
+        <div style={{ padding: '40px', textAlign: 'center', opacity: 0.5 }}>Loading…</div>
+      ) : filtered.length === 0 ? (
+        <div style={{ padding: '40px', textAlign: 'center', opacity: 0.4 }}>
+          No certificates found.
+        </div>
+      ) : (
+        <div style={{ overflowX: 'auto' }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.82rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.1)' }}>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '10px 12px',
+                    color: 'rgba(255,255,255,0.5)',
+                    fontWeight: 600,
+                  }}
+                >
+                  Certificate ID
+                </th>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '10px 12px',
+                    color: 'rgba(255,255,255,0.5)',
+                    fontWeight: 600,
+                  }}
+                >
+                  Student
+                </th>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '10px 12px',
+                    color: 'rgba(255,255,255,0.5)',
+                    fontWeight: 600,
+                  }}
+                >
+                  Event
+                </th>
+                <th
+                  style={{
+                    textAlign: 'left',
+                    padding: '10px 12px',
+                    color: 'rgba(255,255,255,0.5)',
+                    fontWeight: 600,
+                  }}
+                >
+                  Status
+                </th>
+                <th
+                  style={{
+                    textAlign: 'right',
+                    padding: '10px 12px',
+                    color: 'rgba(255,255,255,0.5)',
+                    fontWeight: 600,
+                  }}
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {filtered.map((c) => (
+                <tr
+                  key={c.certificateId}
+                  style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}
+                >
+                  <td
+                    style={{
+                      padding: '10px 12px',
+                      fontFamily: 'monospace',
+                      color: 'rgba(255,255,255,0.7)',
+                      fontSize: '0.75rem',
+                    }}
+                  >
+                    {c.certificateId}
+                  </td>
+                  <td style={{ padding: '10px 12px' }}>
+                    <div style={{ fontWeight: 600, color: '#fff' }}>{c.studentName}</div>
+                    <div style={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.4)' }}>
+                      {c.studentEmail}
+                    </div>
+                  </td>
+                  <td style={{ padding: '10px 12px', color: 'rgba(255,255,255,0.7)' }}>
+                    {c.eventName}
+                  </td>
+                  <td style={{ padding: '10px 12px' }}>
+                    <span
+                      style={{
+                        display: 'inline-block',
+                        padding: '2px 10px',
+                        borderRadius: '20px',
+                        fontSize: '0.72rem',
+                        fontWeight: 600,
+                        background: c.revoked ? 'rgba(239,68,68,0.12)' : 'rgba(34,197,94,0.1)',
+                        color: c.revoked ? '#ef4444' : '#22c55e',
+                        border: `1px solid ${c.revoked ? 'rgba(239,68,68,0.3)' : 'rgba(34,197,94,0.2)'}`,
+                      }}
+                    >
+                      {c.revoked ? 'Revoked' : 'Active'}
+                    </span>
+                  </td>
+                  <td style={{ padding: '10px 12px', textAlign: 'right' }}>
+                    <div style={{ display: 'flex', gap: '6px', justifyContent: 'flex-end' }}>
+                      <a
+                        href={`/verify/${c.certificateId}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        style={{
+                          ...tabBtn(false),
+                          padding: '4px 10px',
+                          fontSize: '0.72rem',
+                          textDecoration: 'none',
+                        }}
+                      >
+                        Verify
+                      </a>
+                      {!c.revoked && (
+                        <button
+                          onClick={() => handleRevoke(c.certificateId)}
+                          style={{
+                            ...tabBtn(false),
+                            padding: '4px 10px',
+                            fontSize: '0.72rem',
+                            color: '#ef4444',
+                          }}
+                        >
+                          Revoke
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── CertRow helper ──────────────────────────────────────────────────────
 
 function CertRow({ cert }) {
   const [copied, setCopied] = useState(false);
+  const verifyUrl = `${window.location.origin}/verify/${cert.certificate_id}`;
 
   const copyLink = () => {
-    navigator.clipboard.writeText(cert.verification_url).then(() => {
+    navigator.clipboard.writeText(verifyUrl).then(() => {
       setCopied(true);
       setTimeout(() => setCopied(false), 1800);
     });
   };
 
   return (
-    <div style={{
-      display: 'grid',
-      gridTemplateColumns: '1fr 1fr auto',
-      gap: '12px',
-      alignItems: 'center',
-      padding: '10px 14px',
-      background: 'rgba(34,197,94,0.04)',
-      borderRadius: '8px',
-      border: '1px solid rgba(34,197,94,0.12)',
-      marginBottom: '6px',
-      fontSize: '0.85rem',
-    }}>
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: '1fr 1fr auto',
+        gap: '12px',
+        alignItems: 'center',
+        padding: '10px 14px',
+        background: 'rgba(34,197,94,0.04)',
+        borderRadius: '8px',
+        border: '1px solid rgba(34,197,94,0.12)',
+        marginBottom: '6px',
+        fontSize: '0.85rem',
+      }}
+    >
       <div>
         <div style={{ fontWeight: 600, color: '#fff' }}>{cert.student_name}</div>
-        <div style={{ color: 'rgba(255,255,255,0.72)', fontSize: '0.72rem', fontFamily: 'monospace' }}>
+        <div
+          style={{ color: 'rgba(255,255,255,0.72)', fontSize: '0.72rem', fontFamily: 'monospace' }}
+        >
           {cert.certificate_id}
         </div>
       </div>
       <div style={{ color: 'rgba(255,255,255,0.72)', fontSize: '0.78rem', wordBreak: 'break-all' }}>
-        {cert.verification_url}
+        {verifyUrl}
       </div>
       <button
         onClick={copyLink}
@@ -85,213 +958,63 @@ function CertRow({ cert }) {
   );
 }
 
+// ── Main Component ──────────────────────────────────────────────────────
+
 export function CertificateManager() {
-  const [eventId, setEventId] = useState('');
-  const [eventName, setEventName] = useState('');
-  const [eventDate, setEventDate] = useState('');
-  const [studentsRaw, setStudentsRaw] = useState('');
-  const [templateStyle, setTemplateStyle] = useState('default');
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState('');
-  const [result, setResult] = useState(null);
+  const [activeTab, setActiveTab] = useState('templates');
+  const [notif, setNotif] = useState(null);
 
-  const handleGenerate = async () => {
-    setError('');
-    setResult(null);
-
-    if (!eventId.trim() || !eventName.trim() || !eventDate.trim()) {
-      setError('Please fill in all event fields.');
-      return;
-    }
-
-    const students = parseStudents(studentsRaw);
-    if (students.length === 0) {
-      setError('Please enter at least one student.');
-      return;
-    }
-
-    setLoading(true);
-    try {
-      const res = await fetch(`${API_BASE}/certificates/generate`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Admin-Secret': ADMIN_SECRET,
-        },
-        body: JSON.stringify({
-          event_id: eventId.trim(),
-          event_name: eventName.trim(),
-          event_date: eventDate.trim(),
-          students,
-          template_style: templateStyle,
-        }),
-      });
-
-      if (!res.ok) {
-        const err = await res.json().catch(() => ({}));
-        throw new Error(err.detail || `Server error: ${res.status}`);
-      }
-
-      const data = await res.json();
-      setResult(data);
-    } catch (e) {
-      setError(e.message || 'Failed to generate certificates. Check backend connection.');
-    } finally {
-      setLoading(false);
-    }
+  const onNotify = (type, message) => {
+    setNotif({ type, message });
+    setTimeout(() => setNotif(null), 3000);
   };
 
   return (
     <div className="page">
       <div className="page-header">
-        <h2 className="page-title">Certificate Generator</h2>
+        <h2 className="page-title">Certificate Manager</h2>
       </div>
 
-      <div style={{ maxWidth: '760px' }}>
-        {/* Event Details */}
-        <section style={{ marginBottom: '28px' }}>
-          <h3 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '14px', textTransform: 'uppercase', letterSpacing: '0.06em', opacity: 0.6 }}>
-            Event Details
-          </h3>
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px', marginBottom: '12px' }}>
-            <div>
-              <label htmlFor="cert-event-id" style={{ display: 'block', fontSize: '0.8rem', marginBottom: '5px', opacity: 0.7 }}>
-                Event ID *
-              </label>
-              <input
-                id="cert-event-id"
-                type="text"
-                placeholder="e.g. kss-153"
-                value={eventId}
-                onChange={e => setEventId(e.target.value)}
-                className="form-input"
-                style={{ width: '100%' }}
-              />
-            </div>
-            <div>
-              <label htmlFor="cert-event-date" style={{ display: 'block', fontSize: '0.8rem', marginBottom: '5px', opacity: 0.7 }}>
-                Event Date *
-              </label>
-              <input
-                id="cert-event-date"
-                type="text"
-                placeholder="e.g. March 15, 2025"
-                value={eventDate}
-                onChange={e => setEventDate(e.target.value)}
-                className="form-input"
-                style={{ width: '100%' }}
-              />
-            </div>
-          </div>
-          <div style={{ marginBottom: '12px' }}>
-            <label htmlFor="cert-event-name" style={{ display: 'block', fontSize: '0.8rem', marginBottom: '5px', opacity: 0.7 }}>
-              Event Name *
-            </label>
-            <input
-              id="cert-event-name"
-              type="text"
-              placeholder="e.g. Knowledge Sharing Session #153"
-              value={eventName}
-              onChange={e => setEventName(e.target.value)}
-              className="form-input"
-              style={{ width: '100%' }}
-            />
-          </div>
-          <div>
-            <label htmlFor="cert-template-style" style={{ display: 'block', fontSize: '0.8rem', marginBottom: '5px', opacity: 0.7 }}>
-              Certificate Style
-            </label>
-            <select
-              id="cert-template-style"
-              value={templateStyle}
-              onChange={e => setTemplateStyle(e.target.value)}
-              className="form-input"
-              style={{ width: '200px' }}
-            >
-              <option value="default">Default (Red)</option>
-              <option value="gold">Gold</option>
-              <option value="silver">Silver</option>
-            </select>
-          </div>
-        </section>
-
-        {/* Students */}
-        <section style={{ marginBottom: '28px' }}>
-          <h3 style={{ fontSize: '0.85rem', fontWeight: 700, marginBottom: '6px', textTransform: 'uppercase', letterSpacing: '0.06em', opacity: 0.6 }}>
-            Students
-          </h3>
-          <p style={{ fontSize: '0.78rem', opacity: 0.5, marginBottom: '10px' }}>
-            One per line: <code>STUDENT_ID, Full Name</code> — e.g. <code>STU001, Anshika Rai</code>
-          </p>
-          <textarea
-            id="cert-students"
-            aria-label="Student list"
-            rows={8}
-            placeholder={"STU001, Anshika Rai\nSTU002, Ayush Sharma\nSTU003, Riya Singh"}
-            value={studentsRaw}
-            onChange={e => setStudentsRaw(e.target.value)}
-            className="form-input"
-            style={{ width: '100%', fontFamily: 'monospace', resize: 'vertical' }}
-          />
-          <div style={{ fontSize: '0.75rem', opacity: 0.4, marginTop: '5px' }}>
-            {parseStudents(studentsRaw).length} student(s) ready
-          </div>
-        </section>
-
-        {/* Error */}
-        {error && (
-          <div style={{
-            background: 'rgba(239,68,68,0.08)',
-            border: '1px solid rgba(239,68,68,0.25)',
-            borderRadius: '8px',
-            padding: '12px 16px',
-            color: '#f87171',
+      {/* Notification */}
+      {notif && (
+        <div
+          style={{
+            position: 'fixed',
+            top: '20px',
+            right: '20px',
+            zIndex: 9999,
+            background: notif.type === 'error' ? 'rgba(239,68,68,0.12)' : 'rgba(34,197,94,0.12)',
+            border: `1px solid ${notif.type === 'error' ? 'rgba(239,68,68,0.3)' : 'rgba(34,197,94,0.3)'}`,
+            color: notif.type === 'error' ? '#f87171' : '#22c55e',
+            borderRadius: '10px',
+            padding: '12px 20px',
             fontSize: '0.85rem',
-            marginBottom: '16px',
-          }}>
-            {error}
-          </div>
-        )}
-
-        {/* Generate button */}
-        <button
-          className="btn-primary"
-          onClick={handleGenerate}
-          disabled={loading}
-          aria-busy={loading}
-          style={{ opacity: loading ? 0.7 : 1 }}
+            fontWeight: 600,
+            boxShadow: '0 8px 32px rgba(0,0,0,0.4)',
+          }}
         >
-          {loading ? 'Generating…' : '🎓 Generate Certificates'}
-        </button>
+          {notif.message}
+        </div>
+      )}
 
-        {/* Results */}
-        {result && (
-          <div style={{ marginTop: '28px' }}>
-            <div style={{
-              background: 'rgba(34,197,94,0.07)',
-              border: '1px solid rgba(34,197,94,0.2)',
-              borderRadius: '10px',
-              padding: '14px 18px',
-              marginBottom: '16px',
-              display: 'flex',
-              gap: '24px',
-              fontSize: '0.88rem',
-            }}>
-              <span style={{ color: '#22c55e', fontWeight: 700 }}>✓ Generated: {result.generated}</span>
-              {result.skipped > 0 && (
-                <span style={{ color: 'rgba(255,255,255,0.72)' }}>⟳ Skipped (already issued): {result.skipped}</span>
-              )}
-            </div>
-            <h4 style={{ fontSize: '0.82rem', opacity: 0.5, marginBottom: '10px', textTransform: 'uppercase', letterSpacing: '0.06em' }}>
-              Generated Certificates
-            </h4>
-            <div>
-              {result.certificates.map(cert => (
-                <CertRow key={cert.certificate_id} cert={cert} />
-              ))}
-            </div>
-          </div>
-        )}
+      {/* Tab bar */}
+      <div style={{ display: 'flex', gap: '8px', marginBottom: '28px', flexWrap: 'wrap' }}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            onClick={() => setActiveTab(tab.key)}
+            style={tabBtn(activeTab === tab.key)}
+          >
+            <span>{tab.icon}</span> {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div style={{ maxWidth: '1000px' }}>
+        {activeTab === 'templates' && <TemplateBuilder onNotify={onNotify} />}
+        {activeTab === 'issue' && <IssueCertificate onNotify={onNotify} />}
+        {activeTab === 'logs' && <IssuedLogs onNotify={onNotify} />}
       </div>
     </div>
   );

--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -518,6 +518,62 @@ export const api = {
   membership: {
     getAll: () => fetchWithAuth('/api/admin/membership'),
   },
+
+  certificates: {
+    getTemplates: () => fetchWithAuth('/api/admin/certificates/templates'),
+    createTemplate: async (template) => {
+      const result = await fetchWithAuth('/api/admin/certificates/templates', {
+        method: 'POST',
+        body: JSON.stringify(template),
+      });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Template saved' });
+      return result;
+    },
+    updateTemplate: async (id, template) => {
+      const result = await fetchWithAuth(`/api/admin/certificates/templates/${id}`, {
+        method: 'PUT',
+        body: JSON.stringify(template),
+      });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Template updated' });
+      return result;
+    },
+    deleteTemplate: async (id) => {
+      await fetchWithAuth(`/api/admin/certificates/templates/${id}`, { method: 'DELETE' });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Template deleted' });
+    },
+    getParticipants: (eventId) => fetchWithAuth(`/api/admin/certificates/participants/${eventId}`),
+    addParticipant: async (eventId, participant) => {
+      return fetchWithAuth(`/api/admin/certificates/participants/${eventId}`, {
+        method: 'POST',
+        body: JSON.stringify(participant),
+      });
+    },
+    bulkAddParticipants: async (eventId, participants) => {
+      return fetchWithAuth(`/api/admin/certificates/participants/${eventId}/bulk`, {
+        method: 'POST',
+        body: JSON.stringify(participants),
+      });
+    },
+    generate: async (data) => {
+      const result = await fetchWithAuth('/api/admin/certificates/generate', {
+        method: 'POST',
+        body: JSON.stringify(data),
+      });
+      eventEmitter.emit(EVENTS.NOTIFY, {
+        type: 'success',
+        message: `Generated ${result.generated} certificate(s)`,
+      });
+      return result;
+    },
+    getAll: () => fetchWithAuth('/api/admin/certificates'),
+    revoke: async (id) => {
+      const result = await fetchWithAuth(`/api/admin/certificates/${id}/revoke`, {
+        method: 'PATCH',
+      });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'success', message: 'Certificate revoked' });
+      return result;
+    },
+  },
 };
 
 export { auth, eventEmitter, EVENTS };

--- a/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
+++ b/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
@@ -73,6 +73,7 @@ public class SecurityConfig {
                         .requestMatchers("/actuator/**").authenticated()
                         .requestMatchers("/api/admin/login").permitAll()
                         .requestMatchers("/api/content/**").permitAll()
+                        .requestMatchers("/api/public/**").permitAll()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/admin/**").authenticated()

--- a/server-java/src/main/java/org/nexasphere/controller/CertificatesController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/CertificatesController.java
@@ -1,0 +1,187 @@
+package org.nexasphere.controller;
+
+import jakarta.validation.Valid;
+import org.nexasphere.model.entity.CertificateEntity;
+import org.nexasphere.model.entity.CertificateTemplateEntity;
+import org.nexasphere.model.entity.EventParticipantEntity;
+import org.nexasphere.repository.CertificateRepository;
+import org.nexasphere.repository.CertificateTemplateRepository;
+import org.nexasphere.repository.EventParticipantRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@RestController
+@RequestMapping("/api/admin/certificates")
+public class CertificatesController {
+
+    private final CertificateRepository certRepo;
+    private final CertificateTemplateRepository templateRepo;
+    private final EventParticipantRepository participantRepo;
+
+    public CertificatesController(CertificateRepository certRepo,
+                                   CertificateTemplateRepository templateRepo,
+                                   EventParticipantRepository participantRepo) {
+        this.certRepo = certRepo;
+        this.templateRepo = templateRepo;
+        this.participantRepo = participantRepo;
+    }
+
+    // ── Templates ──────────────────────────────────────────────────────
+
+    @GetMapping("/templates")
+    public Map<String, Object> getTemplates() {
+        return Map.of("templates", templateRepo.findAll());
+    }
+
+    @PostMapping("/templates")
+    public ResponseEntity<CertificateTemplateEntity> createTemplate(
+            @Valid @RequestBody CertificateTemplateEntity template) {
+        template.setId(null);
+        return ResponseEntity.status(HttpStatus.CREATED).body(templateRepo.save(template));
+    }
+
+    @PutMapping("/templates/{id}")
+    public ResponseEntity<CertificateTemplateEntity> updateTemplate(
+            @PathVariable @NonNull Long id,
+            @Valid @RequestBody CertificateTemplateEntity template) {
+        return templateRepo.findById(id).map(existing -> {
+            if (template.getName() != null) existing.setName(template.getName());
+            if (template.getType() != null) existing.setType(template.getType());
+            if (template.getContent() != null) existing.setContent(template.getContent());
+            if (template.getPlaceholdersJson() != null) existing.setPlaceholdersJson(template.getPlaceholdersJson());
+            return ResponseEntity.ok(templateRepo.save(existing));
+        }).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/templates/{id}")
+    public ResponseEntity<Void> deleteTemplate(@PathVariable @NonNull Long id) {
+        if (!templateRepo.existsById(id)) return ResponseEntity.notFound().build();
+        templateRepo.deleteById(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    // ── Participants ───────────────────────────────────────────────────
+
+    @GetMapping("/participants/{eventId}")
+    public Map<String, Object> getParticipants(@PathVariable @NonNull String eventId) {
+        return Map.of("participants", participantRepo.findByEventId(eventId));
+    }
+
+    @PostMapping("/participants/{eventId}")
+    public ResponseEntity<EventParticipantEntity> addParticipant(
+            @PathVariable @NonNull String eventId,
+            @Valid @RequestBody EventParticipantEntity participant) {
+        participant.setId(null);
+        participant.setEventId(eventId);
+        return ResponseEntity.status(HttpStatus.CREATED).body(participantRepo.save(participant));
+    }
+
+    @PostMapping("/participants/{eventId}/bulk")
+    public Map<String, Object> bulkAddParticipants(
+            @PathVariable @NonNull String eventId,
+            @RequestBody List<EventParticipantEntity> participants) {
+        int added = 0;
+        for (EventParticipantEntity p : participants) {
+            p.setId(null);
+            p.setEventId(eventId);
+            participantRepo.save(p);
+            added++;
+        }
+        return Map.of("added", added);
+    }
+
+    // ── Generate Certificates ──────────────────────────────────────────
+
+    @PostMapping("/generate")
+    public Map<String, Object> generateCertificates(@RequestBody Map<String, Object> body) {
+        String eventId = (String) body.get("eventId");
+        String eventName = (String) body.get("eventName");
+        String templateStyle = (String) body.getOrDefault("templateStyle", "default");
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> students = (List<Map<String, String>>) body.get("students");
+
+        if (eventId == null || eventName == null || students == null || students.isEmpty()) {
+            return Map.of("error", "Missing required fields: eventId, eventName, students");
+        }
+
+        List<Map<String, String>> generated = new ArrayList<>();
+        int skipped = 0;
+
+        for (Map<String, String> student : students) {
+            String email = student.getOrDefault("email", student.get("student_id", ""));
+            String name = student.getOrDefault("name", student.get("student_name", "Unknown"));
+            String roll = student.getOrDefault("rollNumber", student.get("student_id", ""));
+
+            if (certRepo.existsByStudentEmailAndEventId(email, eventId)) {
+                skipped++;
+                continue;
+            }
+
+            String certId = generateDeterministicId(email, eventId);
+            CertificateEntity cert = new CertificateEntity();
+            cert.setCertificateId(certId);
+            cert.setEventId(eventId);
+            cert.setEventName(eventName);
+            cert.setStudentName(name);
+            cert.setStudentEmail(email);
+            cert.setStudentRollNumber(roll);
+            cert.setIssueDate(LocalDateTime.now());
+            cert.setRevoked(false);
+            cert.setTemplateStyle(templateStyle);
+
+            certRepo.save(cert);
+            generated.add(Map.of(
+                "certificate_id", certId,
+                "student_name", name,
+                "verification_url", "/verify/" + certId
+            ));
+        }
+
+        return Map.of(
+            "generated", generated.size(),
+            "skipped", skipped,
+            "certificates", generated
+        );
+    }
+
+    // ── Revoke ─────────────────────────────────────────────────────────
+
+    @PatchMapping("/{id}/revoke")
+    public ResponseEntity<Map<String, Object>> revokeCertificate(@PathVariable @NonNull String id) {
+        return certRepo.findById(id).map(cert -> {
+            cert.setRevoked(true);
+            certRepo.save(cert);
+            return ResponseEntity.ok(Map.<String, Object>of("success", true, "certificate_id", id));
+        }).orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    // ── List all certificates ──────────────────────────────────────────
+
+    @GetMapping
+    public Map<String, Object> getAllCertificates() {
+        return Map.of("certificates", certRepo.findAll());
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────
+
+    private String generateDeterministicId(String email, String eventId) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest((email + ":" + eventId).getBytes());
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return "NS-CERT-" + hex.substring(0, 12).toUpperCase();
+        } catch (NoSuchAlgorithmException e) {
+            return "NS-CERT-" + UUID.randomUUID().toString().substring(0, 12).toUpperCase();
+        }
+    }
+}

--- a/server-java/src/main/java/org/nexasphere/controller/PublicCertificateController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/PublicCertificateController.java
@@ -1,0 +1,64 @@
+package org.nexasphere.controller;
+
+import org.nexasphere.model.entity.CertificateEntity;
+import org.nexasphere.repository.CertificateRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/public/certificates")
+public class PublicCertificateController {
+
+    private final CertificateRepository certRepo;
+
+    public PublicCertificateController(CertificateRepository certRepo) {
+        this.certRepo = certRepo;
+    }
+
+    @GetMapping("/verify/{id}")
+    public Map<String, Object> verify(@PathVariable String id) {
+        return certRepo.findById(id).map(cert -> {
+            if (cert.isRevoked()) {
+                return Map.<String, Object>of(
+                    "valid", false,
+                    "message", "This certificate has been revoked."
+                );
+            }
+            return Map.<String, Object>of(
+                "valid", true,
+                "message", "Certificate verified successfully.",
+                "certificate", Map.of(
+                    "certificate_id", cert.getCertificateId(),
+                    "student_name", cert.getStudentName(),
+                    "student_email", cert.getStudentEmail(),
+                    "student_roll_number", cert.getStudentRollNumber(),
+                    "event_name", cert.getEventName(),
+                    "event_id", cert.getEventId(),
+                    "issue_date", cert.getIssueDate() != null ? cert.getIssueDate().toString() : "",
+                    "template_style", cert.getTemplateStyle() != null ? cert.getTemplateStyle() : "default"
+                )
+            );
+        }).orElse(Map.of(
+            "valid", false,
+            "message", "Certificate not found."
+        ));
+    }
+
+    @GetMapping("/{id}/download")
+    public Map<String, Object> download(@PathVariable String id) {
+        return certRepo.findById(id).map(cert -> {
+            if (cert.isRevoked()) {
+                return Map.<String, Object>of("error", "Certificate has been revoked.");
+            }
+            return Map.<String, Object>of(
+                "certificate_id", cert.getCertificateId(),
+                "student_name", cert.getStudentName(),
+                "event_name", cert.getEventName(),
+                "issue_date", cert.getIssueDate() != null ? cert.getIssueDate().toString() : "",
+                "template_style", cert.getTemplateStyle() != null ? cert.getTemplateStyle() : "default",
+                "download_url", "/api/public/certificates/" + cert.getCertificateId() + "/download"
+            );
+        }).orElse(Map.of("error", "Certificate not found."));
+    }
+}

--- a/server-java/src/main/java/org/nexasphere/model/entity/CertificateEntity.java
+++ b/server-java/src/main/java/org/nexasphere/model/entity/CertificateEntity.java
@@ -1,0 +1,52 @@
+package org.nexasphere.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "certificates")
+@Data
+@NoArgsConstructor
+public class CertificateEntity {
+
+    @Id
+    @Size(max = 80)
+    private String certificateId;
+
+    @NotBlank
+    @Size(max = 100)
+    private String eventId;
+
+    @NotBlank
+    @Size(max = 200)
+    private String eventName;
+
+    private Long templateId;
+
+    @NotBlank
+    @Size(max = 120)
+    private String studentName;
+
+    @NotBlank
+    @Size(max = 200)
+    private String studentEmail;
+
+    @NotBlank
+    @Size(max = 30)
+    private String studentRollNumber;
+
+    private LocalDateTime issueDate;
+
+    private boolean revoked = false;
+
+    @Size(max = 40)
+    private String templateStyle = "default";
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+}

--- a/server-java/src/main/java/org/nexasphere/model/entity/CertificateTemplateEntity.java
+++ b/server-java/src/main/java/org/nexasphere/model/entity/CertificateTemplateEntity.java
@@ -1,0 +1,42 @@
+package org.nexasphere.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "certificate_templates")
+@Data
+@NoArgsConstructor
+public class CertificateTemplateEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 120)
+    @Column(unique = true)
+    private String name;
+
+    @NotBlank
+    @Pattern(regexp = "HTML_CSS|IMAGE_OVERLAY")
+    private String type = "HTML_CSS";
+
+    @Column(columnDefinition = "text")
+    private String content;
+
+    @Column(name = "placeholders_json", columnDefinition = "text")
+    private String placeholdersJson;
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/server-java/src/main/java/org/nexasphere/model/entity/EventParticipantEntity.java
+++ b/server-java/src/main/java/org/nexasphere/model/entity/EventParticipantEntity.java
@@ -1,0 +1,43 @@
+package org.nexasphere.model.entity;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "event_certificate_participants")
+@Data
+@NoArgsConstructor
+public class EventParticipantEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotBlank
+    @Size(max = 100)
+    private String eventId;
+
+    @NotBlank
+    @Size(max = 120)
+    private String fullName;
+
+    @NotBlank
+    @Size(max = 200)
+    private String email;
+
+    @NotBlank
+    @Size(max = 30)
+    private String rollNumber;
+
+    @NotBlank
+    @Pattern(regexp = "REGISTERED|ATTENDED|ABSENT")
+    private String status = "REGISTERED";
+
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+}

--- a/server-java/src/main/java/org/nexasphere/repository/CertificateRepository.java
+++ b/server-java/src/main/java/org/nexasphere/repository/CertificateRepository.java
@@ -1,0 +1,12 @@
+package org.nexasphere.repository;
+
+import org.nexasphere.model.entity.CertificateEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CertificateRepository extends JpaRepository<CertificateEntity, String> {
+    List<CertificateEntity> findByEventId(String eventId);
+    List<CertificateEntity> findByStudentEmail(String studentEmail);
+    List<CertificateEntity> findByStudentRollNumber(String rollNumber);
+    boolean existsByStudentEmailAndEventId(String studentEmail, String eventId);
+}

--- a/server-java/src/main/java/org/nexasphere/repository/CertificateTemplateRepository.java
+++ b/server-java/src/main/java/org/nexasphere/repository/CertificateTemplateRepository.java
@@ -1,0 +1,9 @@
+package org.nexasphere.repository;
+
+import org.nexasphere.model.entity.CertificateTemplateEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface CertificateTemplateRepository extends JpaRepository<CertificateTemplateEntity, Long> {
+    Optional<CertificateTemplateEntity> findByName(String name);
+}

--- a/server-java/src/main/java/org/nexasphere/repository/EventParticipantRepository.java
+++ b/server-java/src/main/java/org/nexasphere/repository/EventParticipantRepository.java
@@ -1,0 +1,10 @@
+package org.nexasphere.repository;
+
+import org.nexasphere.model.entity.EventParticipantEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface EventParticipantRepository extends JpaRepository<EventParticipantEntity, Long> {
+    List<EventParticipantEntity> findByEventId(String eventId);
+    List<EventParticipantEntity> findByEventIdAndStatus(String eventId, String status);
+}

--- a/server-java/src/main/resources/db/migration/V4__Create_Certificate_System.sql
+++ b/server-java/src/main/resources/db/migration/V4__Create_Certificate_System.sql
@@ -1,0 +1,62 @@
+-- Flyway Migration: V4__Create_Certificate_System
+-- Description: Add certificate management tables (templates, participants, certificates)
+-- Version: 1.0.3
+-- Date: 2026-05-30
+-- Author: NexaSphere Core Team
+
+-- Table 1: event_certificate_participants
+-- Tracks students who registered for/attended an event
+CREATE TABLE IF NOT EXISTS event_certificate_participants (
+  id bigserial PRIMARY KEY,
+  event_id text NOT NULL,
+  full_name text NOT NULL,
+  email text NOT NULL,
+  roll_number text NOT NULL,
+  status text NOT NULL DEFAULT 'REGISTERED',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_participant_status CHECK (status IN ('REGISTERED', 'ATTENDED', 'ABSENT'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_participants_event ON event_certificate_participants (event_id);
+CREATE INDEX IF NOT EXISTS idx_participants_email ON event_certificate_participants (email);
+CREATE INDEX IF NOT EXISTS idx_participants_roll ON event_certificate_participants (roll_number);
+
+-- Table 2: certificate_templates
+-- Stores custom certificate design templates (HTML/CSS or image overlay)
+CREATE TABLE IF NOT EXISTS certificate_templates (
+  id bigserial PRIMARY KEY,
+  name text NOT NULL UNIQUE,
+  type text NOT NULL DEFAULT 'HTML_CSS',
+  content text,
+  placeholders_json text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT chk_template_type CHECK (type IN ('HTML_CSS', 'IMAGE_OVERLAY'))
+);
+
+-- Table 3: certificates
+-- Stores issued, verifiable certificates
+CREATE TABLE IF NOT EXISTS certificates (
+  certificate_id text PRIMARY KEY,
+  event_id text NOT NULL,
+  event_name text NOT NULL,
+  template_id bigint,
+  student_name text NOT NULL,
+  student_email text NOT NULL,
+  student_roll_number text NOT NULL,
+  issue_date timestamptz NOT NULL DEFAULT now(),
+  revoked boolean NOT NULL DEFAULT false,
+  template_style text NOT NULL DEFAULT 'default',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT fk_certificates_template FOREIGN KEY (template_id) REFERENCES certificate_templates (id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_certificates_event ON certificates (event_id);
+CREATE INDEX IF NOT EXISTS idx_certificates_student_email ON certificates (student_email);
+CREATE INDEX IF NOT EXISTS idx_certificates_student_roll ON certificates (student_roll_number);
+CREATE INDEX IF NOT EXISTS idx_certificates_revoked ON certificates (revoked);
+
+-- Audit trail
+COMMENT ON TABLE event_certificate_participants IS 'Students registered for or attending NexaSphere events';
+COMMENT ON TABLE certificate_templates IS 'Custom certificate design templates (HTML/CSS or image overlay)';
+COMMENT ON TABLE certificates IS 'Issued certificates with verification IDs';

--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -3,7 +3,7 @@
  * Public page at /verify/:id — verifies a NexaSphere event certificate via QR or direct URL.
  *
  * Features:
- * - Fetches verification data from the FastAPI /certificates/verify/:id endpoint
+ * - Fetches verification data from the Java Spring Boot /api/public/certificates/verify/:id endpoint
  * - Displays verified/invalid state with premium glassmorphic styling
  * - Shows student name, event name, issue date
  * - Certificate download button for valid certs
@@ -18,13 +18,18 @@ import { useEffect, useState } from 'react';
 // ---------------------------------------------------------------------------
 
 function getApiBase() {
-  const base = (import.meta?.env?.VITE_PYTHON_API_BASE || '').replace(/\/+$/, '');
-  return base || 'http://localhost:8000';
+  const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+  return base || 'http://localhost:8080';
 }
 
 function formatDate(dateStr) {
   if (!dateStr) return '—';
-  return dateStr;
+  try {
+    const d = new Date(dateStr);
+    return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  } catch {
+    return dateStr;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -53,9 +58,19 @@ function VerifiedBadge() {
         fontFamily: "'Rajdhani', sans-serif",
       }}
     >
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/>
-        <polyline points="22 4 12 14.01 9 11.01"/>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
       </svg>
       Certificate Verified
     </div>
@@ -84,9 +99,20 @@ function InvalidBadge() {
         fontFamily: "'Rajdhani', sans-serif",
       }}
     >
-      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-        <circle cx="12" cy="12" r="10"/>
-        <line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
+      <svg
+        width="16"
+        height="16"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="12" cy="12" r="10" />
+        <line x1="15" y1="9" x2="9" y2="15" />
+        <line x1="9" y1="9" x2="15" y2="15" />
       </svg>
       Not Verified
     </div>
@@ -95,23 +121,31 @@ function InvalidBadge() {
 
 function InfoRow({ icon, label, value }) {
   return (
-    <div style={{
-      display: 'flex',
-      alignItems: 'flex-start',
-      gap: '12px',
-      padding: '16px 20px',
-      borderBottom: '1px solid rgba(255,255,255,0.06)',
-    }}>
-      <span style={{ color: '#CC1111', flexShrink: 0, marginTop: '2px' }} aria-hidden="true">{icon}</span>
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '12px',
+        padding: '16px 20px',
+        borderBottom: '1px solid rgba(255,255,255,0.06)',
+      }}
+    >
+      <span style={{ color: '#CC1111', flexShrink: 0, marginTop: '2px' }} aria-hidden="true">
+        {icon}
+      </span>
       <div>
-        <div style={{
-          fontSize: '0.7rem',
-          color: 'rgba(255,255,255,0.72)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.1em',
-          marginBottom: '3px',
-          fontFamily: "'Rajdhani', sans-serif",
-        }}>{label}</div>
+        <div
+          style={{
+            fontSize: '0.7rem',
+            color: 'rgba(255,255,255,0.72)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.1em',
+            marginBottom: '3px',
+            fontFamily: "'Rajdhani', sans-serif",
+          }}
+        >
+          {label}
+        </div>
         <div style={{ fontSize: '1rem', color: '#fff', fontWeight: 600 }}>{value}</div>
       </div>
     </div>
@@ -120,21 +154,27 @@ function InfoRow({ icon, label, value }) {
 
 function LoadingSpinner() {
   return (
-    <div style={{
-      display: 'flex',
-      flexDirection: 'column',
-      alignItems: 'center',
-      gap: '20px',
-      padding: '60px 20px',
-    }}>
-      <div style={{
-        width: '48px',
-        height: '48px',
-        border: '3px solid rgba(204,17,17,0.2)',
-        borderTop: '3px solid #CC1111',
-        borderRadius: '50%',
-        animation: 'ns-spin 0.8s linear infinite',
-      }} role="status" aria-label="Loading" />
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '20px',
+        padding: '60px 20px',
+      }}
+    >
+      <div
+        style={{
+          width: '48px',
+          height: '48px',
+          border: '3px solid rgba(204,17,17,0.2)',
+          borderTop: '3px solid #CC1111',
+          borderRadius: '50%',
+          animation: 'ns-spin 0.8s linear infinite',
+        }}
+        role="status"
+        aria-label="Loading"
+      />
       <p style={{ color: 'rgba(255,255,255,0.72)', fontSize: '0.9rem', margin: 0 }}>
         Verifying certificate…
       </p>
@@ -171,13 +211,16 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
     async function fetchVerification() {
       try {
         const apiBase = getApiBase();
-        const res = await fetch(`${apiBase}/certificates/verify/${encodeURIComponent(certificateId)}`, {
-          signal: controller.signal,
-        });
+        const res = await fetch(
+          `${apiBase}/api/public/certificates/verify/${encodeURIComponent(certificateId)}`,
+          {
+            signal: controller.signal,
+          }
+        );
 
         if (!res.ok) {
           const errData = await res.json().catch(() => ({}));
-          setMessage(errData.detail || 'Server error during verification.');
+          setMessage(errData.message || 'Server error during verification.');
           setStatus('error');
           return;
         }
@@ -199,7 +242,7 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
 
   const cert = data?.certificate;
   const downloadUrl = cert
-    ? `${getApiBase()}/certificates/${encodeURIComponent(cert.certificate_id)}/download`
+    ? `${getApiBase()}/api/public/certificates/${encodeURIComponent(cert.certificate_id)}/download`
     : null;
 
   return (
@@ -218,19 +261,29 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
       }}
     >
       {/* Ambient glow */}
-      <div aria-hidden="true" style={{
-        position: 'absolute', top: '-15%', left: '50%', transform: 'translateX(-50%)',
-        width: '700px', height: '700px', borderRadius: '50%',
-        background: 'radial-gradient(circle, rgba(204,17,17,0.07) 0%, transparent 70%)',
-        pointerEvents: 'none',
-      }} />
+      <div
+        aria-hidden="true"
+        style={{
+          position: 'absolute',
+          top: '-15%',
+          left: '50%',
+          transform: 'translateX(-50%)',
+          width: '700px',
+          height: '700px',
+          borderRadius: '50%',
+          background: 'radial-gradient(circle, rgba(204,17,17,0.07) 0%, transparent 70%)',
+          pointerEvents: 'none',
+        }}
+      />
 
       {/* Back button */}
       <button
         onClick={onGoHome}
         aria-label="Go back to homepage"
         style={{
-          position: 'absolute', top: '24px', left: '24px',
+          position: 'absolute',
+          top: '24px',
+          left: '24px',
           background: 'rgba(255,255,255,0.05)',
           border: '1px solid rgba(255,255,255,0.12)',
           borderRadius: '20px',
@@ -245,37 +298,55 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
           fontFamily: "'Rajdhani', sans-serif",
           fontWeight: 600,
         }}
-        onMouseEnter={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.1)'; }}
-        onMouseLeave={e => { e.currentTarget.style.background = 'rgba(255,255,255,0.05)'; }}
+        onMouseEnter={(e) => {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.1)';
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.background = 'rgba(255,255,255,0.05)';
+        }}
       >
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-          <polyline points="15 18 9 12 15 6"/>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <polyline points="15 18 9 12 15 6" />
         </svg>
         Back
       </button>
 
       {/* NexaSphere logo wordmark */}
       <div style={{ marginBottom: '40px', textAlign: 'center' }}>
-        <div style={{
-          fontFamily: "'Orbitron', monospace",
-          fontSize: 'clamp(1.1rem, 3vw, 1.4rem)',
-          fontWeight: 900,
-          background: 'linear-gradient(135deg, #CC1111, #EE4444)',
-          WebkitBackgroundClip: 'text',
-          WebkitTextFillColor: 'transparent',
-          backgroundClip: 'text',
-          letterSpacing: '0.12em',
-          marginBottom: '4px',
-        }}>
+        <div
+          style={{
+            fontFamily: "'Orbitron', monospace",
+            fontSize: 'clamp(1.1rem, 3vw, 1.4rem)',
+            fontWeight: 900,
+            background: 'linear-gradient(135deg, #CC1111, #EE4444)',
+            WebkitBackgroundClip: 'text',
+            WebkitTextFillColor: 'transparent',
+            backgroundClip: 'text',
+            letterSpacing: '0.12em',
+            marginBottom: '4px',
+          }}
+        >
           NexaSphere
         </div>
-        <div style={{
-          fontSize: '0.7rem',
-          color: 'rgba(255,255,255,0.3)',
-          textTransform: 'uppercase',
-          letterSpacing: '0.2em',
-          fontFamily: "'Rajdhani', sans-serif",
-        }}>
+        <div
+          style={{
+            fontSize: '0.7rem',
+            color: 'rgba(255,255,255,0.3)',
+            textTransform: 'uppercase',
+            letterSpacing: '0.2em',
+            fontFamily: "'Rajdhani', sans-serif",
+          }}
+        >
           Certificate Verification Portal
         </div>
       </div>
@@ -296,19 +367,23 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
         }}
       >
         {/* Card header */}
-        <div style={{
-          padding: '28px 28px 20px',
-          borderBottom: '1px solid rgba(255,255,255,0.06)',
-          textAlign: 'center',
-        }}>
-          <div style={{
-            fontFamily: "'Orbitron', monospace",
-            fontSize: '0.78rem',
-            color: 'rgba(255,255,255,0.3)',
-            textTransform: 'uppercase',
-            letterSpacing: '0.2em',
-            marginBottom: '16px',
-          }}>
+        <div
+          style={{
+            padding: '28px 28px 20px',
+            borderBottom: '1px solid rgba(255,255,255,0.06)',
+            textAlign: 'center',
+          }}
+        >
+          <div
+            style={{
+              fontFamily: "'Orbitron', monospace",
+              fontSize: '0.78rem',
+              color: 'rgba(255,255,255,0.3)',
+              textTransform: 'uppercase',
+              letterSpacing: '0.2em',
+              marginBottom: '16px',
+            }}
+          >
             Certificate ID: {certificateId || '—'}
           </div>
 
@@ -322,28 +397,77 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
           <div>
             <InfoRow
               icon={
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+                  <circle cx="12" cy="7" r="4" />
+                </svg>
               }
               label="Student Name"
               value={cert.student_name}
             />
             <InfoRow
               icon={
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+                  <line x1="16" y1="2" x2="16" y2="6" />
+                  <line x1="8" y1="2" x2="8" y2="6" />
+                  <line x1="3" y1="10" x2="21" y2="10" />
+                </svg>
               }
               label="Event"
               value={cert.event_name}
             />
             <InfoRow
               icon={
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
               }
               label="Issued On"
               value={formatDate(cert.issue_date)}
             />
             <InfoRow
               icon={
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
+                </svg>
               }
               label="Status"
               value="Valid — Issued by NexaSphere"
@@ -353,14 +477,16 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
 
         {/* Message area */}
         {status !== 'loading' && (
-          <div style={{
-            padding: '20px 28px',
-            textAlign: 'center',
-            color: status === 'valid' ? 'rgba(34,197,94,0.8)' : 'rgba(239,68,68,0.8)',
-            fontSize: '0.85rem',
-            lineHeight: 1.6,
-            borderTop: cert ? '1px solid rgba(255,255,255,0.06)' : 'none',
-          }}>
+          <div
+            style={{
+              padding: '20px 28px',
+              textAlign: 'center',
+              color: status === 'valid' ? 'rgba(34,197,94,0.8)' : 'rgba(239,68,68,0.8)',
+              fontSize: '0.85rem',
+              lineHeight: 1.6,
+              borderTop: cert ? '1px solid rgba(255,255,255,0.06)' : 'none',
+            }}
+          >
             {message}
           </div>
         )}
@@ -391,13 +517,29 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
                 transition: 'all 0.2s',
                 boxShadow: '0 4px 20px rgba(204,17,17,0.4)',
               }}
-              onMouseEnter={e => { e.currentTarget.style.transform = 'translateY(-2px)'; e.currentTarget.style.boxShadow = '0 8px 28px rgba(204,17,17,0.55)'; }}
-              onMouseLeave={e => { e.currentTarget.style.transform = ''; e.currentTarget.style.boxShadow = '0 4px 20px rgba(204,17,17,0.4)'; }}
+              onMouseEnter={(e) => {
+                e.currentTarget.style.transform = 'translateY(-2px)';
+                e.currentTarget.style.boxShadow = '0 8px 28px rgba(204,17,17,0.55)';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.transform = '';
+                e.currentTarget.style.boxShadow = '0 4px 20px rgba(204,17,17,0.4)';
+              }}
             >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                <polyline points="7 10 12 15 17 10"/>
-                <line x1="12" y1="15" x2="12" y2="3"/>
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+                <polyline points="7 10 12 15 17 10" />
+                <line x1="12" y1="15" x2="12" y2="3" />
               </svg>
               Download Certificate
             </a>
@@ -406,14 +548,17 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
       </div>
 
       {/* Footer */}
-      <p style={{
-        marginTop: '32px',
-        color: 'rgba(255,255,255,0.2)',
-        fontSize: '0.75rem',
-        textAlign: 'center',
-        lineHeight: 1.6,
-      }}>
-        Issued by NexaSphere — GL Bajaj Group of Institutions<br />
+      <p
+        style={{
+          marginTop: '32px',
+          color: 'rgba(255,255,255,0.2)',
+          fontSize: '0.75rem',
+          textAlign: 'center',
+          lineHeight: 1.6,
+        }}
+      >
+        Issued by NexaSphere — GL Bajaj Group of Institutions
+        <br />
         <span style={{ fontSize: '0.7rem' }}>
           Certificates are tamper-proof and cryptographically linked to our records.
         </span>


### PR DESCRIPTION
## What this fixes

The existing CertificateManager was a basic frontend mockup connected to a mock Python backend on port 8000. It had no database persistence, no template customization, no event participant integration, and no proper verification portal. The admin had to manually type CSV student lists with no way to fetch participants from actual events.

## Root cause

No certificate infrastructure existed in the Java Spring Boot backend. The admin dashboard connected to a non-existent Python API, and the website verification page targeted the wrong backend endpoint. There were no database tables for templates, participants, or issued certificates.

## What changed

**Backend (server-java/):**
- V4 Flyway migration creating 3 tables: `event_certificate_participants`, `certificate_templates`, `certificates`
- 3 new JPA entities: `EventParticipantEntity`, `CertificateTemplateEntity`, `CertificateEntity`
- 3 new Spring Data repositories for the above entities
- `CertificatesController` with admin endpoints: templates CRUD, participant management, bulk certificate generation with deterministic SHA-256 IDs, revocation, and listing
- `PublicCertificateController` with public verification and download endpoints
- Security config updated to permit `/api/public/**`

**Admin Dashboard:**
- Complete rewrite of `CertificateManager.jsx` with 3-tab layout:
  - **Template Builder**: HTML/CSS editor, image overlay mode with coordinate inputs, live preview, preset templates (Gold/Silver/Red), save/edit/delete
  - **Issue Certificate**: Event selector dropdown, fetch participants with checkboxes, manual entry mode, bulk generation with progress feedback
  - **Issued Logs**: Searchable table by name/email/roll/event/cert-ID, active/revoked status badges, verify and revoke actions
- Added 12 certificate API methods to `api.js`

**Website:**
- Updated `CertificateVerifyPage.jsx` to call `/api/public/certificates/verify/:id` (Java backend) instead of the Python endpoint
- Proper date formatting and maintained existing premium glassmorphic UI

## How to verify

1. Start the Java backend — V4 migration creates the certificate tables automatically
2. Open Admin Dashboard → Certificate Manager
3. **Template Builder tab**: Create a new HTML/CSS template with placeholders, verify live preview updates, save it
4. **Issue Certificate tab**: Select a completed event, verify participant list loads (or use Manual Entry), select students, click Generate
5. **Issued Logs tab**: Verify the generated certificates appear, search works, Revoke button works
6. Open `/verify/NS-CERT-XXXXXXXXXXXX` on the website — verify certificate details display correctly
7. Click Download Certificate button — verify it fetches from the Java endpoint

## Edge cases considered

- Deterministic certificate IDs via SHA-256 prevent duplicate issuance for same student+event
- Revoked certificates show invalid status on public verification
- Offline mode: admin API falls back to localStorage when backend is unreachable
- Template content is optional for preset styles (Gold/Silver/Red use gradient overlays)
- Empty participant lists show helpful message instead of breaking
- Search in logs is case-insensitive across all fields

Closes #667