### PR TITLE
fix: replace hardcoded localhost:5000 with getSocketServerUrl() in socket.ts

### DIFF
--- a/website/src/services/socket.ts
+++ b/website/src/services/socket.ts
@@ -1,11 +1,15 @@
 import { io, Socket } from 'socket.io-client';
+import { getSocketServerUrl } from '../utils/runtimeConfig';
 
 // Keep a singleton instance
 let socketInstance: Socket | null = null;
 let connectionUrl: string = '';
 
 export const initializeSocket = (
-  url: string = import.meta.env.VITE_API_URL || 'http://localhost:5000'
+  // Uses getSocketServerUrl() from runtimeConfig which correctly returns
+  // empty string in production when unconfigured instead of falling back
+  // to a hardcoded localhost URL that doesn't exist in deployed environments.
+  url: string = getSocketServerUrl()
 ): Socket => {
   if (!socketInstance || (connectionUrl && connectionUrl !== url)) {
     if (socketInstance) {


### PR DESCRIPTION
## Description
`website/src/services/socket.ts` hardcoded `http://localhost:5000` as a fallback when `VITE_API_URL` is not set:

```ts
export const initializeSocket = (
  url: string = import.meta.env.VITE_API_URL || 'http://localhost:5000'
): Socket => {
```

In any deployed environment where `VITE_API_URL` is not configured, the socket silently attempted to connect to `http://localhost:5000` — a URL that doesn't exist in production. This caused the socket connection to fail with repeated `connect_error` events on every page load, polluting the console and preventing all real-time features (workspace sync, live content updates, collaboration) from working.

The rest of the codebase uses `getSocketServerUrl()` from `runtimeConfig.js` which correctly returns an empty string in production when unconfigured, and handles `VITE_SOCKET_URL`, `VITE_API_BASE`, and local development fallbacks consistently.

Changes made:
- Imported `getSocketServerUrl` from `../utils/runtimeConfig`
- Replaced `import.meta.env.VITE_API_URL || 'http://localhost:5000'` with `getSocketServerUrl()`
- Added a comment explaining why `getSocketServerUrl()` is used instead of a hardcoded fallback
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #993

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings