### PR TITLE
fix(auth): secure admin logout mechanism and invalidate tokens

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -180,7 +180,7 @@ app.delete(
 
 // Admin Auth Endpoints
 app.post('/api/admin/login', authRateLimiter, adminAuthMiddleware.login);
-app.post('/api/admin/logout', adminAuthMiddleware.logout);
+app.post('/api/admin/logout', adminAuth, adminAuthMiddleware.logout);
 app.use('/api/admin/analytics', adminAuth, analyticsRouter);
 app.use('/api/admin/metrics', adminAuth, adminStreamRouter);
 

--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -222,12 +222,13 @@ async function login(req, res) {
 
 async function logout(req, res) {
   try {
-    const token =
-      req.cookies?.ns_admin_token ||
-      getCookie(req, 'ns_admin_token') ||
-      parseBearer(req.headers.authorization || '');
+    const token = req.adminSession?.token;
+
     if (token) {
       await revokeAdminSession(token);
+    } else {
+      // In case logout is called without authentication
+      return res.status(401).json({ error: 'No active session to revoke' });
     }
 
     res.clearCookie('ns_admin_token', {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -30,7 +30,7 @@ router.delete(
 // Admin auth
 router.get('/api/admin/users', adminAuthMiddleware.requireAdmin, usersController.getAdminUsers);
 router.post('/api/admin/login', adminAuthMiddleware.login);
-router.post('/api/admin/logout', adminAuthMiddleware.logout);
+router.post('/api/admin/logout', adminAuthMiddleware.requireAdmin, adminAuthMiddleware.logout);
 
 router.get('/api/admin/events', adminAuthMiddleware.requireAdmin, eventsController.adminListEvents);
 router.post(

--- a/server/test/adminAuthMiddleware.test.js
+++ b/server/test/adminAuthMiddleware.test.js
@@ -16,10 +16,10 @@ const createMockReqRes = (ip, username, password) => {
     headers: {},
     get: () => '',
   };
-  
+
   let statusCode = 200;
   let responseData = null;
-  
+
   const res = {
     status(code) {
       statusCode = code;
@@ -40,9 +40,9 @@ const createMockReqRes = (ip, username, password) => {
     },
     responseData() {
       return responseData;
-    }
+    },
   };
-  
+
   return { req, res };
 };
 
@@ -60,7 +60,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
 
     const ip = '192.168.1.50';
     const { req, res } = createMockReqRes(ip, 'admin', 'wrongpass');
-    
+
     await adminAuthMiddleware.login(req, res);
     assert.equal(res.statusCode(), 401);
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
@@ -82,7 +82,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     adminAuthMiddleware._clearAllLoginAttempts();
 
     const ip = '192.168.1.60';
-    
+
     // Failed attempt 1
     const { req: reqFail, res: resFail } = createMockReqRes(ip, 'admin', 'wrongpass');
     await adminAuthMiddleware.login(reqFail, resFail);
@@ -90,9 +90,13 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
 
     // Successful attempt
-    const { req: reqSuccess, res: resSuccess } = createMockReqRes(ip, 'admin', 'AdminStrongPass123!');
+    const { req: reqSuccess, res: resSuccess } = createMockReqRes(
+      ip,
+      'admin',
+      'AdminStrongPass123!'
+    );
     await adminAuthMiddleware.login(reqSuccess, resSuccess);
-    
+
     // The credentials match and success returns 200 (or calls createAdminSession which fails because DB isn't connected, returning 500 but it should have cleared the attempts first!)
     // Yes! clearLoginAttempts(ip) is called before createAdminSession:
     // 113: clearLoginAttempts(ip);
@@ -104,7 +108,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     adminAuthMiddleware._clearAllLoginAttempts();
 
     const ip = '192.168.1.70';
-    
+
     // Attempt 1: Failed (Attempts set to 1)
     const { req: req1, res: res1 } = createMockReqRes(ip, 'admin', 'wrongpass');
     await adminAuthMiddleware.login(req1, res1);
@@ -157,82 +161,119 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
 
   await t.test('Adversarial: Large IP Header String Truncation', async () => {
     adminAuthMiddleware._clearAllLoginAttempts();
-    
+
     const massiveHeader = '1.1.1.1,' + 'A'.repeat(50000);
     const req = {
       body: { username: 'admin', password: 'wrongpassword' },
       headers: { 'x-forwarded-for': massiveHeader },
       get: () => '',
     };
-    
+
     let statusCode = 200;
     const res = {
-      status(code) { statusCode = code; return this; },
-      json() { return this; }
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json() {
+        return this;
+      },
     };
-    
+
     await adminAuthMiddleware.login(req, res);
     assert.equal(statusCode, 401);
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
   });
 
-  await t.test('Adversarial: Eviction priority evicts blocked IPs before unblocked ones', async () => {
-    adminAuthMiddleware._clearAllLoginAttempts();
+  await t.test(
+    'Adversarial: Eviction priority evicts blocked IPs before unblocked ones',
+    async () => {
+      adminAuthMiddleware._clearAllLoginAttempts();
 
-    const blockedIp = '10.0.0.1';
-    const unblockedIp = '10.0.0.2';
+      const blockedIp = '10.0.0.1';
+      const unblockedIp = '10.0.0.2';
 
-    // Block blockedIp with 3 failed attempts (> max 2)
-    for (let i = 0; i < 3; i++) {
-      const { req, res } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-      await adminAuthMiddleware.login(req, res);
+      // Block blockedIp with 3 failed attempts (> max 2)
+      for (let i = 0; i < 3; i++) {
+        const { req, res } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
+        await adminAuthMiddleware.login(req, res);
+      }
+      const { req: reqCheckBlocked, res: resCheckBlocked } = createMockReqRes(
+        blockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqCheckBlocked, resCheckBlocked);
+      assert.equal(resCheckBlocked.statusCode(), 429);
+
+      // Add unblockedIp with 1 failed attempt
+      const { req: reqUnblocked, res: resUnblocked } = createMockReqRes(
+        unblockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqUnblocked, resUnblocked);
+      assert.equal(resUnblocked.statusCode(), 401);
+
+      // Flood map with 8 more unique IPs to fill past capacity (5) and trigger eviction
+      for (let i = 3; i <= 10; i++) {
+        const { req, res } = createMockReqRes(`10.0.0.${i}`, 'admin', 'wrongpass');
+        await adminAuthMiddleware.login(req, res);
+      }
+
+      assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
+
+      // blockedIp must be evicted (blocked IPs are evicted first)
+      const { req: reqVerifyEvicted, res: resVerifyEvicted } = createMockReqRes(
+        blockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqVerifyEvicted, resVerifyEvicted);
+      assert.equal(resVerifyEvicted.statusCode(), 401);
+
+      // unblockedIp must still be in map (unblocked IPs preserved)
+      const { req: reqVerifyPreserved, res: resVerifyPreserved } = createMockReqRes(
+        unblockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqVerifyPreserved, resVerifyPreserved);
+      assert.equal(resVerifyPreserved.statusCode(), 401);
     }
-    const { req: reqCheckBlocked, res: resCheckBlocked } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqCheckBlocked, resCheckBlocked);
-    assert.equal(resCheckBlocked.statusCode(), 429);
-
-    // Add unblockedIp with 1 failed attempt
-    const { req: reqUnblocked, res: resUnblocked } = createMockReqRes(unblockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqUnblocked, resUnblocked);
-    assert.equal(resUnblocked.statusCode(), 401);
-
-    // Flood map with 8 more unique IPs to fill past capacity (5) and trigger eviction
-    for (let i = 3; i <= 10; i++) {
-      const { req, res } = createMockReqRes(`10.0.0.${i}`, 'admin', 'wrongpass');
-      await adminAuthMiddleware.login(req, res);
-    }
-
-    assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
-
-    // blockedIp must be evicted (blocked IPs are evicted first)
-    const { req: reqVerifyEvicted, res: resVerifyEvicted } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqVerifyEvicted, resVerifyEvicted);
-    assert.equal(resVerifyEvicted.statusCode(), 401);
-
-    // unblockedIp must still be in map (unblocked IPs preserved)
-    const { req: reqVerifyPreserved, res: resVerifyPreserved } = createMockReqRes(unblockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqVerifyPreserved, resVerifyPreserved);
-    assert.equal(resVerifyPreserved.statusCode(), 401);
-  });
+  );
 
   await t.test('Stress & Concurrency: 1000 Concurrent Requests', async () => {
     adminAuthMiddleware._clearAllLoginAttempts();
-    
+
     const startTime = Date.now();
     const concurrentRequests = 1000;
     const promises = [];
-    
+
     for (let i = 0; i < concurrentRequests; i++) {
       const ip = `172.16.0.${i % 254}`;
       const { req, res } = createMockReqRes(ip, 'admin', 'wrongpass');
       promises.push(adminAuthMiddleware.login(req, res));
     }
-    
+
     await Promise.all(promises);
     const duration = Date.now() - startTime;
-    
-    console.log(`[Combined Concurrency Test] Processed ${concurrentRequests} requests in ${duration}ms`);
+
+    console.log(
+      `[Combined Concurrency Test] Processed ${concurrentRequests} requests in ${duration}ms`
+    );
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
     assert.ok(duration < 500);
+  });
+
+  await t.test('Logout requires an active session in req.adminSession (returns 401)', async () => {
+    adminAuthMiddleware._clearAllLoginAttempts();
+    const { req, res } = createMockReqRes('10.0.0.99', 'admin', '');
+
+    // Simulate a request without a token attached by requireAdmin
+    await adminAuthMiddleware.logout(req, res);
+
+    assert.equal(res.statusCode(), 401);
+    assert.equal(res.responseData().error, 'No active session to revoke');
   });
 });


### PR DESCRIPTION
closes #879
Fixes #879 by adding requireAdmin middleware to the /api/admin/logout endpoint to ensure only authenticated requests can revoke tokens. Also updates the logout handler to securely extract the validated token directly from the request object.

## Description
This PR fixes a critical security vulnerability where admin session tokens remained valid in the backend database after logout. The `/api/admin/logout` endpoint was previously unprotected by `requireAdmin`, which meant that if a client failed to send the correct session token/cookie (e.g., missing credentials header), the backend silently returned success and cleared local client cookies, but completely skipped the server-side revocation.

Fixes #879

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings