### PR TITLE
fix: restore body overflow on unmount in ProjectsPage to prevent permanent scroll lock

### DIFF
--- a/website/src/pages/projects/ProjectsPage.jsx
+++ b/website/src/pages/projects/ProjectsPage.jsx
@@ -5,16 +5,24 @@ import { projectsData } from '../../data/projectsData';
 import SafeImage from '../../shared/SafeImage';
 import '../../styles/projects.css';
 
-const CATEGORIES = ['All', 'Web App', 'Mobile', 'Machine Learning', 'Cybersecurity', 'UI/UX Design'];
+const CATEGORIES = [
+  'All',
+  'Web App',
+  'Mobile',
+  'Machine Learning',
+  'Cybersecurity',
+  'UI/UX Design',
+];
 
 export default function ProjectsPage({ onBack }) {
   const [activeCategory, setActiveCategory] = useState('All');
   const [selectedProject, setSelectedProject] = useState(null);
 
   // Filter projects based on category
-  const filteredProjects = activeCategory === 'All'
-    ? projectsData
-    : projectsData.filter(project => project.category === activeCategory);
+  const filteredProjects =
+    activeCategory === 'All'
+      ? projectsData
+      : projectsData.filter((project) => project.category === activeCategory);
 
   // Handle escape key for modal
   useEffect(() => {
@@ -27,13 +35,18 @@ export default function ProjectsPage({ onBack }) {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [selectedProject]);
 
-  // Prevent background scrolling when modal is open
+  // Prevent background scrolling when modal is open.
+  // Saves the original overflow value and restores it on both
+  // modal close AND component unmount to prevent the page becoming
+  // permanently unscrollable if the user navigates away while modal is open.
   useEffect(() => {
+    const originalOverflow = document.body.style.overflow;
     if (selectedProject) {
       document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'unset';
     }
+    return () => {
+      document.body.style.overflow = originalOverflow;
+    };
   }, [selectedProject]);
 
   return (
@@ -44,12 +57,14 @@ export default function ProjectsPage({ onBack }) {
           ← Back to Home
         </button>
         <h1 className="projects-title">Project Showcase</h1>
-        <p className="projects-subtitle">Discover the innovative solutions built by the NexaSphere community.</p>
+        <p className="projects-subtitle">
+          Discover the innovative solutions built by the NexaSphere community.
+        </p>
       </div>
 
       {/* Category Filters */}
       <div className="category-filters" role="tablist" aria-label="Project Categories">
-        {CATEGORIES.map(category => (
+        {CATEGORIES.map((category) => (
           <button
             key={category}
             role="tab"
@@ -85,7 +100,12 @@ export default function ProjectsPage({ onBack }) {
               aria-label={`View details for ${project.title}`}
             >
               <div className="project-card-image">
-                <SafeImage src={project.image} alt={project.title} loading="lazy" fallbackType="project" />
+                <SafeImage
+                  src={project.image}
+                  alt={project.title}
+                  loading="lazy"
+                  fallbackType="project"
+                />
                 <div className="project-card-overlay">
                   <span className="view-details-text">View Details</span>
                 </div>
@@ -95,8 +115,10 @@ export default function ProjectsPage({ onBack }) {
                 <h3 className="project-card-title">{project.title}</h3>
                 <p className="project-card-desc">{project.shortDesc}</p>
                 <div className="project-tech-stack">
-                  {project.techStack.slice(0, 3).map(tech => (
-                    <span key={tech} className="tech-pill">{tech}</span>
+                  {project.techStack.slice(0, 3).map((tech) => (
+                    <span key={tech} className="tech-pill">
+                      {tech}
+                    </span>
                   ))}
                   {project.techStack.length > 3 && (
                     <span className="tech-pill">+{project.techStack.length - 3}</span>
@@ -116,7 +138,13 @@ export default function ProjectsPage({ onBack }) {
       {/* Project Details Modal */}
       <AnimatePresence>
         {selectedProject && (
-          <div className="modal-overlay projects-modal-overlay" onClick={() => setSelectedProject(null)} role="dialog" aria-modal="true" aria-labelledby="modal-title">
+          <div
+            className="modal-overlay projects-modal-overlay"
+            onClick={() => setSelectedProject(null)}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="modal-title"
+          >
             <motion.div
               initial={{ opacity: 0, y: 50, scale: 0.95 }}
               animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -125,40 +153,58 @@ export default function ProjectsPage({ onBack }) {
               className="modal-box project-modal"
               onClick={(e) => e.stopPropagation()}
             >
-              <button 
-                className="modal-close" 
-                onClick={() => setSelectedProject(null)} 
+              <button
+                className="modal-close"
+                onClick={() => setSelectedProject(null)}
                 aria-label="Close modal"
                 autoFocus
               >
                 <X size={20} />
               </button>
 
-              <SafeImage src={selectedProject.image} alt={selectedProject.title} className="project-modal-image" fallbackType="project" />
-              
+              <SafeImage
+                src={selectedProject.image}
+                alt={selectedProject.title}
+                className="project-modal-image"
+                fallbackType="project"
+              />
+
               <div className="project-modal-header">
                 <span className="project-category">{selectedProject.category}</span>
-                <h2 id="modal-title" className="project-modal-title">{selectedProject.title}</h2>
+                <h2 id="modal-title" className="project-modal-title">
+                  {selectedProject.title}
+                </h2>
               </div>
 
               <div className="project-modal-body">
                 <p className="project-modal-desc">{selectedProject.longDesc}</p>
-                
+
                 <div className="project-modal-section">
-                  <h4 className="section-title"><Tag size={16} /> Tech Stack</h4>
+                  <h4 className="section-title">
+                    <Tag size={16} /> Tech Stack
+                  </h4>
                   <div className="project-tech-stack">
-                    {selectedProject.techStack.map(tech => (
-                      <span key={tech} className="tech-pill">{tech}</span>
+                    {selectedProject.techStack.map((tech) => (
+                      <span key={tech} className="tech-pill">
+                        {tech}
+                      </span>
                     ))}
                   </div>
                 </div>
 
                 <div className="project-modal-section">
-                  <h4 className="section-title"><Users size={16} /> Team</h4>
+                  <h4 className="section-title">
+                    <Users size={16} /> Team
+                  </h4>
                   <div className="project-team-list">
                     {selectedProject.team.map((member, idx) => (
                       <div key={idx} className="team-member">
-                        <SafeImage src={member.photo} alt={member.name} className="team-member-photo" fallbackType="avatar" />
+                        <SafeImage
+                          src={member.photo}
+                          alt={member.name}
+                          className="team-member-photo"
+                          fallbackType="avatar"
+                        />
                         <div className="team-member-info">
                           <span className="team-member-name">{member.name}</span>
                           <span className="team-member-role">{member.role}</span>
@@ -171,12 +217,24 @@ export default function ProjectsPage({ onBack }) {
 
               <div className="project-modal-footer">
                 {selectedProject.github && selectedProject.github !== '#' && (
-                  <a href={selectedProject.github} target="_blank" rel="noopener noreferrer" className="btn btn-outline" aria-label="View Source Code on GitHub">
+                  <a
+                    href={selectedProject.github}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-outline"
+                    aria-label="View Source Code on GitHub"
+                  >
                     <Code size={18} /> Source Code
                   </a>
                 )}
                 {selectedProject.demo && selectedProject.demo !== '#' && (
-                  <a href={selectedProject.demo} target="_blank" rel="noopener noreferrer" className="btn btn-primary" aria-label="View Live Demo">
+                  <a
+                    href={selectedProject.demo}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="btn btn-primary"
+                    aria-label="View Live Demo"
+                  >
                     <ExternalLink size={18} /> Live Demo
                   </a>
                 )}


### PR DESCRIPTION
## Description
`ProjectsPage.jsx` set `document.body.style.overflow = 'hidden'` when a project modal was opened, but the cleanup only ran when `selectedProject` changed — not when the component unmounted:

```js
useEffect(() => {
  if (selectedProject) {
    document.body.style.overflow = 'hidden';
  } else {
    document.body.style.overflow = 'unset';
  }
}, [selectedProject]);
```

If the user navigated away from the Projects page while a modal was open (e.g. clicked the Back button or a nav tab), `selectedProject` never became `null` — the cleanup branch never ran — and `document.body.style.overflow` stayed as `'hidden'` permanently. The entire site became unscrollable until the page was refreshed.

Changes made:
- Saved the original `document.body.style.overflow` value at effect run time
- Moved the restore logic into the `useEffect` cleanup function, which now runs on both modal close **and** component unmount
- Removed the `else` branch — cleanup function handles both cases correctly
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #935

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings