### PR TITLE
fix: validate rate limiter environment variables

### DIFF
--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -1,26 +1,22 @@
-import rateLimit from "express-rate-limit";
-import logger from "../utils/logger.js";
+import rateLimit from 'express-rate-limit';
+import logger from '../utils/logger.js';
 
+function parsePositiveInt(value, fallback) {
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
 // ---------------------------------------------------------------------------
 // Shared env-var config for the general API limiter
 // Override via API_RATE_LIMIT_WINDOW_MS and API_RATE_LIMIT_MAX in .env
 // ---------------------------------------------------------------------------
-const API_WINDOW_MS = process.env.API_RATE_LIMIT_WINDOW_MS
-  ? parseInt(process.env.API_RATE_LIMIT_WINDOW_MS, 10)
-  : 10 * 60 * 1000; // 10 minutes
+const API_WINDOW_MS = parsePositiveInt(process.env.API_RATE_LIMIT_WINDOW_MS, 10 * 60 * 1000);
 
-const API_MAX_REQUESTS = process.env.API_RATE_LIMIT_MAX
-  ? parseInt(process.env.API_RATE_LIMIT_MAX, 10)
-  : 100;
+const API_MAX_REQUESTS = parsePositiveInt(process.env.API_RATE_LIMIT_MAX, 100);
 
 // Shared env-var config for the form limiter
-const FORM_WINDOW_MS = process.env.RATE_LIMIT_WINDOW_MS
-  ? parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10)
-  : 10 * 60 * 1000; // 10 minutes
+const FORM_WINDOW_MS = parsePositiveInt(process.env.RATE_LIMIT_WINDOW_MS, 10 * 60 * 1000);
 
-const FORM_MAX_REQUESTS = process.env.RATE_LIMIT_MAX_REQUESTS
-  ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS, 10)
-  : 5;
+const FORM_MAX_REQUESTS = parsePositiveInt(process.env.RATE_LIMIT_MAX_REQUESTS, 5);
 
 // ---------------------------------------------------------------------------
 // Global API rate limiter — applied to every /api route
@@ -34,7 +30,7 @@ export const apiRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res, _next, options) => {
-    logger.warn("Global API rate limit exceeded", {
+    logger.warn('Global API rate limit exceeded', {
       ip: req.ip,
       path: req.originalUrl || req.path,
       method: req.method,
@@ -42,7 +38,7 @@ export const apiRateLimiter = rateLimit({
       windowMs: options.windowMs,
     });
     res.status(options.statusCode).json({
-      error: "Too many requests from this IP, please try again later.",
+      error: 'Too many requests from this IP, please try again later.',
     });
   },
 });
@@ -56,7 +52,7 @@ export const formRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res, _next, options) => {
-    logger.warn("Rate limit exceeded for public form API", {
+    logger.warn('Rate limit exceeded for public form API', {
       ip: req.ip,
       path: req.originalUrl || req.path,
       method: req.method,
@@ -64,7 +60,7 @@ export const formRateLimiter = rateLimit({
       windowMs: options.windowMs,
     });
     res.status(options.statusCode).json({
-      error: "Too many form submissions from this IP, please try again later.",
+      error: 'Too many form submissions from this IP, please try again later.',
     });
   },
 });
@@ -76,7 +72,7 @@ export const authRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: {
-    error: "Too many login attempts, please try again after a minute.",
+    error: 'Too many login attempts, please try again after a minute.',
   },
 });
 
@@ -87,7 +83,7 @@ export const notificationRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: {
-    error: "Too many notification requests, please try again later.",
+    error: 'Too many notification requests, please try again later.',
   },
 });
 
@@ -102,13 +98,13 @@ export const activityAuthRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   handler: (req, res, next, options) => {
-    logger.warn("Activity-event auth rate limit exceeded", {
+    logger.warn('Activity-event auth rate limit exceeded', {
       ip: req.ip,
       path: req.originalUrl || req.path,
       method: req.method,
     });
     res.status(options.statusCode).json({
-      error: "Too many attempts from this IP, please try again later.",
+      error: 'Too many attempts from this IP, please try again later.',
     });
   },
 });
@@ -120,8 +116,7 @@ export const portfolioRateLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: {
-    error:
-      "Too many portfolio update attempts from this IP, please try again after 15 minutes.",
+    error: 'Too many portfolio update attempts from this IP, please try again after 15 minutes.',
   },
 });
 
@@ -141,7 +136,7 @@ export function validateLimiters() {
   };
 
   for (const [name, limiter] of Object.entries(limiters)) {
-    if (typeof limiter !== "function") {
+    if (typeof limiter !== 'function') {
       throw new Error(
         `Rate limiter misconfiguration: "${name}" is not a function. Check rateLimiter.js exports.`
       );


### PR DESCRIPTION
## Description

Added validation for rate limiter environment variables to prevent invalid values from disabling rate limiting.

### Changes Made

* Added `parsePositiveInt()` helper
* Added validation for `API_RATE_LIMIT_WINDOW_MS`
* Added validation for `API_RATE_LIMIT_MAX`
* Added validation for `RATE_LIMIT_WINDOW_MS`
* Added validation for `RATE_LIMIT_MAX_REQUESTS`
* Falls back to safe defaults when invalid values are provided

Fixes #763

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings