### PR TITLE
Fix/sse service healthcheck typeerror

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,4 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+ 

--- a/logs/.006e56e76f46db94a2d10e093bc5dd038f5e4068-audit.json
+++ b/logs/.006e56e76f46db94a2d10e093bc5dd038f5e4068-audit.json
@@ -1,0 +1,15 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": "E:\\gssoc26\\NexaSphere\\logs\\.006e56e76f46db94a2d10e093bc5dd038f5e4068-audit.json",
+    "files": [
+        {
+            "date": 1780309103654,
+            "name": "E:\\gssoc26\\NexaSphere\\logs\\application-2026-06-01.log",
+            "hash": "bf622782a9221cda006d7467c600dabe307e9237b73abb180ca0b2f9aa28b12e"
+        }
+    ],
+    "hashType": "sha256"
+}

--- a/logs/.f452c1c952887b2a15325260c456c2d9057f51ae-audit.json
+++ b/logs/.f452c1c952887b2a15325260c456c2d9057f51ae-audit.json
@@ -1,0 +1,15 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": "E:\\gssoc26\\NexaSphere\\logs\\.f452c1c952887b2a15325260c456c2d9057f51ae-audit.json",
+    "files": [
+        {
+            "date": 1780309103661,
+            "name": "E:\\gssoc26\\NexaSphere\\logs\\exceptions-2026-06-01.log",
+            "hash": "bb2b7da857970d14acc078680919ed2bd81c79443faca29f20a476c624bf6686"
+        }
+    ],
+    "hashType": "sha256"
+}

--- a/logs/.f7a3366fa85249107ff7fb0f8b28de40b09d6b83-audit.json
+++ b/logs/.f7a3366fa85249107ff7fb0f8b28de40b09d6b83-audit.json
@@ -1,0 +1,15 @@
+{
+    "keep": {
+        "days": true,
+        "amount": 14
+    },
+    "auditLog": "E:\\gssoc26\\NexaSphere\\logs\\.f7a3366fa85249107ff7fb0f8b28de40b09d6b83-audit.json",
+    "files": [
+        {
+            "date": 1780309103664,
+            "name": "E:\\gssoc26\\NexaSphere\\logs\\rejections-2026-06-01.log",
+            "hash": "79aad6004fee8f7b2b07222fe5649af6df06e201a35c3cb974d82ea299919836"
+        }
+    ],
+    "hashType": "sha256"
+}


### PR DESCRIPTION
## Description
Resolves a TypeError that crashed the server's Server-Sent Events (SSE) health check. `adminClients` is defined as a `Set`, but the health check interval attempted to loop over and destructure it as a key-value iterable (`for (const [client, joined] of adminClients)`), which raised a runtime error. This PR also syncs the branch with DCO sign-offs for all commits.

Fixes #844 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings