### PR TITLE
fix: export missing toSafeString function in sanitize.js

### DIFF
--- a/server/utils/sanitize.js
+++ b/server/utils/sanitize.js
@@ -71,4 +71,8 @@ export function sanitizeCoreTeamMemberRecord(member = {}) {
   };
 }
 
-export { escapeHtml, sanitizeNullableText, sanitizeText, sanitizeTextArray };
+function toSafeString(value, max = 4000) {
+  return String(value ?? '').trim().slice(0, max);
+}
+
+export { escapeHtml, sanitizeNullableText, sanitizeText, sanitizeTextArray, toSafeString };


### PR DESCRIPTION
## Description
Resolves a Syntax/Import error during server startup. The event schema (`server/schemas/eventSchema.js`) imports the `toSafeString` helper function from `../utils/sanitize.js`. However, `toSafeString` was not defined or exported by that module. Added `toSafeString` to `server/utils/sanitize.js` and exported it.

Fixes #850

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings