### PR TITLE
fix: replace local getApiBase() with shared runtimeConfig import in CertificateVerifyPage

### DIFF
--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -12,15 +12,11 @@
  */
 
 import { useEffect, useState } from 'react';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function getApiBase() {
-  const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
-  return base || 'http://localhost:8080';
-}
 
 function formatDate(dateStr) {
   if (!dateStr) return '—';


### PR DESCRIPTION
## Description
`CertificateVerifyPage.jsx` defined its own local `getApiBase()` function that hardcoded `http://localhost:8080` as a fallback:

```js
function getApiBase() {
  const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
  return base || 'http://localhost:8080';
}
```

In any deployed environment where `VITE_API_BASE` is not configured, all certificate verification requests were silently sent to `http://localhost:8080` — a URL that doesn't exist in production — causing every `/verify/:id` page visit to fail with a network error. The rest of the codebase uses `getApiBase()` from `runtimeConfig.js` which correctly returns an empty string in production when unconfigured, instead of falling back to a hardcoded localhost URL.

Changes made:
- Removed the local `getApiBase()` definition from `CertificateVerifyPage.jsx`
- Added import of `getApiBase` from `../../utils/runtimeConfig`
- All three call sites (`fetchVerification`, `apiBase` assignment, and the download URL builder) now use the shared utility automatically
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #933

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings