### PR TITLE
fix(#762): validate formType against allowlist in handleFormByParam

### DIFF
--- a/server/controllers/formsController.js
+++ b/server/controllers/formsController.js
@@ -16,8 +16,18 @@ export function makeHandleForm(formType) {
   });
 }
 
+// Allowlist of form types accepted by the parameterised route.
+// These must match the keys recognised by formsService.handleForm and the
+// tabMap in formsService.appendFormToSheet. Any other value is rejected
+// with 400 before reaching the service layer or being written to Supabase
+// or Google Sheets.
+const ALLOWED_FORM_TYPES = new Set(['membership', 'recruitment', 'core_team']);
+
 export const handleFormByParam = wrapAsync(async (req, res) => {
   const formType = req.params?.formType;
+  if (!ALLOWED_FORM_TYPES.has(formType)) {
+    return res.status(400).json({ error: `Unknown form type: '${formType}'. Allowed values: ${[...ALLOWED_FORM_TYPES].join(', ')}.` });
+  }
   const result = await formsService.handleForm(formType, req.body || {});
   return res.json(result);
 });


### PR DESCRIPTION
## Summary

`handleFormByParam` in `server/controllers/formsController.js` reads `formType` from the URL parameter and passes it to `formsService.handleForm` without validating it against a known set of values. The service stores `formType` verbatim in the Supabase `form_type` column and uses it as a key in the Google Sheets `tabMap`. An attacker can submit arbitrary strings, writing unexpected data to both the database and Google Sheets.

Closes #762

## Root Cause

```js
// Before — no validation before reaching the service layer
export const handleFormByParam = wrapAsync(async (req, res) => {
  const formType = req.params?.formType;
  const result = await formsService.handleForm(formType, req.body || {});
  return res.json(result);
});
```

`formType` is used as a database column value and a sheet-tab lookup key with no restriction on what strings are accepted.

## Fix

Added `ALLOWED_FORM_TYPES = new Set(['membership', 'recruitment', 'core_team'])` matching the three keys in `formsService.appendFormToSheet`'s `tabMap`. If `formType` is missing or not in the set, the handler returns 400 before the service layer is reached.

```js
const ALLOWED_FORM_TYPES = new Set(['membership', 'recruitment', 'core_team']);

export const handleFormByParam = wrapAsync(async (req, res) => {
  const formType = req.params?.formType;
  if (!ALLOWED_FORM_TYPES.has(formType)) {
    return res.status(400).json({ error: `Unknown form type: '${formType}'. Allowed values: ${[...ALLOWED_FORM_TYPES].join(', ')}.` });
  }
  const result = await formsService.handleForm(formType, req.body || {});
  return res.json(result);
});
```

## Files Changed

- `server/controllers/formsController.js`: added `ALLOWED_FORM_TYPES` set and early return in `handleFormByParam`.

## How to Test

1. `POST /api/forms/unknown_type` should return 400 with an error listing valid values.
2. `POST /api/forms/membership` with a valid body should behave identically to before.
3. `POST /api/forms/../../etc/passwd` (path traversal attempt) should return 400.

## Checklist

- [x] Allowlist values match the `tabMap` keys in `formsService.js`.
- [x] No change to `makeHandleForm` (which already receives a hardcoded form type from the route definition).
- [x] No new dependencies.