### PR TITLE
feat: render missing upcomingEvents stat card in DashboardHome

### DIFF
--- a/admin-dashboard/src/pages/DashboardHome.jsx
+++ b/admin-dashboard/src/pages/DashboardHome.jsx
@@ -58,7 +58,7 @@ export function DashboardHome() {
 
       {loading ? (
         <div className="stats-grid">
-          <Skeleton height={100} count={3} />
+          <Skeleton height={100} count={4} />
         </div>
       ) : (
         <div className="stats-grid">
@@ -69,6 +69,15 @@ export function DashboardHome() {
             <div>
               <div className="stat-value">{stats.totalEvents}</div>
               <div className="stat-label">Total Events</div>
+            </div>
+          </div>
+          <div className="stat-card">
+            <span className="stat-icon">
+              <AdminIcon name="Clock" size={28} aria-hidden="true" />
+            </span>
+            <div>
+              <div className="stat-value">{stats.upcomingEvents}</div>
+              <div className="stat-label">Upcoming Events</div>
             </div>
           </div>
           <div className="stat-card">


### PR DESCRIPTION
closes #797 
## Description
The admin dashboard was computing `upcomingEvents` inside `setStats` 
but never rendering it anywhere. The dashboard showed only 3 stat cards 
(Total Events, Core Team, Applications) while the 4th value was silently 
thrown away on every render. Admins had no way to see upcoming event 
count without navigating away.

This PR adds the missing 4th stat card for Upcoming Events between 
Total Events and Core Team cards.

Fixes #797

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings