### PR TITLE
fix: validate push subscription payloads and prevent memory exhaustio…

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,6 +1,7 @@
 import 'dotenv/config';
 import helmet from 'helmet';
 import express from 'express';
+import { body, validationResult } from 'express-validator';
 import cors from 'cors';
 import morgan from 'morgan';
 import { promises as fs } from 'fs';
@@ -267,7 +268,41 @@ app.get('/api/admin/me', adminAuth, (req, res) => {
 // Real-time Push Subscriber channels
 const pushSubscriptions = new Set();
 
-app.post('/api/notifications/subscribe', (req, res) => {
+const validatePushSubscription = [
+  body('subscription').isObject().withMessage('subscription must be an object'),
+  body('subscription.endpoint')
+    .isURL()
+    .withMessage('endpoint must be a valid URL')
+    .isLength({ max: 2048 }),
+  body('subscription.keys').isObject().withMessage('keys must be an object'),
+  body('subscription.keys.p256dh')
+    .isString()
+    .isLength({ max: 256 })
+    .withMessage('p256dh must be a string up to 256 chars'),
+  body('subscription.keys.auth')
+    .isString()
+    .isLength({ max: 128 })
+    .withMessage('auth must be a string up to 128 chars'),
+  (req, res, next) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res
+        .status(400)
+        .json({ error: 'Invalid subscription payload', details: errors.array() });
+    }
+
+    // Strict sanitization: reconstruct object to drop malicious properties and limit memory size
+    const {
+      endpoint,
+      keys: { p256dh, auth },
+    } = req.body.subscription;
+    req.body.subscription = { endpoint, keys: { p256dh, auth } };
+
+    next();
+  },
+];
+
+app.post('/api/notifications/subscribe', validatePushSubscription, (req, res) => {
   try {
     const { subscription } = req.body;
     if (subscription) {
@@ -283,7 +318,7 @@ app.post('/api/notifications/subscribe', (req, res) => {
   }
 });
 
-app.post('/api/notifications/unsubscribe', (req, res) => {
+app.post('/api/notifications/unsubscribe', validatePushSubscription, (req, res) => {
   try {
     const { subscription } = req.body;
     if (subscription) pushSubscriptions.delete(JSON.stringify(subscription));

--- a/server/package.json
+++ b/server/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "dev": "node index.js",
     "build": "echo \"server build step not required\"",
-    "test": "node --test test/sanitize.test.js test/formSchemas.test.js test/adminSessions.test.js",
-    "test:watch": "node --test --watch test/sanitize.test.js test/formSchemas.test.js test/adminSessions.test.js",
+    "test": "node --test test/sanitize.test.js test/formSchemas.test.js test/adminSessions.test.js test/portfolioAuth.test.js test/notificationSubscription.test.js",
+    "test:watch": "node --test --watch test/sanitize.test.js test/formSchemas.test.js test/adminSessions.test.js test/portfolioAuth.test.js test/notificationSubscription.test.js",
     "migrate": "node-pg-migrate -f .postgres_migrations_config.json",
     "migrate:latest": "node-pg-migrate -f .postgres_migrations_config.json up",
     "migrate:rollback": "node-pg-migrate -f .postgres_migrations_config.json down",

--- a/server/test/notificationSubscription.test.js
+++ b/server/test/notificationSubscription.test.js
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import http from 'node:http';
+
+process.env.ADMIN_USERNAME = 'admin';
+process.env.ADMIN_PASSWORD = 'StrongPassword123!';
+process.env.ADMIN_EVENT_PASSWORD = 'StrongEventPassword123!';
+process.env.CORS_ORIGIN = 'http://localhost:3000';
+process.env.JWT_SECRET = 'secret_super_long_secret_key_that_is_safe_and_long_enough_for_256bit';
+process.env.PORT = '0';
+
+test('Push Subscription Validation and Memory Safety', async (t) => {
+  const { default: app } = await import('../index.js');
+  const server = http.createServer(app);
+  await new Promise((resolve) => server.listen(0, resolve));
+  const port = server.address().port;
+
+  const sendRequest = (path, body) => {
+    return new Promise((resolve) => {
+      const options = {
+        hostname: 'localhost',
+        port: port,
+        path: path,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+      };
+
+      const req = http.request(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => resolve({ status: res.statusCode, body: JSON.parse(data || '{}') }));
+      });
+
+      req.write(JSON.stringify(body));
+      req.end();
+    });
+  };
+
+  const validSubscription = {
+    endpoint: 'https://fcm.googleapis.com/fcm/send/test-endpoint',
+    keys: {
+      p256dh: 'BNcRdreALRFG-OydA...',
+      auth: 'A_test_auth_key',
+    },
+  };
+
+  try {
+    await t.test('1. Valid subscription is accepted', async () => {
+      const res = await sendRequest('/api/notifications/subscribe', {
+        subscription: validSubscription,
+      });
+      assert.equal(res.status, 200, 'Expected 200 OK');
+      assert.equal(res.body.success, true);
+    });
+
+    await t.test('2. Missing endpoint fails validation', async () => {
+      const res = await sendRequest('/api/notifications/subscribe', {
+        subscription: { keys: validSubscription.keys },
+      });
+      assert.equal(res.status, 400, 'Expected 400 Bad Request');
+      assert.ok(res.body.error.includes('Invalid subscription payload'));
+    });
+
+    await t.test('3. Oversized string payload is rejected', async () => {
+      const massiveEndpoint = 'https://fcm.googleapis.com/' + 'a'.repeat(3000);
+      const res = await sendRequest('/api/notifications/subscribe', {
+        subscription: { endpoint: massiveEndpoint, keys: validSubscription.keys },
+      });
+      assert.equal(res.status, 400, 'Expected 400 Bad Request');
+    });
+
+    await t.test('4. Unexpected structure fails validation', async () => {
+      const res = await sendRequest('/api/notifications/subscribe', {
+        subscription: 'Not an object, just a string!',
+      });
+      assert.equal(res.status, 400, 'Expected 400 Bad Request');
+    });
+
+    await t.test('5. Valid unsubscription is accepted', async () => {
+      const res = await sendRequest('/api/notifications/unsubscribe', {
+        subscription: validSubscription,
+      });
+      assert.equal(res.status, 200, 'Expected 200 OK');
+    });
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
closes #956
## Description
Fixes a memory exhaustion (Denial-of-Service) vulnerability in the notification subscription endpoint by enforcing strict schema validation and payload size limits before storing subscription data.

### Root Cause
Subscription payloads were previously accepted without sufficient validation or size restrictions and immediately serialized into memory. An attacker could exploit this by sending excessively large or deeply nested JSON objects, consuming vast amounts of heap memory and impacting application stability.

### Changes Made
* Added schema validation using `express-validator` to strictly type-check subscription objects (`/subscribe` and `/unsubscribe`).
* Added string length boundaries (e.g., 2048 chars max for endpoints).
* Improved memory safety via Defensive Object Reconstruction (explicitly stripping undocumented/excess fields before memory insertion).
* Added comprehensive automated tests to prevent regressions and validate security constraints.

Fixes #956

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings