### PR TITLE
fix: replace unconditional 4s polling with visibilitychange in App.jsx and TeamPage.jsx

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,4 +1,13 @@
-import { useState, useEffect, useRef, useCallback, useLayoutEffect, lazy, Suspense, memo } from 'react';
+import {
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useLayoutEffect,
+  lazy,
+  Suspense,
+  memo,
+} from 'react';
 import {
   BrowserRouter,
   Routes,
@@ -428,10 +437,15 @@ function AppShell() {
     };
 
     fetchEvents();
-    const interval = setInterval(fetchEvents, 4000);
+    // Removed unconditional 4s polling — socket event handles live updates.
+    // Re-fetch once when the tab becomes visible again after being backgrounded.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') fetchEvents();
+    };
     const onContentUpdated = (data) => {
       if (data?.type === 'events' || data?.type === 'activities') fetchEvents();
     };
+    document.addEventListener('visibilitychange', onVisibilityChange);
     on('content:updated', onContentUpdated);
 
     return () => {

--- a/website/src/pages/team/TeamPage.jsx
+++ b/website/src/pages/team/TeamPage.jsx
@@ -129,14 +129,18 @@ export default function TeamPage({ onBack, onApply }) {
     };
 
     fetchTeam();
-    const interval = setInterval(fetchTeam, 4000);
-
+    // Removed unconditional 4s polling — socket event handles live updates.
+    // Re-fetch once when the tab becomes visible again after being backgrounded.
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') fetchTeam();
+    };
     // Socket: refetch immediately when admin updates team
     const onContentUpdated = (data) => {
       if (data?.type === 'team') {
         fetchTeam();
       }
     };
+    document.addEventListener('visibilitychange', onVisibilityChange);
     on('content:updated', onContentUpdated);
 
     return () => {


### PR DESCRIPTION
## Description
`App.jsx` and `TeamPage.jsx` both had unconditional `setInterval` calls polling the API every 4 seconds:

- `App.jsx` — `setInterval(fetchEvents, 4000)`
- `TeamPage.jsx` — `setInterval(fetchTeam, 4000)`

Both pages already subscribe to the `content:updated` socket event which triggers an immediate refetch whenever the admin updates data — making the polling intervals completely redundant. The intervals fired 15 times per minute regardless of whether the user was active, the tab was visible, or any data had changed, causing unnecessary network load and battery drain especially on mobile.

Changes made:
- Removed `setInterval(fetchEvents, 4000)` from `App.jsx`
- Removed `setInterval(fetchTeam, 4000)` from `TeamPage.jsx`
- Added a `visibilitychange` listener in both files that triggers a single refetch when the tab becomes visible again after being backgrounded — preserving the freshness guarantee without continuous polling
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #910

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings