### PR TITLE
fix: import exportPrompts in Chatbot.jsx to resolve ReferenceError on export button click

### DIFF
--- a/website/src/shared/Chatbot.jsx
+++ b/website/src/shared/Chatbot.jsx
@@ -4,7 +4,7 @@ import '../styles/chatbot.css';
 import PromptHistorySidebar from '../components/history/PromptHistorySidebar';
 import SearchBar from '../components/history/SearchBar';
 import PinnedChats from '../components/history/PinnedChats';
-import { savePrompt } from '../lib/promptStore';
+import { savePrompt, exportPrompts } from '../lib/promptStore';
 import { initializeWorkspaces } from '../lib/workspaceService';
 import { buildUrl, getAiApiBase } from '../utils/runtimeConfig';
 


### PR DESCRIPTION
## Description
`Chatbot.jsx` line 181 calls `exportPrompts(currentWorkspace)` on the export button click, but `exportPrompts` was never imported into the file — causing `ReferenceError: exportPrompts is not defined` and crashing the chatbot UI whenever the export button was clicked.

The function was already fully implemented and exported in `website/src/lib/promptStore.js` (fetches all prompts from IndexedDB and downloads them as a JSON file). The fix is a single-line import addition.

Changes made:
- Added `exportPrompts` to the existing `promptStore` import on line 7 of `Chatbot.jsx`
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #909

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings