### PR TITLE
fix(website): rotate Admin Dashboard chart x-axis dates to prevent mobile truncation (#806)

### DIFF
--- a/website/src/features/analytics/TrendChart.tsx
+++ b/website/src/features/analytics/TrendChart.tsx
@@ -11,9 +11,18 @@ interface TrendChartProps {
 export const TrendChart: React.FC<TrendChartProps> = ({ data, loading }) => {
   return (
     <ChartWrapper title="Platform Trends" subtitle="User growth and activity over time" loading={loading} height={350}>
-      <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
+      <LineChart data={data} margin={{ top: 10, right: 10, left: 0, bottom: 20 }}>
         <CartesianGrid strokeDasharray="3 3" stroke="#333" vertical={false} />
-        <XAxis dataKey="name" stroke="#888" tick={{ fill: '#888' }} tickLine={false} axisLine={false} />
+        <XAxis 
+          dataKey="name" 
+          stroke="#888" 
+          tick={{ fill: '#888', fontSize: 11 }} 
+          tickLine={false} 
+          axisLine={false} 
+          angle={-45} 
+          textAnchor="end" 
+          height={50}
+        />
         <YAxis yAxisId="left" stroke="#888" tick={{ fill: '#888' }} tickLine={false} axisLine={false} />
         <YAxis yAxisId="right" orientation="right" stroke="#888" tick={{ fill: '#888' }} tickLine={false} axisLine={false} />
         <Tooltip content={<CustomTooltip />} />


### PR DESCRIPTION
## Description
On narrow screen viewports (320px to 480px), Recharts date string ticks inside the `TrendChart` component overlap or get truncated due to lack of a responsive tick layout. Added rotated tick formatting (`angle={-45}`), end text anchoring, bottom margin, and explicit spacing height configurations to ensure dates are perfectly aligned and readable on all responsive layouts.

## Related Issue
Closes #806

## Type of Contribution
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] GSSoC contribution

## Participant Info
- GitHub username: knoxiboy
- Contribution level (Beginner/Intermediate/Advanced): Beginner

## Checklist
- [x] My changes follow the project structure and coding guidelines
- [x] I have verified that this issue still existed prior to implementing the fix
- [x] Tested chart rendering to verify dates rotate and don't truncate on narrow mobile screens
