### PR TITLE
Fix SSE health check iterating Set as Map and remove duplicate log

### DIFF
--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -1,7 +1,7 @@
 import logger from '../utils/logger.js';
 import { getPublicAppUrl } from '../utils/publicAppUrl.js';
 
-const adminClients = new Set();
+const adminClients = new Map();
 const MAX_SSE_CLIENTS = Math.max(1, parseInt(process.env.MAX_SSE_CLIENTS || '200', 10) || 200);
 const HEARTBEAT_INTERVAL_MS = Math.max(
   5_000,
@@ -39,7 +39,7 @@ export function addSSEClient(res) {
     return;
   }
 
-  adminClients.add(res);
+  adminClients.set(res, Date.now());
   logger.info('SSE client connected', { totalClients: adminClients.size });
 
   res.on('close', () => {
@@ -51,8 +51,6 @@ export function addSSEClient(res) {
     if (res._heartbeat) clearInterval(res._heartbeat);
     logger.error('SSE client error', { error: error.message });
   });
-
-  logger.info('SSE client connected', { totalClients: adminClients.size });
 }
 
 export function broadcastSSEEvent(eventName, data) {
@@ -63,7 +61,7 @@ export function broadcastSSEEvent(eventName, data) {
   });
   const message = `event: ${eventName}\ndata: ${eventData}\n\n`;
 
-  adminClients.forEach((client) => {
+  adminClients.forEach((joined, client) => {
     try {
       const ok = client.write(message);
       if (!ok) {


### PR DESCRIPTION
## Description

The Server-Sent Events service in `server/services/sseService.js` had two critical bugs that broke the real-time admin metrics stream. The health check interval destructured `adminClients` entries as `[client, joined]` but `adminClients` was a `Set`, not a `Map`. Set iteration yields values directly, so `joined` was always `undefined`, `now - undefined` evaluated to `NaN`, and the stale-connection eviction never fired. Dead SSE connections accumulated until `MAX_SSE_CLIENTS` (200) was reached, after which new admin SSE connections were rejected with 503. Additionally, `addSSEClient` logged "SSE client connected" twice per connection.

Fixes #822

## Root cause

`adminClients` on line 4 was declared as `new Set()`. The health check at line 99 used `for (const [client, joined] of adminClients)` — destructuring syntax that only produces correct values when iterating a Map. On a Set, `[client, joined]` destructures the Set element (a Response object) as `client = response, joined = undefined`. The comparison `now - undefined > HEALTH_CHECK_INTERVAL_MS` is `NaN > 60000`, always `false`. The duplicate log was a copy-paste error in `addSSEClient`.

## What changed

- **`server/services/sseService.js`**: Changed `adminClients` from `Set` to `Map<Response, number>` so each entry stores the connection timestamp alongside the response object.
- **`server/services/sseService.js`**: Updated `adminClients.set(res, Date.now())` in `addSSEClient` to record the connection time.
- **`server/services/sseService.js`**: Updated `broadcastSSEEvent` forEach callback signature to `(joined, client)` matching Map.prototype.forEach which calls `(value, key)`.
- **`server/services/sseService.js`**: Removed the duplicate "SSE client connected" log at line 55.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How to verify

1. Start the server.
2. Connect to `GET /api/admin/metrics/stream` (or `/api/admin/stream`) from 10 browser tabs.
3. Verify `getConnectedSSEClientsCount()` returns 10.
4. Close 5 of those tabs.
5. Wait 60+ seconds (the `HEALTH_CHECK_INTERVAL_MS`).
6. Verify `getConnectedSSEClientsCount()` returns 5 or fewer — the dead connections from closed tabs should be evicted.
7. Run `npm test --prefix server` — all 15 tests must pass.
8. Connect 200+ clients and verify the 201st is rejected with 503.

## Edge cases considered

- **Map.forEach signature**: `Map.prototype.forEach` calls the callback as `(value, key, map)` whereas `Set.prototype.forEach` calls `(value, key, set)` where `value === key`. The broadcast function now uses the second parameter (the Response object) instead of the first.
- **cleanupClient compatibility**: Both `.has()` and `.delete()` have identical semantics on Map and Set, so `cleanupClient` required no changes.
- **Backward compatibility**: All public exports (`addSSEClient`, `broadcastSSEEvent`, `getConnectedSSEClientsCount`, `setupSSEHeaders`) keep the same signatures. Only internal iteration logic changed.
- **Concurrent modification safety**: `adminClients.forEach` and `for...of` on a Map are safe against deletion of the current or previously-visited entry during iteration.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings