### PR TITLE
fix: replace hardcoded localhost:5001 with VITE_ADMIN_DASHBOARD_URL in publicContentStore.js

### DIFF
--- a/website/src/utils/publicContentStore.js
+++ b/website/src/utils/publicContentStore.js
@@ -128,7 +128,12 @@ export function initStorageSyncBridge() {
   if (bridgeInitialized || typeof window === 'undefined') return;
   bridgeInitialized = true;
 
-  const adminOrigin = 'http://localhost:5001';
+  // Read admin origin from VITE_ADMIN_DASHBOARD_URL — already defined in
+  // .env.example for both local dev and production deployments.
+  // Falls back to http://localhost:5001 only when running locally.
+  const adminOrigin =
+    (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ADMIN_DASHBOARD_URL) ||
+    'http://localhost:5001';
   const bridgeUrl = `${adminOrigin}/sync-bridge.html`;
 
   // Check if we're in a cross-origin context (different port)


### PR DESCRIPTION
## Description
`publicContentStore.js` hardcoded `http://localhost:5001` as the admin dashboard origin in `initStorageSyncBridge()`:

```js
const adminOrigin = 'http://localhost:5001';
```

This URL is used to embed an invisible iframe for the cross-origin `localStorage` sync bridge between the frontend and admin dashboard. In any deployed environment where the admin dashboard runs on a different URL, the bridge never connects — the iframe fails to load silently, and all `postMessage` events are ignored because the origin doesn't match. Content updates made in the admin dashboard are never received by the frontend.

Changes made:
- Replaced the hardcoded `http://localhost:5001` with `VITE_ADMIN_DASHBOARD_URL`, which is already defined in `.env.example` for both local development (`http://localhost:5001`) and production deployments
- Falls back to `http://localhost:5001` only when the env var is unset, preserving existing local development behaviour
- No new environment variables introduced — reuses the existing `VITE_ADMIN_DASHBOARD_URL` already documented in `.env.example`
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #923

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings