### PR TITLE
fix: resolve missing parenthesis syntax error in sseService broadcast

### DIFF
--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -83,7 +83,7 @@ export function broadcastSSEEvent(eventName, data) {
       logger.error('Failed to send SSE event', { error: error.message });
       cleanupClient(client, 'write_error', { error: error?.message });
     }
-  }
+  });
 
   logger.debug('SSE event broadcast', { event: eventName, clientCount: adminClients.size });
 }


### PR DESCRIPTION
## Description
Resolves a syntax compile error in `server/services/sseService.js`. The `broadcastSSEEvent` function was missing a closing parenthesis `);` on the `adminClients.forEach(...)` callback, preventing the Node.js ESM loader from parsing the file.

Fixes #846 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings