### PR TITLE
fix: replace hardcoded mock leaderboard with real API call in gamificationService

### DIFF
--- a/website/src/components/gamification/GamificationDashboard.jsx
+++ b/website/src/components/gamification/GamificationDashboard.jsx
@@ -11,9 +11,10 @@ export default function GamificationDashboard() {
     loadData();
   }, []);
 
-  const loadData = () => {
+  const loadData = async () => {
     setUserStats(gamificationService.getUserStats());
-    setLeaderboard(gamificationService.getLeaderboard());
+    const lb = await gamificationService.getLeaderboard();
+    setLeaderboard(lb);
   };
 
   const handleAction = (action) => {

--- a/website/src/services/gamification/gamificationService.js
+++ b/website/src/services/gamification/gamificationService.js
@@ -406,16 +406,37 @@ class GamificationService {
     return nextLevel ? nextLevel.xpRequired : this.userData.xp;
   }
 
-  getLeaderboard() {
-    // For demo, return mock leaderboard
-    // In production, this would fetch from backend
-    return [
+  async getLeaderboard() {
+    const MOCK_LEADERBOARD = [
       { rank: 1, name: 'Alex Johnson', xp: 2850, level: 8, avatar: '👨‍💻' },
       { rank: 2, name: 'Sarah Chen', xp: 2420, level: 7, avatar: '👩‍💻' },
       { rank: 3, name: 'Mike Ross', xp: 2100, level: 7, avatar: '👨‍💼' },
       { rank: 4, name: 'Emma Watson', xp: 1850, level: 6, avatar: '👩‍🎓' },
       { rank: 5, name: 'David Kim', xp: 1520, level: 6, avatar: '👨‍🔬' },
     ];
+
+    const base = (
+      (typeof import.meta !== 'undefined' && import.meta.env?.VITE_API_BASE) ||
+      ''
+    ).replace(/\/+$/, '');
+    if (!base) return MOCK_LEADERBOARD;
+
+    try {
+      const res = await fetch(`${base}/api/dashboard/leaderboard`);
+      if (!res.ok) return MOCK_LEADERBOARD;
+      const data = await res.json();
+      if (!Array.isArray(data) || data.length === 0) return MOCK_LEADERBOARD;
+      // Map backend UserProfileEntity shape to leaderboard display shape
+      return data.map((user, i) => ({
+        rank: i + 1,
+        name: user.username || user.name || 'Anonymous',
+        xp: user.xp ?? 0,
+        level: user.level ?? 1,
+        avatar: '👤',
+      }));
+    } catch {
+      return MOCK_LEADERBOARD;
+    }
   }
 
   getTierColor(tier) {


### PR DESCRIPTION
## Description
`gamificationService.js` `getLeaderboard()` always returned a hardcoded array of 5 fictional users with no API call — explicitly commented as unfinished:

```js
getLeaderboard() {
  // For demo, return mock leaderboard
  // In production, this would fetch from backend
  return [
    { rank: 1, name: 'Alex Johnson', xp: 2850, level: 8, avatar: '👨‍💻' },
    ...
  ];
}
```

Every user saw the same 5 fictional names on the leaderboard regardless of actual platform activity. The Java backend already has a `/api/dashboard/leaderboard` endpoint (`DashboardController.java`) that returns real users ordered by XP.

Changes made:
- Made `getLeaderboard()` `async` and added a real `fetch` to `/api/dashboard/leaderboard`
- Maps the backend `UserProfileEntity` shape (`username`, `xp`, `level`) to the leaderboard display shape (`rank`, `name`, `xp`, `level`, `avatar`)
- Falls back to `MOCK_LEADERBOARD` gracefully when:
  - `VITE_API_BASE` is not configured
  - API returns an empty array
  - `fetch` throws a network error
- Updated `loadData()` in `GamificationDashboard.jsx` to `async/await` the now-async `getLeaderboard()` call
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #992

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings