### PR TITLE
fix: replace hardcoded localhost:8000 with getAiApiBase() in AiMentor.jsx

### DIFF
--- a/website/src/components/dashboard/AiMentor.jsx
+++ b/website/src/components/dashboard/AiMentor.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import apiClient from '../../utils/apiClient.js';
+import { getAiApiBase, buildUrl } from '../../utils/runtimeConfig';
 
 export default function AiMentor() {
   const [code, setCode] = useState('');
@@ -9,15 +10,23 @@ export default function AiMentor() {
 
   const handleSubmit = async () => {
     if (!code.trim()) return;
+
+    const reviewUrl = buildUrl(getAiApiBase(), '/ai/review');
+    if (!reviewUrl) {
+      setResult({
+        error: 'AI Mentor is not available in this deployment. Please configure VITE_AI_API_BASE.',
+      });
+      return;
+    }
+
     setLoading(true);
     setResult(null);
 
     try {
-      const base = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
-      const data = await apiClient(`${base}/ai/review`, {
+      const data = await apiClient(reviewUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ code, language })
+        body: JSON.stringify({ code, language }),
       });
       setResult(data);
     } catch (err) {
@@ -29,17 +38,37 @@ export default function AiMentor() {
   };
 
   return (
-    <div className="ai-mentor" style={{ background: 'var(--bg-glass)', padding: '24px', borderRadius: '16px', border: '1px solid var(--b2)', display: 'flex', flexDirection: 'column', gap: '16px' }}>
+    <div
+      className="ai-mentor"
+      style={{
+        background: 'var(--bg-glass)',
+        padding: '24px',
+        borderRadius: '16px',
+        border: '1px solid var(--b2)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+      }}
+    >
       <h3 style={{ color: 'var(--t1)', display: 'flex', alignItems: 'center', gap: '8px' }}>
         🤖 AI Mentor & Code Reviewer
       </h3>
-      <p style={{ color: 'var(--t2)', fontSize: '0.9rem' }}>Submit your code for an AI review, score, and mock interview question.</p>
+      <p style={{ color: 'var(--t2)', fontSize: '0.9rem' }}>
+        Submit your code for an AI review, score, and mock interview question.
+      </p>
 
       <div style={{ display: 'flex', gap: '8px' }}>
-        <select 
-          value={language} 
-          onChange={e => setLanguage(e.target.value)}
-          style={{ background: 'rgba(0,0,0,0.2)', color: 'var(--t1)', border: '1px solid var(--b2)', padding: '8px', borderRadius: '8px', outline: 'none' }}
+        <select
+          value={language}
+          onChange={(e) => setLanguage(e.target.value)}
+          style={{
+            background: 'rgba(0,0,0,0.2)',
+            color: 'var(--t1)',
+            border: '1px solid var(--b2)',
+            padding: '8px',
+            borderRadius: '8px',
+            outline: 'none',
+          }}
         >
           <option value="python">Python</option>
           <option value="javascript">JavaScript</option>
@@ -49,44 +78,108 @@ export default function AiMentor() {
         </select>
       </div>
 
-      <textarea 
+      <textarea
         value={code}
-        onChange={e => setCode(e.target.value)}
+        onChange={(e) => setCode(e.target.value)}
         placeholder="Paste your code here..."
         style={{
-          width: '100%', height: '150px', background: 'rgba(0,0,0,0.3)', color: '#00ffcc', 
-          border: '1px solid var(--b2)', borderRadius: '8px', padding: '12px', 
-          fontFamily: 'monospace', resize: 'vertical', outline: 'none'
+          width: '100%',
+          height: '150px',
+          background: 'rgba(0,0,0,0.3)',
+          color: '#00ffcc',
+          border: '1px solid var(--b2)',
+          borderRadius: '8px',
+          padding: '12px',
+          fontFamily: 'monospace',
+          resize: 'vertical',
+          outline: 'none',
         }}
       />
 
-      <button 
-        onClick={handleSubmit} 
+      <button
+        onClick={handleSubmit}
         disabled={loading || !code.trim()}
         className="btn btn-primary"
-        style={{ alignSelf: 'flex-start', padding: '8px 24px', opacity: (loading || !code.trim()) ? 0.5 : 1 }}
+        style={{
+          alignSelf: 'flex-start',
+          padding: '8px 24px',
+          opacity: loading || !code.trim() ? 0.5 : 1,
+        }}
       >
         {loading ? 'Reviewing...' : 'Get AI Review'}
       </button>
 
       {result && !result.error && (
-        <div style={{ marginTop: '16px', padding: '16px', background: 'rgba(255,255,255,0.02)', borderRadius: '12px', border: '1px solid var(--c1-50)' }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '12px' }}>
+        <div
+          style={{
+            marginTop: '16px',
+            padding: '16px',
+            background: 'rgba(255,255,255,0.02)',
+            borderRadius: '12px',
+            border: '1px solid var(--c1-50)',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: '12px',
+            }}
+          >
             <h4 style={{ color: 'var(--c1)' }}>Review Results</h4>
-            <span style={{ background: 'var(--c1)', color: '#fff', padding: '4px 12px', borderRadius: '20px', fontWeight: 'bold' }}>
+            <span
+              style={{
+                background: 'var(--c1)',
+                color: '#fff',
+                padding: '4px 12px',
+                borderRadius: '20px',
+                fontWeight: 'bold',
+              }}
+            >
               Score: {result.score}/10
             </span>
           </div>
-          <p style={{ color: 'var(--t1)', marginBottom: '12px', fontSize: '0.95rem', lineHeight: '1.5' }}>{result.overview}</p>
-          
+          <p
+            style={{
+              color: 'var(--t1)',
+              marginBottom: '12px',
+              fontSize: '0.95rem',
+              lineHeight: '1.5',
+            }}
+          >
+            {result.overview}
+          </p>
+
           <h5 style={{ color: 'var(--t2)', marginBottom: '8px' }}>Actionable Suggestions:</h5>
-          <ul style={{ color: 'var(--t1)', paddingLeft: '20px', marginBottom: '16px', fontSize: '0.9rem' }}>
-            {result.suggestions && result.suggestions.map((s, i) => <li key={i} style={{ marginBottom: '4px' }}>{s}</li>)}
+          <ul
+            style={{
+              color: 'var(--t1)',
+              paddingLeft: '20px',
+              marginBottom: '16px',
+              fontSize: '0.9rem',
+            }}
+          >
+            {result.suggestions &&
+              result.suggestions.map((s, i) => (
+                <li key={i} style={{ marginBottom: '4px' }}>
+                  {s}
+                </li>
+              ))}
           </ul>
 
-          <div style={{ background: 'rgba(204,17,17,0.1)', padding: '12px', borderRadius: '8px', borderLeft: '4px solid var(--c1)' }}>
+          <div
+            style={{
+              background: 'rgba(204,17,17,0.1)',
+              padding: '12px',
+              borderRadius: '8px',
+              borderLeft: '4px solid var(--c1)',
+            }}
+          >
             <h5 style={{ color: 'var(--c1)', marginBottom: '4px' }}>Mock Interview Question:</h5>
-            <p style={{ color: 'var(--t1)', fontSize: '0.9rem', fontStyle: 'italic' }}>"{result.interview_question}"</p>
+            <p style={{ color: 'var(--t1)', fontSize: '0.9rem', fontStyle: 'italic' }}>
+              "{result.interview_question}"
+            </p>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Description
`AiMentor.jsx` hardcoded `http://localhost:8000` as a fallback when `VITE_API_BASE` is not set:

```js
const base = import.meta.env.VITE_API_BASE || 'http://localhost:8000';
```

In any deployed environment where `VITE_API_BASE` is not configured, all AI review requests were silently sent to `http://localhost:8000` — a URL that doesn't exist in production — causing every "Get AI Review" click to fail with a network error. The rest of the codebase already uses `getAiApiBase()` from `runtimeConfig.js` which correctly returns `http://localhost:8000` only when actually running on localhost, and returns an empty string in all other environments.

Changes made:
- Removed the hardcoded `http://localhost:8000` fallback from `handleSubmit`
- Replaced with `getAiApiBase()` + `buildUrl()` from `runtimeConfig.js`, consistent with the rest of the codebase
- Added an early return with a clear user-facing message when the AI API is not configured in the current deployment, instead of silently firing a request to a non-existent URL
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #920

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings