### PR TITLE
fix: prevent formula injection by using RAW valueInputOption in Googl…

### DIFF
--- a/api/core-team/apply.cjs
+++ b/api/core-team/apply.cjs
@@ -114,7 +114,7 @@ async function appendToSheet(payload) {
   await sheets.spreadsheets.values.append({
     spreadsheetId,
     range: `${sheetName}!A1`,
-    valueInputOption: 'USER_ENTERED',
+    valueInputOption: 'RAW',
     insertDataOption: 'INSERT_ROWS',
     requestBody: { values: [row] },
   });


### PR DESCRIPTION
## Description
Fixes formula injection vulnerability in `api/core-team/apply.cjs` where user-submitted form data was written to Google Sheets with `USER_ENTERED`, allowing malicious formulas to execute in the sheet. Changed `valueInputOption` from `'USER_ENTERED'` to `'RAW'` so all values are stored as plain strings.

Fixes #855

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings