### PR TITLE
fix: wire useRecommendations hook to PersonalizedFeed in EventsPage

### DIFF
--- a/website/src/components/recommendation/PersonalizedFeed.jsx
+++ b/website/src/components/recommendation/PersonalizedFeed.jsx
@@ -1,15 +1,23 @@
 /**
  * PersonalizedFeed
- * Shows a "For You" AI-recommended list of events.
- * Full ML-backed implementation coming soon — this stub renders the
- * events in a simple card grid so the page doesn't break.
+ * Shows a "For You" AI-recommended list of events scored by useRecommendations.
  */
-export default function PersonalizedFeed({ events = [], onEventClick }) {
+export default function PersonalizedFeed({ events = [], loading = false, onEventClick }) {
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: '48px 24px', color: 'var(--t2, #94a3b8)' }}>
+        <div style={{ fontSize: 36, marginBottom: 12 }}>✨</div>
+        <p style={{ margin: 0 }}>Generating personalised recommendations...</p>
+      </div>
+    );
+  }
   if (!events.length) {
     return (
       <div style={{ textAlign: 'center', padding: '48px 24px', color: 'var(--t2, #94a3b8)' }}>
         <div style={{ fontSize: 36, marginBottom: 12 }}>✨</div>
-        <p style={{ margin: 0 }}>No events to recommend yet. Check back soon!</p>
+        <p style={{ margin: 0 }}>
+          No events to recommend yet. Interact with events to personalise your feed!
+        </p>
       </div>
     );
   }
@@ -32,7 +40,7 @@ export default function PersonalizedFeed({ events = [], onEventClick }) {
           <span>✨</span> Recommended For You
         </h2>
         <p style={{ margin: '6px 0 0', fontSize: '0.85rem', color: 'var(--t2, #94a3b8)' }}>
-          Personalised picks based on your activity — full AI recommendations coming soon.
+          Personalised picks based on your browsing activity and interests.
         </p>
       </div>
 
@@ -78,13 +86,9 @@ export default function PersonalizedFeed({ events = [], onEventClick }) {
                   fontWeight: 600,
                   marginBottom: 10,
                   background:
-                    ev.status === 'upcoming'
-                      ? 'rgba(0,212,255,0.12)'
-                      : 'rgba(255,255,255,0.06)',
+                    ev.status === 'upcoming' ? 'rgba(0,212,255,0.12)' : 'rgba(255,255,255,0.06)',
                   color:
-                    ev.status === 'upcoming'
-                      ? 'var(--accent2, #00d4ff)'
-                      : 'var(--t3, #64748b)',
+                    ev.status === 'upcoming' ? 'var(--accent2, #00d4ff)' : 'var(--t3, #64748b)',
                 }}
               >
                 {ev.status === 'upcoming' ? '🔵 Upcoming' : '✅ Completed'}

--- a/website/src/pages/events/EventsPage.jsx
+++ b/website/src/pages/events/EventsPage.jsx
@@ -4,11 +4,13 @@ import { BannerOrbs } from '../../shared/MotionLayer';
 import Footer from '../../shared/Footer';
 import { DynamicIcon } from '../../shared/Icons';
 import PersonalizedFeed from '../../components/recommendation/PersonalizedFeed';
+import { useRecommendations } from '../../hooks/useRecommendations';
 import EventCalendarView from '../../components/calendar/EventCalendarView';
 
 export default function EventsPage({ onBack, onEventClick, events = fallbackEvents }) {
   const [view, setView] = useState('timeline');
   const [recommendationView, setRecommendationView] = useState(false);
+  const { recommendations, loading: recsLoading } = useRecommendations(sortedEvents);
 
   const buildGradient = (ev) => {
     if (ev.gradientColors?.length > 1) {
@@ -223,7 +225,11 @@ export default function EventsPage({ onBack, onEventClick, events = fallbackEven
 
       <div className="container">
         {recommendationView ? (
-          <PersonalizedFeed events={sortedEvents} onEventClick={onEventClick} />
+          <PersonalizedFeed
+            events={recommendations}
+            loading={recsLoading}
+            onEventClick={onEventClick}
+          />
         ) : view === 'timeline' ? (
           <div className="events-timeline ns-reveal">
             {sortedEvents.map((ev, i) => {


### PR DESCRIPTION
## Description
`EventsPage.jsx` passed `sortedEvents` directly to `PersonalizedFeed` with no scoring or filtering:

```jsx
<PersonalizedFeed events={sortedEvents} onEventClick={onEventClick} />
```

The `useRecommendations` hook (`website/src/hooks/useRecommendations.js`) which computes ML-backed recommendation scores using category matching, tag matching, user history similarity, popularity, and recency — existed but was never imported or used in `EventsPage.jsx`. The "For You" tab therefore showed all events in the same order as the main timeline with no personalisation — identical output to the regular events list.

Changes made:

**`EventsPage.jsx`:**
- Imported `useRecommendations` from `../../hooks/useRecommendations`
- Added `useRecommendations(sortedEvents)` hook call to get scored `recommendations` and `recsLoading` state
- Passed `recommendations` instead of `sortedEvents` to `PersonalizedFeed` — the feed now shows events ordered by personalisation score
- Passed `loading={recsLoading}` to `PersonalizedFeed` for loading state

**`PersonalizedFeed.jsx`:**
- Added `loading` prop with a loading state UI shown while recommendations are computed
- Updated empty state message to reflect actual personalisation behaviour
- Removed stale "full AI recommendations coming soon" comment from the subtitle
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1002

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings