### PR TITLE
fix: harden membership form rate limiting (#954)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,6 +42,21 @@ const __dirname = path.dirname(__filename);
 const CONTENT_FILE = path.join(__dirname, 'data', 'content.json');
 
 const app = express();
+
+// Trust the first reverse proxy hop (e.g., Vercel, Render, Nginx, Cloudflare)
+// to correctly populate req.ip and securely discard spoofed X-Forwarded-For headers
+const proxyTrust = process.env.TRUST_PROXY || 1;
+app.set(
+  'trust proxy',
+  proxyTrust === 'true'
+    ? true
+    : proxyTrust === 'false'
+      ? false
+      : !isNaN(proxyTrust)
+        ? parseInt(proxyTrust, 10)
+        : proxyTrust
+);
+
 initializeSentry(app);
 
 if (!process.env.CORS_ORIGIN) {
@@ -418,7 +433,7 @@ app.put('/api/portfolio', portfolioRateLimiter, async (req, res) => {
     const body = req.body || {};
     const username = String(body.username || '').trim();
     const passkey = String(body.passkey || '').trim();
-    const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
+    const ip = req.ip || 'unknown';
 
     if (!username || username.length < 3) {
       return res.status(400).json({ error: 'Username must be at least 3 characters long' });

--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -72,10 +72,7 @@ function requiredStrongPassword(name) {
 }
 
 function getClientIp(req) {
-  const ip =
-    String(req.ip || req.headers['x-forwarded-for'] || 'unknown')
-      .split(',')[0]
-      .trim() || 'unknown';
+  const ip = String(req.ip || 'unknown').trim();
   // Truncate to maximum 128 characters to prevent extremely large malicious headers from causing memory exhaustion
   return ip.slice(0, 128);
 }

--- a/server/test/adminAuthMiddleware.test.js
+++ b/server/test/adminAuthMiddleware.test.js
@@ -16,10 +16,10 @@ const createMockReqRes = (ip, username, password) => {
     headers: {},
     get: () => '',
   };
-  
+
   let statusCode = 200;
   let responseData = null;
-  
+
   const res = {
     status(code) {
       statusCode = code;
@@ -40,9 +40,9 @@ const createMockReqRes = (ip, username, password) => {
     },
     responseData() {
       return responseData;
-    }
+    },
   };
-  
+
   return { req, res };
 };
 
@@ -60,7 +60,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
 
     const ip = '192.168.1.50';
     const { req, res } = createMockReqRes(ip, 'admin', 'wrongpass');
-    
+
     await adminAuthMiddleware.login(req, res);
     assert.equal(res.statusCode(), 401);
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
@@ -82,7 +82,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     adminAuthMiddleware._clearAllLoginAttempts();
 
     const ip = '192.168.1.60';
-    
+
     // Failed attempt 1
     const { req: reqFail, res: resFail } = createMockReqRes(ip, 'admin', 'wrongpass');
     await adminAuthMiddleware.login(reqFail, resFail);
@@ -90,9 +90,13 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
 
     // Successful attempt
-    const { req: reqSuccess, res: resSuccess } = createMockReqRes(ip, 'admin', 'AdminStrongPass123!');
+    const { req: reqSuccess, res: resSuccess } = createMockReqRes(
+      ip,
+      'admin',
+      'AdminStrongPass123!'
+    );
     await adminAuthMiddleware.login(reqSuccess, resSuccess);
-    
+
     // The credentials match and success returns 200 (or calls createAdminSession which fails because DB isn't connected, returning 500 but it should have cleared the attempts first!)
     // Yes! clearLoginAttempts(ip) is called before createAdminSession:
     // 113: clearLoginAttempts(ip);
@@ -104,7 +108,7 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
     adminAuthMiddleware._clearAllLoginAttempts();
 
     const ip = '192.168.1.70';
-    
+
     // Attempt 1: Failed (Attempts set to 1)
     const { req: req1, res: res1 } = createMockReqRes(ip, 'admin', 'wrongpass');
     await adminAuthMiddleware.login(req1, res1);
@@ -157,81 +161,108 @@ test('Security Audit & Validation: Admin Authentication Rate Limiter', async (t)
 
   await t.test('Adversarial: Large IP Header String Truncation', async () => {
     adminAuthMiddleware._clearAllLoginAttempts();
-    
+
     const massiveHeader = '1.1.1.1,' + 'A'.repeat(50000);
     const req = {
       body: { username: 'admin', password: 'wrongpassword' },
-      headers: { 'x-forwarded-for': massiveHeader },
+      ip: massiveHeader,
+      headers: {},
       get: () => '',
     };
-    
+
     let statusCode = 200;
     const res = {
-      status(code) { statusCode = code; return this; },
-      json() { return this; }
+      status(code) {
+        statusCode = code;
+        return this;
+      },
+      json() {
+        return this;
+      },
     };
-    
+
     await adminAuthMiddleware.login(req, res);
     assert.equal(statusCode, 401);
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 1);
   });
 
-  await t.test('Adversarial: Eviction priority evicts blocked IPs before unblocked ones', async () => {
-    adminAuthMiddleware._clearAllLoginAttempts();
+  await t.test(
+    'Adversarial: Eviction priority evicts blocked IPs before unblocked ones',
+    async () => {
+      adminAuthMiddleware._clearAllLoginAttempts();
 
-    const blockedIp = '10.0.0.1';
-    const unblockedIp = '10.0.0.2';
+      const blockedIp = '10.0.0.1';
+      const unblockedIp = '10.0.0.2';
 
-    // Block blockedIp with 3 failed attempts (> max 2)
-    for (let i = 0; i < 3; i++) {
-      const { req, res } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-      await adminAuthMiddleware.login(req, res);
+      // Block blockedIp with 3 failed attempts (> max 2)
+      for (let i = 0; i < 3; i++) {
+        const { req, res } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
+        await adminAuthMiddleware.login(req, res);
+      }
+      const { req: reqCheckBlocked, res: resCheckBlocked } = createMockReqRes(
+        blockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqCheckBlocked, resCheckBlocked);
+      assert.equal(resCheckBlocked.statusCode(), 429);
+
+      // Add unblockedIp with 1 failed attempt
+      const { req: reqUnblocked, res: resUnblocked } = createMockReqRes(
+        unblockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqUnblocked, resUnblocked);
+      assert.equal(resUnblocked.statusCode(), 401);
+
+      // Flood map with 8 more unique IPs to fill past capacity (5) and trigger eviction
+      for (let i = 3; i <= 10; i++) {
+        const { req, res } = createMockReqRes(`10.0.0.${i}`, 'admin', 'wrongpass');
+        await adminAuthMiddleware.login(req, res);
+      }
+
+      assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
+
+      // blockedIp must be evicted (blocked IPs are evicted first)
+      const { req: reqVerifyEvicted, res: resVerifyEvicted } = createMockReqRes(
+        blockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqVerifyEvicted, resVerifyEvicted);
+      assert.equal(resVerifyEvicted.statusCode(), 401);
+
+      // unblockedIp must still be in map (unblocked IPs preserved)
+      const { req: reqVerifyPreserved, res: resVerifyPreserved } = createMockReqRes(
+        unblockedIp,
+        'admin',
+        'wrongpass'
+      );
+      await adminAuthMiddleware.login(reqVerifyPreserved, resVerifyPreserved);
+      assert.equal(resVerifyPreserved.statusCode(), 401);
     }
-    const { req: reqCheckBlocked, res: resCheckBlocked } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqCheckBlocked, resCheckBlocked);
-    assert.equal(resCheckBlocked.statusCode(), 429);
-
-    // Add unblockedIp with 1 failed attempt
-    const { req: reqUnblocked, res: resUnblocked } = createMockReqRes(unblockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqUnblocked, resUnblocked);
-    assert.equal(resUnblocked.statusCode(), 401);
-
-    // Flood map with 8 more unique IPs to fill past capacity (5) and trigger eviction
-    for (let i = 3; i <= 10; i++) {
-      const { req, res } = createMockReqRes(`10.0.0.${i}`, 'admin', 'wrongpass');
-      await adminAuthMiddleware.login(req, res);
-    }
-
-    assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
-
-    // blockedIp must be evicted (blocked IPs are evicted first)
-    const { req: reqVerifyEvicted, res: resVerifyEvicted } = createMockReqRes(blockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqVerifyEvicted, resVerifyEvicted);
-    assert.equal(resVerifyEvicted.statusCode(), 401);
-
-    // unblockedIp must still be in map (unblocked IPs preserved)
-    const { req: reqVerifyPreserved, res: resVerifyPreserved } = createMockReqRes(unblockedIp, 'admin', 'wrongpass');
-    await adminAuthMiddleware.login(reqVerifyPreserved, resVerifyPreserved);
-    assert.equal(resVerifyPreserved.statusCode(), 401);
-  });
+  );
 
   await t.test('Stress & Concurrency: 1000 Concurrent Requests', async () => {
     adminAuthMiddleware._clearAllLoginAttempts();
-    
+
     const startTime = Date.now();
     const concurrentRequests = 1000;
     const promises = [];
-    
+
     for (let i = 0; i < concurrentRequests; i++) {
       const ip = `172.16.0.${i % 254}`;
       const { req, res } = createMockReqRes(ip, 'admin', 'wrongpass');
       promises.push(adminAuthMiddleware.login(req, res));
     }
-    
+
     await Promise.all(promises);
     const duration = Date.now() - startTime;
-    
-    console.log(`[Combined Concurrency Test] Processed ${concurrentRequests} requests in ${duration}ms`);
+
+    console.log(
+      `[Combined Concurrency Test] Processed ${concurrentRequests} requests in ${duration}ms`
+    );
     assert.equal(adminAuthMiddleware._getLoginAttemptsMapSize(), 5);
     assert.ok(duration < 500);
   });

--- a/server/test/rateLimiter.test.js
+++ b/server/test/rateLimiter.test.js
@@ -1,5 +1,5 @@
-import assert from "node:assert/strict";
-import test from "node:test";
+import assert from 'node:assert/strict';
+import test from 'node:test';
 
 import {
   apiRateLimiter,
@@ -8,7 +8,7 @@ import {
   notificationRateLimiter,
   portfolioRateLimiter,
   validateLimiters,
-} from "../middleware/rateLimiter.js";
+} from '../middleware/rateLimiter.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -18,10 +18,10 @@ import {
 // the trust-proxy setting. Both must be present for the middleware to function.
 function makeMockReq(overrides = {}) {
   return {
-    ip: "192.0.2.1", // TEST-NET-1 — unambiguous valid IP, never routable
-    method: "GET",
-    path: "/api/test",
-    originalUrl: "/api/test",
+    ip: '192.0.2.1', // TEST-NET-1 — unambiguous valid IP, never routable
+    method: 'GET',
+    path: '/api/test',
+    originalUrl: '/api/test',
     headers: {},
     app: {
       get: (_setting) => false, // trust proxy disabled
@@ -65,45 +65,45 @@ function makeMockRes() {
 // undefined because the export was never added to rateLimiter.js.
 // ---------------------------------------------------------------------------
 
-test("apiRateLimiter is exported and is a function", () => {
-  assert.equal(typeof apiRateLimiter, "function");
+test('apiRateLimiter is exported and is a function', () => {
+  assert.equal(typeof apiRateLimiter, 'function');
 });
 
-test("formRateLimiter is exported and is a function", () => {
-  assert.equal(typeof formRateLimiter, "function");
+test('formRateLimiter is exported and is a function', () => {
+  assert.equal(typeof formRateLimiter, 'function');
 });
 
-test("authRateLimiter is exported and is a function", () => {
-  assert.equal(typeof authRateLimiter, "function");
+test('authRateLimiter is exported and is a function', () => {
+  assert.equal(typeof authRateLimiter, 'function');
 });
 
-test("notificationRateLimiter is exported and is a function", () => {
-  assert.equal(typeof notificationRateLimiter, "function");
+test('notificationRateLimiter is exported and is a function', () => {
+  assert.equal(typeof notificationRateLimiter, 'function');
 });
 
-test("portfolioRateLimiter is exported and is a function", () => {
-  assert.equal(typeof portfolioRateLimiter, "function");
+test('portfolioRateLimiter is exported and is a function', () => {
+  assert.equal(typeof portfolioRateLimiter, 'function');
 });
 
-test("validateLimiters is exported and is a function", () => {
-  assert.equal(typeof validateLimiters, "function");
+test('validateLimiters is exported and is a function', () => {
+  assert.equal(typeof validateLimiters, 'function');
 });
 
 // ---------------------------------------------------------------------------
 // validateLimiters — startup guard must not throw when all exports are present
 // ---------------------------------------------------------------------------
 
-test("validateLimiters passes without throwing when all limiters are correctly exported", () => {
+test('validateLimiters passes without throwing when all limiters are correctly exported', () => {
   assert.doesNotThrow(() => validateLimiters());
 });
 
-test("validateLimiters throws a descriptive error when a limiter slot is undefined", () => {
+test('validateLimiters throws a descriptive error when a limiter slot is undefined', () => {
   // Replicate the exact failure mode from issue #346: a limiter is undefined
   // because the export was missing. We invoke the validation logic directly
   // with a synthetic object so we do not mutate live module exports.
   function validateCustom(limiters) {
     for (const [name, limiter] of Object.entries(limiters)) {
-      if (typeof limiter !== "function") {
+      if (typeof limiter !== 'function') {
         throw new Error(
           `Rate limiter misconfiguration: "${name}" is not a function. Check rateLimiter.js exports.`
         );
@@ -116,7 +116,7 @@ test("validateLimiters throws a descriptive error when a limiter slot is undefin
     (err) => {
       assert.ok(err instanceof Error);
       assert.ok(
-        err.message.includes("apiRateLimiter"),
+        err.message.includes('apiRateLimiter'),
         `Expected error to name the faulty limiter, got: ${err.message}`
       );
       return true;
@@ -124,19 +124,16 @@ test("validateLimiters throws a descriptive error when a limiter slot is undefin
   );
 });
 
-test("validateLimiters error message names the faulty limiter", () => {
+test('validateLimiters error message names the faulty limiter', () => {
   function validateCustom(limiters) {
     for (const [name, limiter] of Object.entries(limiters)) {
-      if (typeof limiter !== "function") {
+      if (typeof limiter !== 'function') {
         throw new Error(`Rate limiter misconfiguration: "${name}" is not a function.`);
       }
     }
   }
 
-  assert.throws(
-    () => validateCustom({ notificationRateLimiter: null }),
-    /notificationRateLimiter/
-  );
+  assert.throws(() => validateCustom({ notificationRateLimiter: null }), /notificationRateLimiter/);
 });
 
 // ---------------------------------------------------------------------------
@@ -144,47 +141,47 @@ test("validateLimiters error message names the faulty limiter", () => {
 // from a fresh IP (well within any configured limit).
 // ---------------------------------------------------------------------------
 
-test("apiRateLimiter calls next() for a first-time request within the limit", (t, done) => {
+test('apiRateLimiter calls next() for a first-time request within the limit', (t, done) => {
   const req = makeMockReq();
   const res = makeMockRes();
   apiRateLimiter(req, res, () => {
-    assert.equal(res._status, null, "Status must not be set for an allowed request");
+    assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
 });
 
-test("formRateLimiter calls next() for a first-time request within the limit", (t, done) => {
+test('formRateLimiter calls next() for a first-time request within the limit', (t, done) => {
   const req = makeMockReq();
   const res = makeMockRes();
   formRateLimiter(req, res, () => {
-    assert.equal(res._status, null, "Status must not be set for an allowed request");
+    assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
 });
 
-test("authRateLimiter calls next() for a first-time request within the limit", (t, done) => {
+test('authRateLimiter calls next() for a first-time request within the limit', (t, done) => {
   const req = makeMockReq();
   const res = makeMockRes();
   authRateLimiter(req, res, () => {
-    assert.equal(res._status, null, "Status must not be set for an allowed request");
+    assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
 });
 
-test("notificationRateLimiter calls next() for a first-time request within the limit", (t, done) => {
+test('notificationRateLimiter calls next() for a first-time request within the limit', (t, done) => {
   const req = makeMockReq();
   const res = makeMockRes();
   notificationRateLimiter(req, res, () => {
-    assert.equal(res._status, null, "Status must not be set for an allowed request");
+    assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
 });
 
-test("portfolioRateLimiter calls next() for a first-time request within the limit", (t, done) => {
+test('portfolioRateLimiter calls next() for a first-time request within the limit', (t, done) => {
   const req = makeMockReq();
   const res = makeMockRes();
   portfolioRateLimiter(req, res, () => {
-    assert.equal(res._status, null, "Status must not be set for an allowed request");
+    assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
 });
@@ -194,11 +191,11 @@ test("portfolioRateLimiter calls next() for a first-time request within the limi
 // a JSON body with an "error" key and a 429 status code.
 // ---------------------------------------------------------------------------
 
-test("apiRateLimiter 429 response body contains an error key", async () => {
+test('apiRateLimiter 429 response body contains an error key', async () => {
   // Use a window of 1 ms and max of 0 to force an immediate block.
   // We import rateLimit directly here to create a throwaway instance,
   // keeping the real apiRateLimiter's in-memory counter unaffected.
-  const { default: rateLimit } = await import("express-rate-limit");
+  const { default: rateLimit } = await import('express-rate-limit');
 
   const blocker = rateLimit({
     windowMs: 1,
@@ -206,7 +203,9 @@ test("apiRateLimiter 429 response body contains an error key", async () => {
     standardHeaders: false,
     legacyHeaders: false,
     handler: (_req, res, _next, options) => {
-      res.status(options.statusCode).json({ error: "Too many requests from this IP, please try again later." });
+      res
+        .status(options.statusCode)
+        .json({ error: 'Too many requests from this IP, please try again later.' });
     },
   });
 
@@ -218,9 +217,79 @@ test("apiRateLimiter 429 response body contains an error key", async () => {
       resolve();
     });
     setImmediate(() => {
-      assert.equal(res._status, 429, "Blocked response must use 429 status");
-      assert.ok(res._body && typeof res._body.error === "string", "Response body must have an error string");
+      assert.equal(res._status, 429, 'Blocked response must use 429 status');
+      assert.ok(
+        res._body && typeof res._body.error === 'string',
+        'Response body must have an error string'
+      );
       resolve();
     });
   });
+});
+
+// ---------------------------------------------------------------------------
+// Proxy trust and client IP extraction integration tests
+// ---------------------------------------------------------------------------
+
+test('Express trust proxy configuration properly extracts client IP from X-Forwarded-For', async () => {
+  const express = (await import('express')).default;
+  const http = await import('node:http');
+
+  const app = express();
+  app.set('trust proxy', 1);
+
+  // A simple endpoint to echo back the resolved IP
+  app.get('/ip', (req, res) => {
+    res.json({ ip: req.ip });
+  });
+
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  try {
+    // Scenario 1: Trusted proxy scenario (1 proxy hop)
+    const res1 = await new Promise((resolve) => {
+      http.get(
+        `http://localhost:${port}/ip`,
+        {
+          headers: { 'x-forwarded-for': '203.0.113.5, 198.51.100.10' },
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => resolve(JSON.parse(data)));
+        }
+      );
+    });
+    // Since trust proxy is 1, it trusts the last IP in the chain (198.51.100.10)
+    // as the proxy, and takes the one before it (203.0.113.5) as the client.
+    // Wait, if trust proxy is 1, it takes the right-most IP as the client IP!
+    // No, trust proxy 1 means the direct connection is the 1st proxy.
+    // The right-most IP in X-Forwarded-For is the client's IP as seen by that proxy.
+    // So the client IP is 198.51.100.10!
+    assert.equal(res1.ip, '198.51.100.10', 'Trust proxy 1 extracts the right-most IP');
+
+    // Scenario 2: Spoofed header attempt
+    // Attacker sends X-Forwarded-For: 1.1.1.1, 2.2.2.2.
+    // The proxy appends the attacker's true IP (e.g., 3.3.3.3) to the right.
+    // X-Forwarded-For: 1.1.1.1, 2.2.2.2, 3.3.3.3
+    const res2 = await new Promise((resolve) => {
+      http.get(
+        `http://localhost:${port}/ip`,
+        {
+          headers: { 'x-forwarded-for': '1.1.1.1, 2.2.2.2, 3.3.3.3' },
+        },
+        (res) => {
+          let data = '';
+          res.on('data', (chunk) => (data += chunk));
+          res.on('end', () => resolve(JSON.parse(data)));
+        }
+      );
+    });
+    // It should securely pick 3.3.3.3 and ignore the spoofed 1.1.1.1 and 2.2.2.2
+    assert.equal(res2.ip, '3.3.3.3', 'Securely discards spoofed IPs beyond the trusted proxy hop');
+  } finally {
+    server.close();
+  }
 });


### PR DESCRIPTION
closes #954
## Description
Fixes a rate-limiting weakness affecting membership form submissions by improving client identification and strengthening protection against excessive request traffic.

The application's rate limiter relied on `req.ip`, which native resolves to the reverse proxy's IP in an untrusted configuration, grouping all users into a single rate limit bucket. This PR securely resolves this by configuring `app.set('trust proxy', 1)` in Express and migrating manual, spoof-vulnerable `X-Forwarded-For` parsers in the application to natively rely on Express's secure IP extraction. This protects third-party integrations (like Google Apps Script) from quota exhaustion attacks via spoofed headers.

Fixes #954

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings