### PR TITLE
fix(security): cap failedPasskeyAttempts Map size and add periodic cleanup sweep

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -373,7 +373,24 @@ app.get('/api/portfolio/:username', async (req, res) => {
   }
 });
 
+// Hard cap on tracked username:ip pairs. When the limit is reached, the
+// oldest inserted entry is evicted before adding a new one, preventing the
+// Map from growing without bound when an attacker rotates through many
+// distinct usernames from the same or different IP addresses.
+const MAX_PASSKEY_TRACKED_KEYS = 10_000;
 const failedPasskeyAttempts = new Map();
+
+// Periodic sweep every 30 minutes: remove entries whose lockout period has
+// expired and whose attempt count has already been reset to 0, so they do
+// not accumulate for keys that are never visited again.
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of failedPasskeyAttempts) {
+    if (entry.count === 0 && now > entry.lockoutUntil) {
+      failedPasskeyAttempts.delete(key);
+    }
+  }
+}, 30 * 60 * 1000).unref();
 
 function checkPasskeyLockout(username, ip) {
   const key = `${String(username || '').toLowerCase()}:${ip}`;
@@ -388,6 +405,10 @@ function checkPasskeyLockout(username, ip) {
 
 function recordFailedPasskeyAttempt(username, ip) {
   const key = `${String(username || '').toLowerCase()}:${ip}`;
+  // Evict the oldest entry when the Map is at capacity and this is a new key.
+  if (!failedPasskeyAttempts.has(key) && failedPasskeyAttempts.size >= MAX_PASSKEY_TRACKED_KEYS) {
+    failedPasskeyAttempts.delete(failedPasskeyAttempts.keys().next().value);
+  }
   const entry = failedPasskeyAttempts.get(key) || { count: 0, lockoutUntil: 0 };
   entry.count += 1;
   if (entry.count >= 5) {


### PR DESCRIPTION
## Summary

Closes #802

The `failedPasskeyAttempts` Map in `server/index.js` had no upper-bound on its size and no cleanup mechanism for expired entries. An attacker rotating through many unique usernames creates one new Map entry per attempt. Entries for keys that are never retried remain in memory permanently, making this a viable memory exhaustion path given enough requests.

## Root Cause

```js
const failedPasskeyAttempts = new Map(); // no size cap, no TTL cleanup

function recordFailedPasskeyAttempt(username, ip) {
  const key = `${username}:${ip}`;
  const entry = failedPasskeyAttempts.get(key) || { count: 0, lockoutUntil: 0 };
  // ...
  failedPasskeyAttempts.set(key, entry);
}
```

Entries are only deleted when `checkPasskeyLockout` is called for the same key again. Keys that are never reused stay in the Map indefinitely.

## What Changed

`server/index.js` only:

**1. Hard cap on Map size (`MAX_PASSKEY_TRACKED_KEYS = 10 000`)**

When `recordFailedPasskeyAttempt` is called with a new key and the Map is already at capacity, the oldest-inserted entry is evicted before the new one is added. JavaScript Maps preserve insertion order, so `map.keys().next().value` always returns the oldest key. This bounds the maximum number of tracked entries regardless of how many distinct keys the attacker rotates through.

**2. Periodic sweep every 30 minutes**

A `setInterval` removes entries whose lockout period has elapsed and whose attempt count has been reset to 0. These entries would never be cleaned up by the normal request path if the attacker never retries the same key. The timer is `unref()`-ed so it does not keep the Node.js event loop alive in test environments.

## Testing

1. Call `recordFailedPasskeyAttempt` with more than 10 000 distinct keys. Assert `failedPasskeyAttempts.size` does not exceed `MAX_PASSKEY_TRACKED_KEYS`.
2. Insert an entry, advance the clock past 30 minutes (or trigger the interval manually), assert the expired entry is removed.
3. Existing passkey lockout behavior is unchanged: 5 failed attempts still produces a 15-minute lockout.

## Type of Change

- [x] Bug fix (security / memory exhaustion)

*NSoC '26 contribution*