### PR TITLE
fix(java): prevent unhandled NullPointerException in /api/admin/me (#803)

### DIFF
--- a/server-java/src/main/java/org/nexasphere/controller/AdminController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/AdminController.java
@@ -61,6 +61,9 @@ public class AdminController {
     @GetMapping("/me")
     public Map<String, String> me() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getName() == null) {
+            throw new ResponseStatusException(HttpStatus.UNAUTHORIZED, "Not authenticated");
+        }
         return Collections.singletonMap("email", auth.getName());
     }
 


### PR DESCRIPTION
## Description
Fixed an unhandled `NullPointerException` inside the `/api/admin/me` GET mapping. When a request is sent without any authentication context, `SecurityContextHolder.getContext().getAuthentication()` resolves to `null`, which causes a crash on calling `auth.getName()`. Added a robust null safety check to throw a clean `401 Unauthorized` response status exception instead.

## Related Issue
Closes #803

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: knoxiboy
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] My changes follow the project structure and coding guidelines
- [x] I have verified that this issue still existed prior to implementing the fix
- [x] I have tested the endpoint manually to confirm a clean 401 response is returned when unauthenticated
- [x] No duplicate/stray print statements left in the code
