### PR TITLE
fix: remove duplicate Express routes and mount global rate limiter

### DIFF
--- a/server-python/main.py
+++ b/server-python/main.py
@@ -89,13 +89,14 @@ class ChatRequest(BaseModel):
 
 # 4. Chat Endpoint
 @app.post("/ai/chat")
-async def chat_with_ai(request: ChatRequest):
+@limiter.limit("20/minute")
+async def chat_with_ai(http_request: Request, chat_req: ChatRequest):
     try:
         if not model:
             return {"reply": "Nexa-AI Core is offline. (GEMINI_API_KEY missing)"}
             
         # We send the user message to the model along with system instructions manually
-        full_prompt = f"System Instruction:\n{SYSTEM_PROMPT}\n\nUser Message:\n{request.message}"
+        full_prompt = f"System Instruction:\n{SYSTEM_PROMPT}\n\nUser Message:\n{chat_req.message}"
         response = model.generate_content(full_prompt)
         
         if not response.text:

--- a/server-python/routers/review.py
+++ b/server-python/routers/review.py
@@ -1,9 +1,11 @@
 import logging
 import os
 import google.generativeai as genai
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel
 import json
+
+from utils.security import limiter
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -22,7 +24,8 @@ class ReviewRequest(BaseModel):
     language: str
 
 @router.post("/ai/review", tags=["AI Mentor"])
-async def review_code(request: ReviewRequest):
+@limiter.limit("10/minute")
+async def review_code(http_request: Request, request: ReviewRequest):
     if not model:
         raise HTTPException(status_code=503, detail="AI services are currently unavailable.")
     

--- a/server/index.js
+++ b/server/index.js
@@ -64,6 +64,11 @@ app.use(express.json({ limit: '512kb' }));
 app.use(morgan('combined'));
 app.use(performanceMonitor);
 
+// Global API rate limiter — protects all /api routes from request flooding
+// Previously missing: the middleware was correctly defined in rateLimiter.js
+// but never mounted, leaving every API endpoint without baseline protection.
+app.use("/api", apiRateLimiter);
+
 const adminEvents = new EventEmitter();
 
 function requestLogger(req, res, next) {
@@ -583,26 +588,8 @@ app.get('/api/admin/membership', adminAuth, async (req, res) => {
   }
 });
 
-app.post('/api/admin/login', authRateLimiter, adminAuthMiddleware.login);
-app.post('/api/admin/logout', adminAuthMiddleware.logout);
 app.get('/api/admin/me', adminAuth, (req, res) => {
   return res.json({ username: req.adminSession.username });
-});
-app.use('/api/admin/analytics', adminAuth, analyticsRouter);
-app.use('/api/admin/metrics', adminAuth, adminStreamRouter);
-
-app.get('/api/admin/events', adminAuth, async (req, res) => {
-  const { page, limit } = parsePagination(req.query);
-  const { events, total } = await listEventsStore({ page, limit });
-  return res.json({
-    events,
-    pagination: {
-      page,
-      limit,
-      total,
-      totalPages: Math.ceil(total / limit) || 1,
-    },
-  });
 });
 
 // Real-time Push Subscriber channels
@@ -743,14 +730,6 @@ function clearPasskeyAttempts(username, ip) {
   failedPasskeyAttempts.delete(key);
 }
 
-app.post('/api/forms/membership', formRateLimiter, (req, res) =>
-  handleForm('membership', req, res)
-);
-app.post('/api/forms/recruitment', formRateLimiter, (req, res) =>
-  handleForm('recruitment', req, res)
-);
-app.post('/api/core-team/apply', formRateLimiter, (req, res) => handleForm('core_team', req, res));
-
 // Server-side notifications API (simple in-memory store)
 
 app.get('/api/notifications', (req, res) => {
@@ -761,24 +740,6 @@ app.get('/api/notifications', (req, res) => {
     return res.json({ notifications: list });
   } catch (err) {
     return res.status(500).json({ error: err.message });
-  }
-});
-
-// Portfolio System API Endpoints
-app.get('/api/portfolio/:username', async (req, res) => {
-  try {
-    const username = String(req.params.username || '').trim();
-    if (!username) {
-      return res.status(400).json({ error: 'Username is required' });
-    }
-    const portfolio = await portfolioRepository.getByUsername(username);
-    if (!portfolio) {
-      return res.status(404).json({ error: 'Portfolio not found' });
-    }
-    return res.json(portfolio);
-  } catch (err) {
-    console.error('Error fetching portfolio:', err);
-    return res.status(500).json({ error: err.message || 'Internal server error' });
   }
 });
 


### PR DESCRIPTION
## Description
Remove 6 pairs of duplicate Express route registrations that crash form submissions and mount the global rate limiter on unprotected API endpoints.

**Changes:**
- **server/index.js**: Removed 6 pairs of identical route registrations (admin-auth, admin-events, broken form handlers referencing undefined `handleForm`, duplicate portfolio get); mounted `apiRateLimiter` at `/api` to protect all Express endpoints
- **server-python/main.py**: Added `@limiter.limit("20/minute")` to `POST /ai/chat`; renamed param `request` → `chat_req` to avoid FastAPI `Request` collision
- **server-python/routers/review.py**: Added `@limiter.limit("10/minute")` to `POST /ai/review`; imported `limiter` and `Request`

**Note:** Full test suite requires `@sentry/profiling-node` C++ compilation (Visual Studio Build Tools). All 3 files pass syntax validation (`node --check`, `py_compile`).

Fixes #766

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings