### PR TITLE
fix: use constant-time admin password comparison

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -4,13 +4,26 @@ import {
   revokeAdminSession,
   startAdminSessionCleanup,
 } from '../repositories/adminSessionsRepository.js';
+import crypto from 'crypto';
+function safeEqual(a, b) {
+  const bufA = Buffer.from(String(a));
+  const bufB = Buffer.from(String(b));
 
+  if (bufA.length !== bufB.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(bufA, bufB);
+}
 const ADMIN_USERNAME = requiredEnv('ADMIN_USERNAME');
 const ADMIN_PASSWORD = requiredStrongPassword('ADMIN_PASSWORD');
 const LOGIN_WINDOW_MS = parsePositiveInteger(process.env.ADMIN_LOGIN_WINDOW_MS, 15 * 60 * 1000);
 const LOGIN_MAX_ATTEMPTS = parsePositiveInteger(process.env.ADMIN_LOGIN_MAX_ATTEMPTS, 5);
 const LOGIN_MAX_TRACKED_IPS = parsePositiveInteger(process.env.ADMIN_LOGIN_MAX_TRACKED_IPS, 10000);
-const LOGIN_CLEANUP_INTERVAL_MS = parsePositiveInteger(process.env.ADMIN_LOGIN_CLEANUP_INTERVAL_MS, 15 * 60 * 1000);
+const LOGIN_CLEANUP_INTERVAL_MS = parsePositiveInteger(
+  process.env.ADMIN_LOGIN_CLEANUP_INTERVAL_MS,
+  15 * 60 * 1000
+);
 
 const loginAttemptsByIp = new Map();
 
@@ -59,7 +72,10 @@ function requiredStrongPassword(name) {
 }
 
 function getClientIp(req) {
-  const ip = String(req.ip || req.headers['x-forwarded-for'] || 'unknown').split(',')[0].trim() || 'unknown';
+  const ip =
+    String(req.ip || req.headers['x-forwarded-for'] || 'unknown')
+      .split(',')[0]
+      .trim() || 'unknown';
   // Truncate to maximum 128 characters to prevent extremely large malicious headers from causing memory exhaustion
   return ip.slice(0, 128);
 }
@@ -131,7 +147,7 @@ function parseBearer(authHeader = '') {
 function getCookie(req, name) {
   const cookieHeader = req.headers.cookie;
   if (!cookieHeader) return null;
-  const cookies = cookieHeader.split(';').map(c => c.trim());
+  const cookies = cookieHeader.split(';').map((c) => c.trim());
   for (const cookie of cookies) {
     const [key, value] = cookie.split('=');
     if (key === name) return value;
@@ -145,7 +161,10 @@ async function requireAdmin(req, res, next) {
       return res.status(400).json({ error: 'Do not pass tokens in URLs.' });
     }
 
-    const token = req.cookies?.ns_admin_token || getCookie(req, 'ns_admin_token') || parseBearer(req.headers.authorization || '');
+    const token =
+      req.cookies?.ns_admin_token ||
+      getCookie(req, 'ns_admin_token') ||
+      parseBearer(req.headers.authorization || '');
     const session = await getAdminSession(token);
 
     if (!session) {
@@ -170,7 +189,7 @@ async function login(req, res) {
       return res.status(429).json({ error: 'Too many login attempts. Please wait and try again.' });
     }
 
-    if (u !== ADMIN_USERNAME || p !== ADMIN_PASSWORD) {
+    if (!safeEqual(u, ADMIN_USERNAME) || !safeEqual(p, ADMIN_PASSWORD)) {
       recordLoginAttempt(ip);
       return res.status(401).json({ error: 'Invalid credentials' });
     }
@@ -203,7 +222,10 @@ async function login(req, res) {
 
 async function logout(req, res) {
   try {
-    const token = req.cookies?.ns_admin_token || getCookie(req, 'ns_admin_token') || parseBearer(req.headers.authorization || '');
+    const token =
+      req.cookies?.ns_admin_token ||
+      getCookie(req, 'ns_admin_token') ||
+      parseBearer(req.headers.authorization || '');
     if (token) {
       await revokeAdminSession(token);
     }


### PR DESCRIPTION
## Description

Replaced direct password comparison in the admin authentication middleware with a constant-time comparison using Node.js `crypto.timingSafeEqual` to mitigate timing side-channel attacks.

### Changes Made

* Added `safeEqual()` helper using `crypto.timingSafeEqual`
* Replaced direct `!==` credential comparisons
* Preserved existing authentication behavior
* Improved security against timing attacks

Closes #834

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature
* [ ] Breaking change
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings