### PR TITLE
fix(#761): redact internal error messages from 500 responses in wrapAsync

### DIFF
--- a/server/controllers/eventsController.js
+++ b/server/controllers/eventsController.js
@@ -4,7 +4,12 @@ import { paginationSchema } from '../validators/eventSchemas.js';
 function wrapAsync(fn) {
   return (req, res) =>
     Promise.resolve(fn(req, res)).catch((e) => {
-      res.status(500).json({ error: e?.message || 'Internal server error' });
+      // Log the full error server-side so it is visible in monitoring.
+      // Return only a generic string to the client: raw error messages can
+      // expose database column names, table names, file paths, or library
+      // internals that help an attacker profile the stack.
+      console.error('[eventsController]', e);
+      res.status(500).json({ error: 'Internal server error' });
     });
 }
 

--- a/server/controllers/formsController.js
+++ b/server/controllers/formsController.js
@@ -2,10 +2,15 @@ import { formsService } from '../services/formsService.js';
 
 function wrapAsync(fn) {
   return (req, res) => Promise.resolve(fn(req, res)).catch((e) => {
+    // 400 validation errors are client-facing and safe to return as-is.
     if (e && e.message === 'Invalid form submission' && e.details) {
       return res.status(400).json({ error: e.message, issues: e.details });
     }
-    return res.status(500).json({ error: e?.message || 'Internal server error' });
+    // Log internal errors server-side but return only a generic message to
+    // the client. Leaking e.message on 500s can expose database error
+    // strings, file paths, or library internals to callers.
+    console.error('[formsController]', e);
+    return res.status(500).json({ error: 'Internal server error' });
   });
 }
 


### PR DESCRIPTION
## Summary

The `wrapAsync` helper in both `server/controllers/eventsController.js` and `server/controllers/formsController.js` forwarded `e?.message` to HTTP clients on unhandled exceptions. Raw exception messages can expose database column names, table names, constraint names, file system paths, or third-party library internals. This information assists an attacker in profiling the underlying stack and crafting targeted exploits.

Closes #761

## Root Cause

```js
// eventsController.js and formsController.js (500 branch)
.catch((e) => {
  res.status(500).json({ error: e?.message || 'Internal server error' });
});
```

`e.message` can contain strings such as:
- `column "user_id" of relation "events" does not exist` (Postgres)
- `Cannot read properties of undefined (reading 'id')`
- `ENOENT: no such file or directory, open '/var/data/config.json'`

## Fix

Both `wrapAsync` catch blocks now log the full error server-side with `console.error` and return the static string `'Internal server error'` to the client. The 400 branch in `formsController.js` (which returns the `'Invalid form submission'` message with client-facing validation details) is left unchanged.

```js
// After
.catch((e) => {
  console.error('[eventsController]', e);
  res.status(500).json({ error: 'Internal server error' });
});
```

## Files Changed

- `server/controllers/eventsController.js`: updated `wrapAsync` catch block.
- `server/controllers/formsController.js`: updated `wrapAsync` 500 branch; 400 validation branch is unchanged.

## How to Test

1. Trigger a runtime error in any events endpoint (e.g. temporarily throw inside `listEvents`).
2. Confirm the response body is `{ "error": "Internal server error" }` with no stack trace or database details.
3. Confirm the full error is logged to the server console.
4. Submit an invalid form to confirm the 400 validation path still returns the detailed issues object.

## Checklist

- [x] No change to the 400 validation branch in `formsController.js`.
- [x] Server-side logging added so errors are still observable.
- [x] No new dependencies.