### PR TITLE
fix: cap unbounded localStorage writes in gamification and recommendation services

### DIFF
--- a/website/src/services/gamification/gamificationService.js
+++ b/website/src/services/gamification/gamificationService.js
@@ -10,7 +10,7 @@ export const XP_VALUES = {
   DAILY_STREAK: 20,
   ACHIEVEMENT_UNLOCK: 0,
   SHARE_EVENT: 15,
-  FEEDBACK_GIVEN: 10
+  FEEDBACK_GIVEN: 10,
 };
 
 // Achievement tiers and requirements
@@ -23,7 +23,7 @@ export const ACHIEVEMENTS = {
     icon: '🎯',
     tier: 'bronze',
     xpReward: 50,
-    requirement: { type: 'events_attended', count: 1 }
+    requirement: { type: 'events_attended', count: 1 },
   },
   EVENT_MASTER: {
     id: 'event_master',
@@ -32,7 +32,7 @@ export const ACHIEVEMENTS = {
     icon: '🏆',
     tier: 'gold',
     xpReward: 500,
-    requirement: { type: 'events_attended', count: 10 }
+    requirement: { type: 'events_attended', count: 10 },
   },
   EVENT_ADDICT: {
     id: 'event_addict',
@@ -41,7 +41,7 @@ export const ACHIEVEMENTS = {
     icon: '🌟',
     tier: 'platinum',
     xpReward: 1500,
-    requirement: { type: 'events_attended', count: 25 }
+    requirement: { type: 'events_attended', count: 25 },
   },
 
   // Streak achievements
@@ -52,7 +52,7 @@ export const ACHIEVEMENTS = {
     icon: '🔥',
     tier: 'bronze',
     xpReward: 30,
-    requirement: { type: 'streak', count: 3 }
+    requirement: { type: 'streak', count: 3 },
   },
   STREAK_7: {
     id: 'streak_7',
@@ -61,7 +61,7 @@ export const ACHIEVEMENTS = {
     icon: '⚡',
     tier: 'silver',
     xpReward: 100,
-    requirement: { type: 'streak', count: 7 }
+    requirement: { type: 'streak', count: 7 },
   },
   STREAK_30: {
     id: 'streak_30',
@@ -70,7 +70,7 @@ export const ACHIEVEMENTS = {
     icon: '👑',
     tier: 'platinum',
     xpReward: 500,
-    requirement: { type: 'streak', count: 30 }
+    requirement: { type: 'streak', count: 30 },
   },
 
   // Contribution achievements
@@ -81,7 +81,7 @@ export const ACHIEVEMENTS = {
     icon: '💬',
     tier: 'bronze',
     xpReward: 25,
-    requirement: { type: 'comments', count: 1 }
+    requirement: { type: 'comments', count: 1 },
   },
   COMMUNITY_BUILDER: {
     id: 'community_builder',
@@ -90,7 +90,7 @@ export const ACHIEVEMENTS = {
     icon: '🗣️',
     tier: 'gold',
     xpReward: 300,
-    requirement: { type: 'comments', count: 50 }
+    requirement: { type: 'comments', count: 50 },
   },
 
   // Referral achievements
@@ -101,7 +101,7 @@ export const ACHIEVEMENTS = {
     icon: '🤝',
     tier: 'silver',
     xpReward: 100,
-    requirement: { type: 'referrals', count: 1 }
+    requirement: { type: 'referrals', count: 1 },
   },
   REFERRAL_LEGEND: {
     id: 'referral_legend',
@@ -110,7 +110,7 @@ export const ACHIEVEMENTS = {
     icon: '🌟',
     tier: 'platinum',
     xpReward: 1000,
-    requirement: { type: 'referrals', count: 10 }
+    requirement: { type: 'referrals', count: 10 },
   },
 
   // Content creation
@@ -121,7 +121,7 @@ export const ACHIEVEMENTS = {
     icon: '✍️',
     tier: 'silver',
     xpReward: 50,
-    requirement: { type: 'content_created', count: 1 }
+    requirement: { type: 'content_created', count: 1 },
   },
 
   // Feedback
@@ -132,8 +132,8 @@ export const ACHIEVEMENTS = {
     icon: '📝',
     tier: 'bronze',
     xpReward: 20,
-    requirement: { type: 'feedback', count: 1 }
-  }
+    requirement: { type: 'feedback', count: 1 },
+  },
 };
 
 // Level thresholds
@@ -147,7 +147,7 @@ export const LEVEL_THRESHOLDS = [
   { level: 7, xpRequired: 2200, title: 'Grandmaster' },
   { level: 8, xpRequired: 3000, title: 'Legend' },
   { level: 9, xpRequired: 4000, title: 'Hero' },
-  { level: 10, xpRequired: 5500, title: 'Champion' }
+  { level: 10, xpRequired: 5500, title: 'Champion' },
 ];
 
 class GamificationService {
@@ -176,15 +176,38 @@ class GamificationService {
         shares: 0,
         current_streak: 0,
         longest_streak: 0,
-        last_active: null
+        last_active: null,
       },
       badges: [],
-      notifications: []
+      notifications: [],
     };
   }
 
   saveUserData() {
-    localStorage.setItem('gamification_user_data', JSON.stringify(this.userData));
+    // Cap notifications to last 50 to prevent unbounded localStorage growth
+    if (this.userData.notifications.length > 50) {
+      this.userData.notifications = this.userData.notifications.slice(-50);
+    }
+    try {
+      localStorage.setItem('gamification_user_data', JSON.stringify(this.userData));
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'QuotaExceededError') {
+        console.warn(
+          '[GamificationService] localStorage quota exceeded — trimming notifications ' +
+            'and retrying. Consider migrating to IndexedDB for long-term storage.'
+        );
+        // Aggressively trim notifications and retry once
+        this.userData.notifications = [];
+        try {
+          localStorage.setItem('gamification_user_data', JSON.stringify(this.userData));
+        } catch (_) {
+          // If it still fails, data loss is preferable to a thrown error
+          console.warn('[GamificationService] Retry after trim also failed — skipping save.');
+        }
+      } else {
+        throw err;
+      }
+    }
   }
 
   // Update user ID
@@ -196,34 +219,34 @@ class GamificationService {
   // Track user action and award XP
   trackAction(action, metadata = {}) {
     const xpEarned = XP_VALUES[action] || 0;
-    
+
     // Update stats based on action
     this.updateStats(action, metadata);
-    
+
     // Add XP
     this.addXP(xpEarned);
-    
+
     // Check and unlock achievements
     const newAchievements = this.checkAchievements();
-    
+
     // Update streak
     this.updateStreak();
-    
+
     // Save data
     this.saveUserData();
-    
+
     return {
       xpEarned,
       newAchievements,
       totalXP: this.userData.xp,
-      level: this.userData.level
+      level: this.userData.level,
     };
   }
 
   updateStats(action, metadata) {
     const stats = this.userData.stats;
-    
-    switch(action) {
+
+    switch (action) {
       case 'EVENT_ATTENDANCE':
         stats.events_attended++;
         break;
@@ -256,7 +279,7 @@ class GamificationService {
   updateLevel() {
     let newLevel = 1;
     let newTitle = 'Newcomer';
-    
+
     for (let i = LEVEL_THRESHOLDS.length - 1; i >= 0; i--) {
       if (this.userData.xp >= LEVEL_THRESHOLDS[i].xpRequired) {
         newLevel = LEVEL_THRESHOLDS[i].level;
@@ -264,15 +287,15 @@ class GamificationService {
         break;
       }
     }
-    
+
     if (newLevel > this.userData.level) {
       this.userData.notifications.push({
         type: 'level_up',
         message: `Congratulations! You reached Level ${newLevel} - ${newTitle}!`,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
     }
-    
+
     this.userData.level = newLevel;
     this.userData.title = newTitle;
   }
@@ -280,15 +303,15 @@ class GamificationService {
   updateStreak() {
     const today = new Date().toDateString();
     const lastActive = this.userData.stats.last_active;
-    
+
     if (lastActive === today) {
       return; // Already updated today
     }
-    
+
     const yesterday = new Date();
     yesterday.setDate(yesterday.getDate() - 1);
     const yesterdayStr = yesterday.toDateString();
-    
+
     if (lastActive === yesterdayStr) {
       this.userData.stats.current_streak++;
       if (this.userData.stats.current_streak > this.userData.stats.longest_streak) {
@@ -299,25 +322,25 @@ class GamificationService {
       this.userData.notifications.push({
         type: 'streak',
         message: `🔥 ${this.userData.stats.current_streak} day streak! +${XP_VALUES.DAILY_STREAK} XP`,
-        timestamp: new Date().toISOString()
+        timestamp: new Date().toISOString(),
       });
     } else if (lastActive !== today) {
       this.userData.stats.current_streak = 1;
     }
-    
+
     this.userData.stats.last_active = today;
   }
 
   checkAchievements() {
     const unlockedAchievements = [];
     const stats = this.userData.stats;
-    const existingIds = new Set(this.userData.achievements.map(a => a.id));
-    
+    const existingIds = new Set(this.userData.achievements.map((a) => a.id));
+
     for (const [key, achievement] of Object.entries(ACHIEVEMENTS)) {
       if (existingIds.has(achievement.id)) continue;
-      
+
       let progress = 0;
-      switch(achievement.requirement.type) {
+      switch (achievement.requirement.type) {
         case 'events_attended':
           progress = stats.events_attended;
           break;
@@ -337,30 +360,30 @@ class GamificationService {
           progress = stats.feedback;
           break;
       }
-      
+
       if (progress >= achievement.requirement.count) {
         this.userData.achievements.push({
           ...achievement,
-          unlockedAt: new Date().toISOString()
+          unlockedAt: new Date().toISOString(),
         });
         this.userData.badges.push({
           id: achievement.id,
           title: achievement.title,
           icon: achievement.icon,
           tier: achievement.tier,
-          unlockedAt: new Date().toISOString()
+          unlockedAt: new Date().toISOString(),
         });
         this.addXP(achievement.xpReward);
         unlockedAchievements.push(achievement);
-        
+
         this.userData.notifications.push({
           type: 'achievement',
           message: `🏆 Achievement Unlocked: ${achievement.title}! +${achievement.xpReward} XP`,
-          timestamp: new Date().toISOString()
+          timestamp: new Date().toISOString(),
         });
       }
     }
-    
+
     return unlockedAchievements;
   }
 
@@ -373,13 +396,13 @@ class GamificationService {
       achievements: this.userData.achievements,
       badges: this.userData.badges,
       stats: this.userData.stats,
-      notifications: this.userData.notifications
+      notifications: this.userData.notifications,
     };
   }
 
   getNextLevelXP() {
     const currentLevel = this.userData.level;
-    const nextLevel = LEVEL_THRESHOLDS.find(l => l.level === currentLevel + 1);
+    const nextLevel = LEVEL_THRESHOLDS.find((l) => l.level === currentLevel + 1);
     return nextLevel ? nextLevel.xpRequired : this.userData.xp;
   }
 
@@ -391,17 +414,22 @@ class GamificationService {
       { rank: 2, name: 'Sarah Chen', xp: 2420, level: 7, avatar: '👩‍💻' },
       { rank: 3, name: 'Mike Ross', xp: 2100, level: 7, avatar: '👨‍💼' },
       { rank: 4, name: 'Emma Watson', xp: 1850, level: 6, avatar: '👩‍🎓' },
-      { rank: 5, name: 'David Kim', xp: 1520, level: 6, avatar: '👨‍🔬' }
+      { rank: 5, name: 'David Kim', xp: 1520, level: 6, avatar: '👨‍🔬' },
     ];
   }
 
   getTierColor(tier) {
-    switch(tier) {
-      case 'bronze': return '#CD7F32';
-      case 'silver': return '#C0C0C0';
-      case 'gold': return '#FFD700';
-      case 'platinum': return '#E5E4E2';
-      default: return '#CC1111';
+    switch (tier) {
+      case 'bronze':
+        return '#CD7F32';
+      case 'silver':
+        return '#C0C0C0';
+      case 'gold':
+        return '#FFD700';
+      case 'platinum':
+        return '#E5E4E2';
+      default:
+        return '#CC1111';
     }
   }
 

--- a/website/src/services/recommendation/userInterestTracker.js
+++ b/website/src/services/recommendation/userInterestTracker.js
@@ -3,8 +3,32 @@
 const STORAGE_KEYS = {
   USER_INTERESTS: 'user_interests',
   USER_HISTORY: 'user_history',
-  USER_PREFERENCES: 'user_preferences'
+  USER_PREFERENCES: 'user_preferences',
 };
+
+// Maximum number of interaction history entries to retain.
+// Older entries beyond this cap are evicted to prevent localStorage quota overflow.
+const MAX_HISTORY_ENTRIES = 100;
+
+/**
+ * Safely writes a value to localStorage.
+ * Catches QuotaExceededError and logs a warning instead of silently
+ * corrupting other keys (bookmarks, roadmap autosave) that share the quota.
+ */
+function safeSetItem(key, value) {
+  try {
+    localStorage.setItem(key, value);
+  } catch (err) {
+    if (err instanceof DOMException && err.name === 'QuotaExceededError') {
+      console.warn(
+        `[UserInterestTracker] localStorage quota exceeded while saving "${key}". ` +
+          'Oldest history entries have been trimmed — consider migrating to IndexedDB.'
+      );
+    } else {
+      throw err;
+    }
+  }
+}
 
 class UserInterestTracker {
   constructor() {
@@ -15,11 +39,13 @@ class UserInterestTracker {
 
   loadInterests() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_INTERESTS);
-    return stored ? JSON.parse(stored) : {
-      categories: {},
-      tags: {},
-      events: {}
-    };
+    return stored
+      ? JSON.parse(stored)
+      : {
+          categories: {},
+          tags: {},
+          events: {},
+        };
   }
 
   loadHistory() {
@@ -29,45 +55,51 @@ class UserInterestTracker {
 
   loadPreferences() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_PREFERENCES);
-    return stored ? JSON.parse(stored) : {
-      preferredCategories: [],
-      preferredTags: [],
-      preferredTimeSlots: [],
-      preferredLocations: []
-    };
+    return stored
+      ? JSON.parse(stored)
+      : {
+          preferredCategories: [],
+          preferredTags: [],
+          preferredTimeSlots: [],
+          preferredLocations: [],
+        };
   }
 
   trackEventInteraction(eventId, action, metadata = {}) {
     const interaction = {
       eventId,
-      action, // 'view', 'register', 'attend', 'like', 'share'
+      action,
       timestamp: new Date().toISOString(),
-      metadata
+      metadata,
     };
-    
+
     this.history.push(interaction);
+
+    // Evict oldest entries beyond the cap to prevent unbounded growth
+    if (this.history.length > MAX_HISTORY_ENTRIES) {
+      this.history = this.history.slice(-MAX_HISTORY_ENTRIES);
+    }
+
     this.updateInterests(interaction);
     this.save();
-    
+
     return interaction;
   }
 
   updateInterests(interaction) {
-    // Update category interest
     if (interaction.metadata.category) {
       const cat = interaction.metadata.category;
       this.interests.categories[cat] = (this.interests.categories[cat] || 0) + 1;
     }
-    
-    // Update tag interests
+
     if (interaction.metadata.tags && Array.isArray(interaction.metadata.tags)) {
-      interaction.metadata.tags.forEach(tag => {
+      interaction.metadata.tags.forEach((tag) => {
         this.interests.tags[tag] = (this.interests.tags[tag] || 0) + 1;
       });
     }
-    
-    // Update event interest
-    this.interests.events[interaction.eventId] = (this.interests.events[interaction.eventId] || 0) + 1;
+
+    this.interests.events[interaction.eventId] =
+      (this.interests.events[interaction.eventId] || 0) + 1;
   }
 
   setUserPreferences(categories, tags) {
@@ -77,23 +109,21 @@ class UserInterestTracker {
   }
 
   getUserInterests() {
-    // Get top 5 categories by interest score
     const topCategories = Object.entries(this.interests.categories)
       .sort((a, b) => b[1] - a[1])
       .slice(0, 5)
       .map(([name]) => name);
-    
-    // Get top 10 tags
+
     const topTags = Object.entries(this.interests.tags)
       .sort((a, b) => b[1] - a[1])
       .slice(0, 10)
       .map(([name]) => name);
-    
+
     return {
       topCategories,
       topTags,
       totalInteractions: this.history.length,
-      preferences: this.preferences
+      preferences: this.preferences,
     };
   }
 
@@ -102,15 +132,20 @@ class UserInterestTracker {
   }
 
   save() {
-    localStorage.setItem(STORAGE_KEYS.USER_INTERESTS, JSON.stringify(this.interests));
-    localStorage.setItem(STORAGE_KEYS.USER_HISTORY, JSON.stringify(this.history));
-    localStorage.setItem(STORAGE_KEYS.USER_PREFERENCES, JSON.stringify(this.preferences));
+    safeSetItem(STORAGE_KEYS.USER_INTERESTS, JSON.stringify(this.interests));
+    safeSetItem(STORAGE_KEYS.USER_HISTORY, JSON.stringify(this.history));
+    safeSetItem(STORAGE_KEYS.USER_PREFERENCES, JSON.stringify(this.preferences));
   }
 
   clearHistory() {
     this.interests = { categories: {}, tags: {}, events: {} };
     this.history = [];
-    this.preferences = { preferredCategories: [], preferredTags: [], preferredTimeSlots: [], preferredLocations: [] };
+    this.preferences = {
+      preferredCategories: [],
+      preferredTags: [],
+      preferredTimeSlots: [],
+      preferredLocations: [],
+    };
     this.save();
   }
 }


### PR DESCRIPTION
## Description
Two services wrote unbounded data to `localStorage` on every update with no size cap, TTL, or error handling. On an active session, accumulated history and notifications could silently fill the ~5MB `localStorage` quota, causing `QuotaExceededError` to be thrown — which would then silently corrupt unrelated writes like bookmark saves (`bookmarkStorage.ts`) and roadmap autosave (`RoadmapBuilderContext.tsx`).

**`gamificationService.js`:**
- Wrapped `saveUserData()` in a `try/catch` for `QuotaExceededError`
- Added a cap of 50 entries on `notifications` array before every save
- On quota breach: trims notifications to zero and retries the save once before giving up gracefully

**`userInterestTracker.js`:**
- Added `safeSetItem()` helper that catches `QuotaExceededError` and logs a clear warning instead of letting it propagate silently
- Capped `history` array to last 100 entries in `trackEventInteraction()` — oldest entries are evicted automatically on every write

Fixes #882

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings