### PR TITLE
Fix admin dashboard auth flow with field mismatch, undefined state, and missing headers

### DIFF
--- a/admin-dashboard/src/__tests__/services/auth.test.js
+++ b/admin-dashboard/src/__tests__/services/auth.test.js
@@ -33,7 +33,7 @@ describe('auth.login', () => {
     expect(fetch).toHaveBeenCalledWith(`${API_BASE}/api/admin/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'test@example.com', password: 'secret123' }),
+      body: JSON.stringify({ username: 'test@example.com', password: 'secret123' }),
     });
     expect(localStorage.getItem('ns_admin_token')).toBe(token);
     expect(localStorage.getItem('ns_admin_email')).toBe('test@example.com');
@@ -49,6 +49,11 @@ describe('auth.login', () => {
 
     await auth.login('a@b.com', 'x');
 
+    expect(fetch).toHaveBeenCalledWith(`${API_BASE}/api/admin/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'a@b.com', password: 'x' }),
+    });
     expect(localStorage.getItem('ns_admin_token')).toBe('tok');
     expect(localStorage.getItem('ns_admin_token_expiry')).toBeNull();
   });

--- a/admin-dashboard/src/services/auth.js
+++ b/admin-dashboard/src/services/auth.js
@@ -1,31 +1,30 @@
-const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8080";
-const TOKEN_KEY = "ns_admin_token";
-const EMAIL_KEY = "ns_admin_email";
-const EXPIRY_KEY = "ns_admin_token_expiry";
+const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8080';
+const TOKEN_KEY = 'ns_admin_token';
+const EMAIL_KEY = 'ns_admin_email';
+const EXPIRY_KEY = 'ns_admin_token_expiry';
 
 export const auth = {
-  async login(email, password) {
-    const cleanEmail = email.trim().toLowerCase();
+  async login(username, password) {
+    const cleanUsername = username.trim().toLowerCase();
     const cleanPassword = password.trim();
 
     const res = await fetch(`${API_BASE}/api/admin/login`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ email: cleanEmail, password: cleanPassword }),
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: cleanUsername, password: cleanPassword }),
     });
 
     if (!res.ok) {
       const err = await res.json().catch(() => ({}));
-      throw new Error(err.error || err.message || "Invalid credentials");
+      throw new Error(err.error || err.message || 'Invalid credentials');
     }
 
     const data = await res.json();
 
-    // Persist the token so subsequent requests can use it
     if (data.token) {
       localStorage.setItem(TOKEN_KEY, data.token);
     }
-    localStorage.setItem(EMAIL_KEY, cleanEmail);
+    localStorage.setItem(EMAIL_KEY, cleanUsername);
     if (data.expiresAt) {
       localStorage.setItem(EXPIRY_KEY, data.expiresAt);
     }
@@ -38,7 +37,7 @@ export const auth = {
     if (token) {
       // Fire-and-forget — don't block logout on network
       fetch(`${API_BASE}/api/admin/logout`, {
-        method: "POST",
+        method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
       }).catch(() => {});
     }

--- a/website/src/pages/admin/AdminPage.jsx
+++ b/website/src/pages/admin/AdminPage.jsx
@@ -9,23 +9,28 @@ import socketClient from '../../utils/socketClient';
 export default function AdminPage({ onBack }) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
-  const [isLoggedIn, setIsLoggedIn] = useState(() => localStorage.getItem('ns_admin_logged_in') === 'true');
+  const [isLoggedIn, setIsLoggedIn] = useState(
+    () => localStorage.getItem('ns_admin_logged_in') === 'true'
+  );
+  const [token, setToken] = useState(null);
   const [loginData, setLoginData] = useState({ username: '', password: '' });
   const [data, setData] = useState({
     stats: null,
     growth: [],
-    events: []
+    events: [],
   });
 
   const fetchAnalytics = async () => {
     try {
       setLoading(true);
       const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
-      
+      const authToken = token || localStorage.getItem('ns_admin_token');
+      const headers = { Authorization: `Bearer ${authToken}` };
+
       const [stats, growth, events] = await Promise.all([
         apiClient(`${base}/api/admin/analytics/stats`, { headers }),
         apiClient(`${base}/api/admin/analytics/growth`, { headers }),
-        apiClient(`${base}/api/admin/analytics/events`, { headers })
+        apiClient(`${base}/api/admin/analytics/events`, { headers }),
       ]);
 
       setData({ stats, growth, events });
@@ -89,7 +94,7 @@ export default function AdminPage({ onBack }) {
               currentData = line.slice(6);
             } else if (line === '' && currentEvent && currentData) {
               const event = { data: currentData };
-              (listeners[currentEvent] || []).forEach(fn => fn(event));
+              (listeners[currentEvent] || []).forEach((fn) => fn(event));
               currentEvent = '';
               currentData = '';
             }
@@ -120,21 +125,27 @@ export default function AdminPage({ onBack }) {
         const parsed = JSON.parse(event.data);
         const payload = parsed.data;
 
-        setData(prev => {
-          const currentStats = prev.stats || { totalUsers: null, activeRegistrations: null, upcomingEvents: null, conversionRate: null };
+        setData((prev) => {
+          const currentStats = prev.stats || {
+            totalUsers: null,
+            activeRegistrations: null,
+            upcomingEvents: null,
+            conversionRate: null,
+          };
           const nextStats = {
             ...currentStats,
             totalUsers: currentStats.totalUsers !== null ? currentStats.totalUsers + 1 : 1,
-            activeRegistrations: currentStats.activeRegistrations !== null ? currentStats.activeRegistrations + 1 : 1
+            activeRegistrations:
+              currentStats.activeRegistrations !== null ? currentStats.activeRegistrations + 1 : 1,
           };
 
           const todayStr = new Date().toISOString().split('T')[0];
           const updatedGrowth = [...(prev.growth || [])];
-          const todayIdx = updatedGrowth.findIndex(g => g.date === todayStr);
+          const todayIdx = updatedGrowth.findIndex((g) => g.date === todayStr);
           if (todayIdx >= 0) {
             updatedGrowth[todayIdx] = {
               ...updatedGrowth[todayIdx],
-              registrations: (updatedGrowth[todayIdx].registrations || 0) + 1
+              registrations: (updatedGrowth[todayIdx].registrations || 0) + 1,
             };
           } else {
             updatedGrowth.push({ date: todayStr, registrations: 1 });
@@ -143,7 +154,7 @@ export default function AdminPage({ onBack }) {
           return {
             ...prev,
             stats: nextStats,
-            growth: updatedGrowth
+            growth: updatedGrowth,
           };
         });
       } catch (err) {
@@ -175,11 +186,16 @@ export default function AdminPage({ onBack }) {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(loginData),
-        credentials: 'include'
+        credentials: 'include',
       });
 
-      localStorage.setItem('ns_admin_token', result.token);
-      setToken(result.token);
+      if (result.token) {
+        localStorage.setItem('ns_admin_token', result.token);
+        setToken(result.token);
+      }
+      localStorage.setItem('ns_admin_logged_in', 'true');
+      setIsLoggedIn(true);
+      setError(null);
     } catch (err) {
       setError(err.message);
     } finally {
@@ -192,7 +208,7 @@ export default function AdminPage({ onBack }) {
       const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
       await fetch(`${base}/api/admin/logout`, {
         method: 'POST',
-        credentials: 'include'
+        credentials: 'include',
       });
     } catch (err) {
       console.error(err);
@@ -206,31 +222,47 @@ export default function AdminPage({ onBack }) {
   if (!isLoggedIn) {
     return (
       <div className="analytics-dashboard" style={{ maxWidth: 400, marginTop: '10vh' }}>
-        <button onClick={onBack} className="btn-back">← Back</button>
+        <button onClick={onBack} className="btn-back">
+          ← Back
+        </button>
         <div className="chart-container" style={{ padding: '2rem' }}>
           <h2 style={{ textAlign: 'center', marginBottom: '1.5rem' }}>Admin Login</h2>
-          <form onSubmit={handleLogin} style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}>
-            <input 
-              type="text" 
-              placeholder="Username" 
-              className="input-field" 
+          <form
+            onSubmit={handleLogin}
+            style={{ display: 'flex', flexDirection: 'column', gap: '1rem' }}
+          >
+            <input
+              type="text"
+              placeholder="Username"
+              className="input-field"
               value={loginData.username}
-              onChange={e => setLoginData({...loginData, username: e.target.value})}
+              onChange={(e) => setLoginData({ ...loginData, username: e.target.value })}
               required
             />
-            <input 
-              type="password" 
-              placeholder="Password" 
-              className="input-field" 
+            <input
+              type="password"
+              placeholder="Password"
+              className="input-field"
               value={loginData.password}
-              onChange={e => setLoginData({...loginData, password: e.target.value})}
+              onChange={(e) => setLoginData({ ...loginData, password: e.target.value })}
               required
             />
             <button type="submit" className="btn btn-primary" disabled={loading}>
               {loading ? 'Authenticating...' : 'Login to Dashboard'}
             </button>
           </form>
-          {error && <p style={{ color: '#f87171', fontSize: '0.9rem', marginTop: '1rem', textAlign: 'center' }}>{error}</p>}
+          {error && (
+            <p
+              style={{
+                color: '#f87171',
+                fontSize: '0.9rem',
+                marginTop: '1rem',
+                textAlign: 'center',
+              }}
+            >
+              {error}
+            </p>
+          )}
         </div>
       </div>
     );
@@ -238,15 +270,34 @@ export default function AdminPage({ onBack }) {
 
   return (
     <div className="analytics-dashboard">
-      <header style={{ marginBottom: '2rem', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+      <header
+        style={{
+          marginBottom: '2rem',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'flex-start',
+        }}
+      >
         <div>
-          <button onClick={onBack} className="btn-back">← Back to Home</button>
-          <h1 style={{ fontSize: '2rem', marginBottom: '0.5rem', marginTop: '0.5rem' }}>Admin Analytics</h1>
+          <button onClick={onBack} className="btn-back">
+            ← Back to Home
+          </button>
+          <h1 style={{ fontSize: '2rem', marginBottom: '0.5rem', marginTop: '0.5rem' }}>
+            Admin Analytics
+          </h1>
           <p style={{ opacity: 0.7 }}>Visualizing platform growth and event performance.</p>
         </div>
         <div style={{ display: 'flex', gap: '0.5rem' }}>
-          <button className="btn btn-outline" onClick={fetchAnalytics} disabled={loading}>Refresh</button>
-          <button className="btn btn-outline" onClick={handleLogout} style={{ borderColor: 'rgba(239, 68, 68, 0.5)', color: '#ef4444' }}>Logout</button>
+          <button className="btn btn-outline" onClick={fetchAnalytics} disabled={loading}>
+            Refresh
+          </button>
+          <button
+            className="btn btn-outline"
+            onClick={handleLogout}
+            style={{ borderColor: 'rgba(239, 68, 68, 0.5)', color: '#ef4444' }}
+          >
+            Logout
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## What this fixes

The admin dashboard authentication system had four independent failures that made the admin panel completely non-functional. The `auth.login()` in `admin-dashboard/src/services/auth.js` sent `{ email, password }` to the server, but `adminAuthMiddleware.js:164` reads `req.body.username`, so every login returned 401 regardless of credentials. `AdminPage.jsx` initialized `isLoggedIn` from localStorage but never set it to `true` after a successful login, so the component always rendered the login form. The `handleLogin` function called `setToken(result.token)` without a defined `setToken` state setter — only `setLoginData` and `setIsLoggedIn` existed. And `fetchAnalytics` referenced an undeclared `headers` variable, causing a crash on any analytics API call.

## Root cause

Four independent issues:

1. **Field name mismatch** — `auth.js:14` serialized `{ email, password }` but the server at `adminAuthMiddleware.js:164` destructured `req.body.username`. The `u` variable was always empty, so `u !== ADMIN_USERNAME` always evaluated to true, returning 401.

2. **Missing state setter** — `AdminPage.jsx` had no `const [token, setToken]` declaration. The call `setToken(result.token)` threw a `ReferenceError` at runtime, preventing the catch block from setting `isLoggedIn`.

3. **Login persistence gap** — Even on a successful response, `handleLogin` never called `setIsLoggedIn(true)` or persisted `ns_admin_logged_in` to localStorage. The component re-rendered with `isLoggedIn` still false, showing the login form again.

4. **Undefined headers in fetchAnalytics** — The `headers` variable was never declared before being passed to three `apiClient` calls in `fetchAnalytics`, causing a `ReferenceError` on dashboard mount.

## What changed

- **`admin-dashboard/src/services/auth.js`**: Changed the `login` method parameter from `email` to `username` and the request body field from `email` to `username` to match what `adminAuthMiddleware.login()` expects.
- **`website/src/pages/admin/AdminPage.jsx`**: Added `const [token, setToken] = useState(null)` state declaration. Added `setIsLoggedIn(true)` and `localStorage.setItem(ns_admin_logged_in, true)` after a successful login response. Added `const headers` with `Authorization: Bearer` using the stored token in `fetchAnalytics`. Wrapped `setToken` and `localStorage.setItem(ns_admin_token)` in a `if (result.token)` guard.
- **`admin-dashboard/src/__tests__/services/auth.test.js`**: Updated test assertions to expect `username` instead of `email` in the request body, matching the fixed `auth.js`.

## How to verify

1. Start the backend server and set `VITE_API_BASE` in both `admin-dashboard/` and `website/`.
2. Navigate to the admin login page at either `/admin` (website) or the admin-dashboard standalone app.
3. Enter valid `ADMIN_USERNAME` and `ADMIN_PASSWORD` credentials configured in the server environment.
4. Submit the form — confirm the login call sends `{ "username": "..." }` (check the Network tab).
5. Confirm the server returns 200 with `{ "username": "...", "expiresAt": "..." }` and sets the `ns_admin_token` cookie.
6. Confirm the dashboard renders with analytics data fetched from `/api/admin/analytics/stats`, `/api/admin/analytics/growth`, and `/api/admin/analytics/events` with proper `Authorization` headers.
7. Run `npm test --prefix admin-dashboard` — all 50 tests must pass.
8. Run `npm test --prefix server` — all server tests must pass, including `adminAuthMiddleware` tests.

## Edge cases considered

- **No token in response**: The server login endpoint returns the token only as an httpOnly cookie, not in the response body. The `if (result.token)` guard prevents storing `undefined` in localStorage.
- **Login error handling**: Error messages from the server (e.g., rate limiting, invalid credentials) propagate through the existing catch block and are displayed inline.
- **Token already in localStorage**: `fetchAnalytics` falls back to `localStorage.getItem(ns_admin_token)` if the token state is null, supporting page reloads after login.
- **Session expiry**: The existing SSE stream handler already detects 401 responses and clears `isLoggedIn` with a `localStorage.removeItem(ns_admin_logged_in)` call.
- **Backward compatibility**: The admin-dashboard `fetchWithAuth` utility already sends `credentials: include` and the `Authorization` header, so both cookie-based and bearer-token auth paths continue to work with the server.

Closes #821