### PR TITLE
fix: rename useSocket.js to useSocketConnection.js to resolve duplicate hook conflict

### DIFF
--- a/website/src/hooks/useSocketConnection.js
+++ b/website/src/hooks/useSocketConnection.js
@@ -1,6 +1,13 @@
 /**
- * Socket.IO React Hook
- * Provides reactive access to Socket.IO connections, room subscriptions, and event emitters
+ * useSocketConnection — Socket.IO Connection Manager Hook
+ *
+ * Manages the Socket.IO connection lifecycle (connect, disconnect, identify,
+ * join/leave rooms, emit events).
+ *
+ * NOTE: This hook was renamed from useSocket.js to useSocketConnection.js to
+ * resolve a naming conflict with useSocket.ts, which handles event listener
+ * subscriptions. Use this hook when you need connection state or need to emit.
+ * Use useSocket.ts when you need to subscribe to a specific socket event.
  */
 
 import { useEffect, useState, useCallback } from "react";


### PR DESCRIPTION
## Description
Two hooks existed at `website/src/hooks/useSocket.js` and `website/src/hooks/useSocket.ts` with the same export name `useSocket` but completely different APIs:
- `useSocket.js` — took `serverUrl`, managed connection state, returned `{ connected, socketId, join, leave, emit, on, off, identify }`
- `useSocket.ts` — took `(event, callback)`, used `SocketContext`, returned the socket instance

Any import of `useSocket` resolved to one of these silently depending on Vite/TS bundler resolution order, causing wrong-hook usage with no error or warning.

Fix: renamed `useSocket.js` → `useSocketConnection.js` and updated its file header comment to clearly distinguish the two hooks' responsibilities.

Fixes #878

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings