### PR TITLE
fix(#760): throw on startup when CORS_ORIGIN is unset instead of falling back to origin: true

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -52,11 +52,22 @@ const CONTENT_FILE = path.join(__dirname, 'data', 'content.json');
 const app = express();
 initializeSentry(app);
 
+// CORS_ORIGIN must be explicitly configured. Falling back to origin: true
+// (which reflects any Origin header back) is equivalent to a wildcard and
+// lets any website make credentialed cross-origin requests using the
+// visitor's stored cookies. Fail at startup rather than silently open the
+// API to every origin when the variable is missing.
+if (!process.env.CORS_ORIGIN) {
+  throw new Error(
+    'CORS_ORIGIN environment variable is not set. ' +
+    'Set it to a comma-separated list of allowed origins (e.g. https://nexasphere.org).'
+  );
+}
+
 const allowedOrigins = process.env.CORS_ORIGIN
-  ? process.env.CORS_ORIGIN.split(',')
-      .map((s) => s.trim())
-      .filter(Boolean)
-  : true;
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 app.use(helmet());
 app.use(cors({ origin: allowedOrigins, credentials: true }));


### PR DESCRIPTION
## Summary

The CORS configuration in `server/index.js` fell back to `origin: true` when the `CORS_ORIGIN` environment variable was not set. In the `cors` library, `origin: true` reflects the incoming `Origin` header back in `Access-Control-Allow-Origin`, which is functionally equivalent to the wildcard `*`. Any website could make credentialed cross-origin requests to the API using cookies stored in the visitor's browser. This is especially dangerous in development and staging environments where `CORS_ORIGIN` is typically not configured.

Closes #760

## Root Cause

```js
// Before — open fallback when CORS_ORIGIN is not set
const allowedOrigins = process.env.CORS_ORIGIN
  ? process.env.CORS_ORIGIN.split(',').map((s) => s.trim()).filter(Boolean)
  : true;  // reflects every Origin header back

app.use(cors({ origin: allowedOrigins, credentials: true }));
```

## Fix

Replaced the `true` fallback with a startup error. The process throws before binding if `CORS_ORIGIN` is not set, surfacing the misconfiguration in CI, container health checks, and on first deploy rather than silently in production traffic.

```js
if (!process.env.CORS_ORIGIN) {
  throw new Error(
    'CORS_ORIGIN environment variable is not set. ' +
    'Set it to a comma-separated list of allowed origins (e.g. https://nexasphere.org).'
  );
}

const allowedOrigins = process.env.CORS_ORIGIN
  .split(',')
  .map((s) => s.trim())
  .filter(Boolean);

app.use(cors({ origin: allowedOrigins, credentials: true }));
```

## Files Changed

- `server/index.js`: removed `origin: true` fallback; added startup guard for missing `CORS_ORIGIN`.

## Migration

Add `CORS_ORIGIN=http://localhost:5173` (or the appropriate production URL) to your `.env` file. The `.env.example` should be updated to include this variable if it does not already.

## How to Test

1. Remove `CORS_ORIGIN` from `.env` and start the server: it should throw with a descriptive error.
2. Set `CORS_ORIGIN=http://localhost:5173` and confirm the server starts and cross-origin requests from that origin are allowed.
3. Confirm requests from a different origin are rejected with a CORS error.

## Checklist

- [x] No behaviour change for correctly configured deployments.
- [x] Error message includes the variable name and an example value.
- [x] No new dependencies.