### PR TITLE
fix: validate formType against allowlist

### DIFF
--- a/server/controllers/formsController.js
+++ b/server/controllers/formsController.js
@@ -1,5 +1,11 @@
 import { formsService } from '../services/formsService.js';
 
+const ALLOWED_FORM_TYPES = new Set([
+  'membership',
+  'recruitment',
+  'core_team',
+]);
+
 function wrapAsync(fn) {
   return (req, res) =>
     Promise.resolve(fn(req, res)).catch((e) => {
@@ -27,6 +33,13 @@ export function makeHandleForm(formType) {
 
 export const handleFormByParam = wrapAsync(async (req, res) => {
   const formType = req.params?.formType;
+
+  if (!ALLOWED_FORM_TYPES.has(formType)) {
+    return res.status(400).json({
+      error: 'Invalid form type',
+    });
+  }
+
   const result = await formsService.handleForm(formType, req.body || {});
   return res.json(result);
 });


### PR DESCRIPTION
## Description

Added allowlist validation for form types in `handleFormByParam` to prevent arbitrary values from being passed to the forms service.

### Changes Made

* Added an allowlist of valid form types:

  * `membership`
  * `recruitment`
  * `core_team`
* Added validation before processing form submissions
* Returns HTTP 400 for invalid form types
* Prevents unauthorized or unexpected form types from reaching the service layer

Fixes #762

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings