### PR TITLE
fix: prevent concurrent portfolio creation race condition (#953)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -452,9 +452,14 @@ app.put('/api/portfolio', portfolioRateLimiter, async (req, res) => {
 
     clearPasskeyAttempts(username, ip);
 
-    const saved = await portfolioRepository.createOrUpdate(body);
+    const saved = await portfolioRepository.createOrUpdate(body, isNewRegistration);
     return res.json({ ok: true, portfolio: saved });
   } catch (err) {
+    if (err.code === '23505') {
+      return res
+        .status(409)
+        .json({ error: 'Username already exists. Another request may have just created it.' });
+    }
     console.error('Error saving portfolio:', err);
     return res.status(500).json({ error: err.message || 'Internal server error' });
   }

--- a/server/repositories/portfolioRepository.js
+++ b/server/repositories/portfolioRepository.js
@@ -18,7 +18,9 @@ let lastDbFailTime = 0;
 const DB_RETRY_TTL = 15000;
 
 export function canonicalizeUsername(username) {
-  return String(username || '').trim().toLowerCase();
+  return String(username || '')
+    .trim()
+    .toLowerCase();
 }
 
 async function hashPasskey(passkey) {
@@ -158,10 +160,15 @@ function mapRow(row) {
   return {
     username: row.username,
     theme: row.theme,
-    visibleSections: typeof row.visible_sections === 'string' ? JSON.parse(row.visible_sections) : row.visible_sections || {},
-    socialLinks: typeof row.social_links === 'string' ? JSON.parse(row.social_links) : row.social_links || {},
+    visibleSections:
+      typeof row.visible_sections === 'string'
+        ? JSON.parse(row.visible_sections)
+        : row.visible_sections || {},
+    socialLinks:
+      typeof row.social_links === 'string' ? JSON.parse(row.social_links) : row.social_links || {},
     customDomain: row.custom_domain || '',
-    seoMetadata: typeof row.seo_metadata === 'string' ? JSON.parse(row.seo_metadata) : row.seo_metadata || {},
+    seoMetadata:
+      typeof row.seo_metadata === 'string' ? JSON.parse(row.seo_metadata) : row.seo_metadata || {},
     skills: typeof row.skills === 'string' ? JSON.parse(row.skills) : row.skills || [],
     badges: typeof row.badges === 'string' ? JSON.parse(row.badges) : row.badges || [],
     projects: typeof row.projects === 'string' ? JSON.parse(row.projects) : row.projects || [],
@@ -181,10 +188,9 @@ export const portfolioRepository = {
     if (isDbAvailable) {
       try {
         return await withDb(async (client) => {
-          const { rows } = await client.query(
-            'SELECT * FROM portfolios WHERE username = $1',
-            [sanitizedUsername]
-          );
+          const { rows } = await client.query('SELECT * FROM portfolios WHERE username = $1', [
+            sanitizedUsername,
+          ]);
           if (!rows.length) return null;
           return mapRow(rows[0]);
         });
@@ -260,13 +266,18 @@ export const portfolioRepository = {
     return await verifyHash(passkey, portfolio.passkeyHash);
   },
 
-  async createOrUpdate(data) {
+  async createOrUpdate(data, isNewRegistration) {
     const isDbAvailable = await ensureReady();
     const sanitizedUsername = canonicalizeUsername(data.username);
     const passkeyHash = await hashPasskey(data.passkey);
 
     const theme = data.theme || 'glassmorphic';
-    const visibleSections = data.visibleSections || { quests: true, roadmaps: true, projects: true, analytics: false };
+    const visibleSections = data.visibleSections || {
+      quests: true,
+      roadmaps: true,
+      projects: true,
+      analytics: false,
+    };
     const socialLinks = data.socialLinks || {};
     const customDomain = data.customDomain || '';
     const seoMetadata = data.seoMetadata || {};
@@ -280,41 +291,135 @@ export const portfolioRepository = {
     if (isDbAvailable) {
       try {
         return await withDb(async (client) => {
-          const { rows } = await client.query(
-            `INSERT INTO portfolios (
-              username, passkey_hash, theme, visible_sections, social_links,
-              custom_domain, seo_metadata, skills, badges, projects, roadmaps, bio, title, updated_at
-            ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
-            ON CONFLICT (username) DO UPDATE SET
-              passkey_hash = EXCLUDED.passkey_hash,
-              theme = EXCLUDED.theme,
-              visible_sections = EXCLUDED.visible_sections,
-              social_links = EXCLUDED.social_links,
-              custom_domain = EXCLUDED.custom_domain,
-              seo_metadata = EXCLUDED.seo_metadata,
-              skills = EXCLUDED.skills,
-              badges = EXCLUDED.badges,
-              projects = EXCLUDED.projects,
-              roadmaps = EXCLUDED.roadmaps,
-              bio = EXCLUDED.bio,
-              title = EXCLUDED.title,
-              updated_at = NOW()
-            RETURNING *`,
-            [
-              sanitizedUsername, passkeyHash, theme, JSON.stringify(visibleSections), JSON.stringify(socialLinks),
-              customDomain, JSON.stringify(seoMetadata), JSON.stringify(skills), JSON.stringify(badges),
-              JSON.stringify(projects), JSON.stringify(roadmaps), bio, title
-            ]
-          );
-          return mapRow(rows[0]);
+          await client.query('BEGIN');
+          try {
+            let result;
+            if (isNewRegistration) {
+              result = await client.query(
+                `INSERT INTO portfolios (
+                  username, passkey_hash, theme, visible_sections, social_links,
+                  custom_domain, seo_metadata, skills, badges, projects, roadmaps, bio, title, updated_at
+                ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, NOW())
+                RETURNING *`,
+                [
+                  sanitizedUsername,
+                  passkeyHash,
+                  theme,
+                  JSON.stringify(visibleSections),
+                  JSON.stringify(socialLinks),
+                  customDomain,
+                  JSON.stringify(seoMetadata),
+                  JSON.stringify(skills),
+                  JSON.stringify(badges),
+                  JSON.stringify(projects),
+                  JSON.stringify(roadmaps),
+                  bio,
+                  title,
+                ]
+              );
+            } else {
+              result = await client.query(
+                `UPDATE portfolios SET
+                  passkey_hash = $2,
+                  theme = $3,
+                  visible_sections = $4,
+                  social_links = $5,
+                  custom_domain = $6,
+                  seo_metadata = $7,
+                  skills = $8,
+                  badges = $9,
+                  projects = $10,
+                  roadmaps = $11,
+                  bio = $12,
+                  title = $13,
+                  updated_at = NOW()
+                WHERE username = $1
+                RETURNING *`,
+                [
+                  sanitizedUsername,
+                  passkeyHash,
+                  theme,
+                  JSON.stringify(visibleSections),
+                  JSON.stringify(socialLinks),
+                  customDomain,
+                  JSON.stringify(seoMetadata),
+                  JSON.stringify(skills),
+                  JSON.stringify(badges),
+                  JSON.stringify(projects),
+                  JSON.stringify(roadmaps),
+                  bio,
+                  title,
+                ]
+              );
+            }
+            await client.query('COMMIT');
+            if (!result.rows.length) {
+              throw new Error('Portfolio update failed. Portfolio not found.');
+            }
+            return mapRow(result.rows[0]);
+          } catch (err) {
+            await client.query('ROLLBACK');
+            throw err;
+          }
         });
       } catch (err) {
+        if (err.code === '23505') {
+          throw err; // Bubble up unique constraint violation
+        }
         console.error('Database INSERT/UPDATE failed. Falling back to local file.', err);
       }
     }
 
-    throw new Error('Portfolio storage is unavailable. Please try again later.');
-  }
+    // Local file fallback executed serially to prevent race conditions
+    return await portfolioMutex.runExclusive(async () => {
+      const portfolios = await readLocalPortfolios();
+
+      if (isNewRegistration && portfolios[sanitizedUsername]) {
+        const error = new Error('duplicate key value violates unique constraint');
+        error.code = '23505';
+        throw error;
+      }
+
+      const existing = portfolios[sanitizedUsername] || {};
+      const newPortfolio = {
+        username: sanitizedUsername,
+        passkeyHash,
+        theme,
+        visibleSections,
+        socialLinks,
+        customDomain,
+        seoMetadata,
+        skills,
+        badges,
+        projects,
+        roadmaps,
+        bio,
+        title,
+        createdAt: existing.createdAt || new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+
+      portfolios[sanitizedUsername] = newPortfolio;
+      await fs.writeFile(PORTFOLIOS_FILE, JSON.stringify(portfolios, null, 2), 'utf8');
+
+      return mapRow({
+        username: newPortfolio.username,
+        theme: newPortfolio.theme,
+        visible_sections: newPortfolio.visibleSections,
+        social_links: newPortfolio.socialLinks,
+        custom_domain: newPortfolio.customDomain,
+        seo_metadata: newPortfolio.seoMetadata,
+        skills: newPortfolio.skills,
+        badges: newPortfolio.badges,
+        projects: newPortfolio.projects,
+        roadmaps: newPortfolio.roadmaps,
+        bio: newPortfolio.bio,
+        title: newPortfolio.title,
+        created_at: newPortfolio.createdAt,
+        updated_at: newPortfolio.updatedAt,
+      });
+    });
+  },
 };
 
 export const __portfolioRepositoryInternals = {

--- a/server/test/portfolioConcurrency.test.js
+++ b/server/test/portfolioConcurrency.test.js
@@ -1,0 +1,81 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { portfolioRepository } from '../repositories/portfolioRepository.js';
+
+test('Portfolio Concurrency & Race Condition Prevention', async (t) => {
+  // Use a random username to avoid state collision
+  const username = `raceuser_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+  const passkey = 'SecurePasskey123!';
+
+  await t.test('Two simultaneous creation requests - Exactly one should succeed', async () => {
+    // Send two requests at the exact same time
+    let successCount = 0;
+    let conflictCount = 0;
+
+    const [res1, res2] = await Promise.allSettled([
+      portfolioRepository.createOrUpdate({ username, passkey }, true),
+      portfolioRepository.createOrUpdate({ username, passkey }, true),
+    ]);
+
+    for (const res of [res1, res2]) {
+      if (res.status === 'fulfilled') {
+        successCount++;
+      } else if (res.reason && res.reason.code === '23505') {
+        conflictCount++;
+      }
+    }
+
+    assert.equal(successCount, 1, 'Expected exactly one creation to succeed');
+    assert.equal(
+      conflictCount,
+      1,
+      'Expected exactly one creation to fail with unique violation 23505'
+    );
+  });
+
+  await t.test('Ten simultaneous creation requests (Stress test)', async () => {
+    const stressUser = `stress_${Date.now()}_${Math.floor(Math.random() * 10000)}`;
+    const promises = Array.from({ length: 10 }).map(() =>
+      portfolioRepository.createOrUpdate({ username: stressUser, passkey: 'SuperSecure123!' }, true)
+    );
+
+    const responses = await Promise.allSettled(promises);
+
+    let successCount = 0;
+    let conflictCount = 0;
+
+    for (const res of responses) {
+      if (res.status === 'fulfilled') {
+        successCount++;
+      } else if (res.reason && res.reason.code === '23505') {
+        conflictCount++;
+      }
+    }
+
+    assert.equal(successCount, 1, 'Exactly one creation request should succeed');
+    assert.equal(
+      conflictCount,
+      9,
+      'All other creation requests should fail with unique violation 23505'
+    );
+  });
+
+  await t.test('Passkey authorization on existing portfolio prevents overwriting', async () => {
+    // Try to update an existing one without isNewRegistration but we simulate index.js logic
+    // Actually index.js does verifyPasskey first. Let's test that verifyPasskey fails.
+    const isAuthorized = await portfolioRepository.verifyPasskey(username, 'WrongPasskey456!', {
+      allowNew: false,
+    });
+    assert.equal(isAuthorized, false, 'Should reject wrong passkey');
+  });
+
+  await t.test('Proper transaction completion on valid update', async () => {
+    // Try to update with correct passkey (simulating verified by index.js)
+    const saved = await portfolioRepository.createOrUpdate(
+      { username, passkey, bio: 'Updated bio' },
+      false
+    );
+    assert.equal(saved.bio, 'Updated bio');
+  });
+});


### PR DESCRIPTION
closes #953
## Description
Fixes a critical race condition in portfolio creation where simultaneous requests for the same username could bypass validation checks and create an inconsistent database state. 

The fix implements atomic transaction handling (`BEGIN`/`COMMIT`) for database operations and explicitly catches PostgreSQL unique constraint violations (`23505`), returning a `409 Conflict` instead of throwing a `500`. It also safely protects the local JSON file fallback mechanism using an `async-mutex` lock to serialize parallel requests. Concurrent duplicate submissions are now strictly blocked without race conditions or overwriting existing passkeys.

Fixes #953

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings