### PR TITLE
fix: prevent socket re-authentication

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -450,6 +450,12 @@ export function _onConnection(socket) {
 
   // Authenticate socket for admin rooms using admin token
   socket.on('admin:authenticate', async ({ token } = {}) => {
+    if (socket.adminAuthenticated) {
+      return socket.emit('admin:authenticated', {
+        success: false,
+        error: 'Already authenticated',
+      });
+    }
     if (!token) {
       return socket.emit('admin:authenticated', { success: false, error: 'Token is required' });
     }


### PR DESCRIPTION
## Description

Prevented already-authenticated sockets from re-authenticating through the `admin:authenticate` socket event.

### Changes Made

* Added a guard to check if a socket is already authenticated
* Rejected repeated authentication attempts with an appropriate error response
* Prevented multiple joins to the protected `admin-room`
* Preserved existing authentication behavior for valid admin sessions

Closes #836

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
