### PR TITLE
fix(#763): guard parseInt env-var reads with NaN validation in rateLimiter.js

### DIFF
--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -2,25 +2,43 @@ import rateLimit from "express-rate-limit";
 import logger from "../utils/logger.js";
 
 // ---------------------------------------------------------------------------
+// Safe integer parser for environment variable configuration.
+// parseInt returns NaN when the env var is set to a non-numeric string
+// (e.g. "ten_minutes", "0x", or a string with a leading space after trimming).
+// Passing windowMs: NaN or max: NaN to express-rate-limit silently disables
+// the limiter or causes a runtime throw depending on the library version.
+// This helper falls back to the supplied default for any non-positive or
+// non-finite parsed value.
+// ---------------------------------------------------------------------------
+function parsePositiveInt(value, fallback) {
+  const n = parseInt(value, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// ---------------------------------------------------------------------------
 // Shared env-var config for the general API limiter
 // Override via API_RATE_LIMIT_WINDOW_MS and API_RATE_LIMIT_MAX in .env
 // ---------------------------------------------------------------------------
-const API_WINDOW_MS = process.env.API_RATE_LIMIT_WINDOW_MS
-  ? parseInt(process.env.API_RATE_LIMIT_WINDOW_MS, 10)
-  : 10 * 60 * 1000; // 10 minutes
+const API_WINDOW_MS = parsePositiveInt(
+  process.env.API_RATE_LIMIT_WINDOW_MS,
+  10 * 60 * 1000 // 10 minutes
+);
 
-const API_MAX_REQUESTS = process.env.API_RATE_LIMIT_MAX
-  ? parseInt(process.env.API_RATE_LIMIT_MAX, 10)
-  : 100;
+const API_MAX_REQUESTS = parsePositiveInt(
+  process.env.API_RATE_LIMIT_MAX,
+  100
+);
 
 // Shared env-var config for the form limiter
-const FORM_WINDOW_MS = process.env.RATE_LIMIT_WINDOW_MS
-  ? parseInt(process.env.RATE_LIMIT_WINDOW_MS, 10)
-  : 10 * 60 * 1000; // 10 minutes
+const FORM_WINDOW_MS = parsePositiveInt(
+  process.env.RATE_LIMIT_WINDOW_MS,
+  10 * 60 * 1000 // 10 minutes
+);
 
-const FORM_MAX_REQUESTS = process.env.RATE_LIMIT_MAX_REQUESTS
-  ? parseInt(process.env.RATE_LIMIT_MAX_REQUESTS, 10)
-  : 5;
+const FORM_MAX_REQUESTS = parsePositiveInt(
+  process.env.RATE_LIMIT_MAX_REQUESTS,
+  5
+);
 
 // ---------------------------------------------------------------------------
 // Global API rate limiter — applied to every /api route


### PR DESCRIPTION
## Summary

`rateLimiter.js` reads four rate-limit configuration values from environment variables using bare `parseInt` calls. When an env var is set to a non-numeric string (e.g. `ten_minutes`, a string with a leading space, or a hex literal like `0x`), `parseInt` returns `NaN`. Passing `windowMs: NaN` or `max: NaN` to `express-rate-limit` silently disables the limiter or causes a runtime throw depending on the library version, leaving every protected API endpoint exposed to unlimited requests.

Closes #763

## Root Cause

```js
// Before — NaN is silently accepted
const API_WINDOW_MS = process.env.API_RATE_LIMIT_WINDOW_MS
  ? parseInt(process.env.API_RATE_LIMIT_WINDOW_MS, 10)
  : 10 * 60 * 1000;
```

The ternary guard only checks for a truthy string. A truthy but non-numeric value (e.g. `"ten_minutes"`) passes the guard, `parseInt` returns `NaN`, and the limiter is initialised with `windowMs: NaN`.

## Fix

Added `parsePositiveInt(value, fallback)` which wraps `parseInt` and returns the fallback when the result is not a finite positive number. Applied it to all four env-var reads (`API_WINDOW_MS`, `API_MAX_REQUESTS`, `FORM_WINDOW_MS`, `FORM_MAX_REQUESTS`).

```js
function parsePositiveInt(value, fallback) {
  const n = parseInt(value, 10);
  return Number.isFinite(n) && n > 0 ? n : fallback;
}

const API_WINDOW_MS = parsePositiveInt(process.env.API_RATE_LIMIT_WINDOW_MS, 10 * 60 * 1000);
const API_MAX_REQUESTS = parsePositiveInt(process.env.API_RATE_LIMIT_MAX, 100);
```

## Files Changed

- `server/middleware/rateLimiter.js`: added `parsePositiveInt` helper; replaced all four bare `parseInt` calls.

## How to Test

1. Set `API_RATE_LIMIT_WINDOW_MS=ten_minutes` in `.env` and start the server.
2. Confirm the server starts without errors and the API limiter applies the default 10-minute window.
3. Set `API_RATE_LIMIT_MAX=50` and confirm requests are limited to 50 per window.

## Checklist

- [x] No behaviour change when env vars are unset or set to valid numeric strings.
- [x] No new dependencies.
- [x] All four env-var reads updated consistently.