### PR TITLE
fix: rename visibleSections.quests to skillsAndQuests for clarity in portfolio components

### DIFF
--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -14,7 +14,7 @@ export default function PortfolioBuilder() {
 
   // Section Visibilities
   const [visibleSections, setVisibleSections] = useState({
-    quests: true,
+    skillsAndQuests: true,
     roadmaps: true,
     projects: true,
   });
@@ -90,7 +90,13 @@ export default function PortfolioBuilder() {
         setTheme(data.theme || 'glassmorphic');
         setCustomDomain(data.customDomain || '');
         setVisibleSections(
-          data.visibleSections || { quests: true, roadmaps: true, projects: true }
+          data.visibleSections
+            ? {
+                ...data.visibleSections,
+                skillsAndQuests:
+                  data.visibleSections.skillsAndQuests ?? data.visibleSections.quests ?? true,
+              }
+            : { skillsAndQuests: true, roadmaps: true, projects: true }
         );
         setSocialLinks(data.socialLinks || { github: '', linkedin: '', twitter: '', resume: '' });
         setSeoMetadata(data.seoMetadata || { title: '', description: '' });
@@ -440,9 +446,9 @@ export default function PortfolioBuilder() {
               <label className="switch">
                 <input
                   type="checkbox"
-                  checked={visibleSections.quests}
+                  checked={visibleSections.skillsAndQuests}
                   onChange={(e) =>
-                    setVisibleSections((prev) => ({ ...prev, quests: e.target.checked }))
+                    setVisibleSections((prev) => ({ ...prev, skillsAndQuests: e.target.checked }))
                   }
                 />
                 <span className="slider"></span>
@@ -961,7 +967,7 @@ export default function PortfolioBuilder() {
               <div
                 style={{ display: 'flex', flexDirection: 'column', gap: '20px', marginTop: '16px' }}
               >
-                {visibleSections.quests && selectedSkills.length > 0 && (
+                {visibleSections.skillsAndQuests && selectedSkills.length > 0 && (
                   <div className="portfolio-panel" style={{ padding: '16px' }}>
                     <div
                       style={{

--- a/website/src/components/portfolio/ResumePrintTemplate.jsx
+++ b/website/src/components/portfolio/ResumePrintTemplate.jsx
@@ -4,20 +4,44 @@ import { roadmapData } from '../../data/roadmapData';
 
 const ResumePrintTemplate = forwardRef(({ portfolio }, ref) => {
   if (!portfolio) return null;
-  const { username, title, bio, visibleSections, socialLinks, skills, roadmaps, projects } = portfolio;
+  const { username, title, bio, visibleSections, socialLinks, skills, roadmaps, projects } =
+    portfolio;
 
   // Map project IDs to full project data
-  const resolvedProjects = projects?.map(id => projectsData.find(p => p.id === id)).filter(Boolean) || [];
+  const resolvedProjects =
+    projects?.map((id) => projectsData.find((p) => p.id === id)).filter(Boolean) || [];
 
   return (
-    <div ref={ref} style={{ padding: '40px', fontFamily: 'Arial, sans-serif', color: '#000', backgroundColor: '#fff', fontSize: '12pt', lineHeight: 1.5 }}>
+    <div
+      ref={ref}
+      style={{
+        padding: '40px',
+        fontFamily: 'Arial, sans-serif',
+        color: '#000',
+        backgroundColor: '#fff',
+        fontSize: '12pt',
+        lineHeight: 1.5,
+      }}
+    >
       {/* Header */}
-      <header style={{ borderBottom: '2px solid #333', paddingBottom: '16px', marginBottom: '24px' }}>
+      <header
+        style={{ borderBottom: '2px solid #333', paddingBottom: '16px', marginBottom: '24px' }}
+      >
         <h1 style={{ margin: 0, fontSize: '28pt', fontWeight: 'bold' }}>{username}</h1>
-        <h2 style={{ margin: '8px 0', fontSize: '14pt', fontWeight: 'normal', color: '#444' }}>{title || 'Tech Specialist & Developer'}</h2>
-        
+        <h2 style={{ margin: '8px 0', fontSize: '14pt', fontWeight: 'normal', color: '#444' }}>
+          {title || 'Tech Specialist & Developer'}
+        </h2>
+
         {/* Contact Links */}
-        <div style={{ display: 'flex', gap: '16px', fontSize: '10pt', marginTop: '12px', flexWrap: 'wrap' }}>
+        <div
+          style={{
+            display: 'flex',
+            gap: '16px',
+            fontSize: '10pt',
+            marginTop: '12px',
+            flexWrap: 'wrap',
+          }}
+        >
           {socialLinks?.email && <span>Email: {socialLinks.email}</span>}
           {socialLinks?.linkedin && <span>LinkedIn: {socialLinks.linkedin}</span>}
           {socialLinks?.github && <span>GitHub: {socialLinks.github}</span>}
@@ -29,15 +53,34 @@ const ResumePrintTemplate = forwardRef(({ portfolio }, ref) => {
       {/* Summary */}
       {bio && (
         <section className="resume-section" style={{ marginBottom: '24px' }}>
-          <h3 style={{ fontSize: '14pt', borderBottom: '1px solid #ccc', paddingBottom: '4px', marginBottom: '8px' }}>Summary</h3>
+          <h3
+            style={{
+              fontSize: '14pt',
+              borderBottom: '1px solid #ccc',
+              paddingBottom: '4px',
+              marginBottom: '8px',
+            }}
+          >
+            Summary
+          </h3>
           <p style={{ margin: 0 }}>{bio}</p>
         </section>
       )}
 
       {/* Skills */}
-      {visibleSections?.quests && skills && skills.length > 0 && (
+      {/* skillsAndQuests key controls both Skills and Quests sections */}
+      {visibleSections?.skillsAndQuests && skills && skills.length > 0 && (
         <section className="resume-section" style={{ marginBottom: '24px' }}>
-          <h3 style={{ fontSize: '14pt', borderBottom: '1px solid #ccc', paddingBottom: '4px', marginBottom: '8px' }}>Skills & Technologies</h3>
+          <h3
+            style={{
+              fontSize: '14pt',
+              borderBottom: '1px solid #ccc',
+              paddingBottom: '4px',
+              marginBottom: '8px',
+            }}
+          >
+            Skills & Technologies
+          </h3>
           <p style={{ margin: 0 }}>{skills.join(' • ')}</p>
         </section>
       )}
@@ -45,19 +88,34 @@ const ResumePrintTemplate = forwardRef(({ portfolio }, ref) => {
       {/* Projects */}
       {visibleSections?.projects && resolvedProjects.length > 0 && (
         <section className="resume-section" style={{ marginBottom: '24px' }}>
-          <h3 style={{ fontSize: '14pt', borderBottom: '1px solid #ccc', paddingBottom: '4px', marginBottom: '16px' }}>Selected Projects</h3>
-          {resolvedProjects.map(proj => (
+          <h3
+            style={{
+              fontSize: '14pt',
+              borderBottom: '1px solid #ccc',
+              paddingBottom: '4px',
+              marginBottom: '16px',
+            }}
+          >
+            Selected Projects
+          </h3>
+          {resolvedProjects.map((proj) => (
             <div key={proj.id} className="resume-item" style={{ marginBottom: '16px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+              <div
+                style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}
+              >
                 <strong style={{ fontSize: '12pt' }}>{proj.title}</strong>
                 <span style={{ fontSize: '10pt', color: '#555' }}>{proj.category}</span>
               </div>
               <p style={{ margin: '4px 0', fontSize: '11pt' }}>{proj.shortDesc}</p>
               {proj.techStack && proj.techStack.length > 0 && (
-                <p style={{ margin: 0, fontSize: '10pt', color: '#444' }}><strong>Tech:</strong> {proj.techStack.join(', ')}</p>
+                <p style={{ margin: 0, fontSize: '10pt', color: '#444' }}>
+                  <strong>Tech:</strong> {proj.techStack.join(', ')}
+                </p>
               )}
               <div style={{ fontSize: '9pt', color: '#666', marginTop: '4px' }}>
-                {proj.github && proj.github !== '#' && <span style={{ marginRight: '16px' }}>GitHub: {proj.github}</span>}
+                {proj.github && proj.github !== '#' && (
+                  <span style={{ marginRight: '16px' }}>GitHub: {proj.github}</span>
+                )}
                 {proj.demo && proj.demo !== '#' && <span>Demo: {proj.demo}</span>}
               </div>
             </div>
@@ -68,15 +126,32 @@ const ResumePrintTemplate = forwardRef(({ portfolio }, ref) => {
       {/* Curriculum/Education */}
       {visibleSections?.roadmaps && roadmaps && roadmaps.length > 0 && (
         <section className="resume-section" style={{ marginBottom: '24px' }}>
-          <h3 style={{ fontSize: '14pt', borderBottom: '1px solid #ccc', paddingBottom: '4px', marginBottom: '16px' }}>Education & Curriculum Progress</h3>
-          {roadmaps.map(roadmapKey => {
+          <h3
+            style={{
+              fontSize: '14pt',
+              borderBottom: '1px solid #ccc',
+              paddingBottom: '4px',
+              marginBottom: '16px',
+            }}
+          >
+            Education & Curriculum Progress
+          </h3>
+          {roadmaps.map((roadmapKey) => {
             const data = roadmapData[roadmapKey];
             if (!data) return null;
             return (
               <div key={roadmapKey} className="resume-item" style={{ marginBottom: '12px' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline' }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'baseline',
+                  }}
+                >
                   <strong style={{ fontSize: '11pt' }}>{data.title}</strong>
-                  <span style={{ fontSize: '10pt', color: '#555' }}>Completed Modules: {data.nodes?.length || 0}</span>
+                  <span style={{ fontSize: '10pt', color: '#555' }}>
+                    Completed Modules: {data.nodes?.length || 0}
+                  </span>
                 </div>
               </div>
             );

--- a/website/src/pages/portfolio/PublicPortfolio.jsx
+++ b/website/src/pages/portfolio/PublicPortfolio.jsx
@@ -326,7 +326,8 @@ export default function PublicPortfolio({ username, onBack }) {
         {/* Dynamic section grid layouts */}
         <main className="portfolio-grid">
           {/* Section A: Certified Skills & Badges */}
-          {visibleSections?.quests && skills && skills.length > 0 && (
+          {/* skillsAndQuests key controls both Skills and Quests sections */}
+          {visibleSections?.skillsAndQuests && skills && skills.length > 0 && (
             <section className="portfolio-panel" aria-labelledby="skills-heading">
               <h2 id="skills-heading" className="portfolio-section-title">
                 <svg


### PR DESCRIPTION
## Description
`ResumePrintTemplate.jsx` and `PublicPortfolio.jsx` gated the Skills & Technologies section using `visibleSections?.quests`:

```jsx
{visibleSections?.quests && skills && skills.length > 0 && (
  <section>Skills & Technologies</section>
)}
```

The toggle in `PortfolioBuilder.jsx` is labelled **"Skills & Quests"** and uses the `quests` key to control both skills and quests together — meaning disabling quests also silently hid the skills section with no indication to the user. The key name `quests` was misleading since it actually controls both sections.

Changes made:
- Renamed `visibleSections.quests` → `visibleSections.skillsAndQuests` across all three files to match the UI toggle label and make the intent explicit
- Updated `PortfolioBuilder.jsx` initial state, load path, toggle handler, and preview render
- Added a backwards-compatible migration in the load path: reads `skillsAndQuests` first, falls back to the legacy `quests` key for portfolios saved before this change — no user data is lost
- Updated `ResumePrintTemplate.jsx` and `PublicPortfolio.jsx` to use `skillsAndQuests` with clarifying comments
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #991

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings