### PR TITLE
docs: fix root quick links paths in docs README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,10 +17,10 @@ Welcome to the NexaSphere documentation. Use the links below to find what you ne
 | Document | Description |
 |---|---|
 | [README.md](../README.md) | Project overview, tech stack, quick start |
-| [CONTRIBUTING.md](../CONTRIBUTING.md) | How to contribute (fork, branch, PR, GSSoC rules) |
-| [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md) | Community standards |
-| [SECURITY.md](../SECURITY.md) | Vulnerability reporting policy |
-| [CHANGELOG.md](../CHANGELOG.md) | Version history |
+| [CONTRIBUTING.md](./community/CONTRIBUTING.md) | How to contribute (fork, branch, PR, GSSoC rules) |
+| [CODE_OF_CONDUCT.md](./community/CODE_OF_CONDUCT.md) | Community standards |
+| [SECURITY.md](./community/SECURITY.md) | Vulnerability reporting policy |
+| [CHANGELOG.md](./CHANGELOG.md) | Version history |
 
 ## 🖥️ Backend
 


### PR DESCRIPTION
## Description

Fixed broken quick-link paths in `docs/README.md`.

### Changes Made

* Updated `CONTRIBUTING.md` link to point to `docs/community/CONTRIBUTING.md`
* Updated `CODE_OF_CONDUCT.md` link to point to `docs/community/CODE_OF_CONDUCT.md`
* Updated `SECURITY.md` link to point to `docs/community/SECURITY.md`
* Updated `CHANGELOG.md` link to use the correct relative path
* Corrected invalid `../` references that caused broken navigation

Closes #741

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
