### PR TITLE
fix: require CORS_ORIGIN configuration

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -52,14 +52,17 @@ const CONTENT_FILE = path.join(__dirname, 'data', 'content.json');
 const app = express();
 initializeSentry(app);
 
-const allowedOrigins = process.env.CORS_ORIGIN
-  ? process.env.CORS_ORIGIN.split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-  : true;
+if (!process.env.CORS_ORIGIN) {
+  throw new Error('CORS_ORIGIN environment variable must be set.');
+}
+
+const allowedOrigins = process.env.CORS_ORIGIN.split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 app.use(helmet());
 app.use(cors({ origin: allowedOrigins, credentials: true }));
+
 app.use(express.json({ limit: '512kb' }));
 app.use(morgan('combined'));
 app.use(performanceMonitor);


### PR DESCRIPTION
## Description

Fixed insecure CORS configuration that allowed requests from any origin when `CORS_ORIGIN` was not configured.

### Changes Made

- Removed insecure `origin: true` fallback
- Added startup validation for `CORS_ORIGIN`
- Throws an error when `CORS_ORIGIN` is not configured
- Restricts CORS access to explicitly configured origins

Fixes #760

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings