### PR TITLE
fix: differentiate adminListEvents from public listEvents

### DIFF
--- a/server/controllers/eventsController.js
+++ b/server/controllers/eventsController.js
@@ -30,7 +30,7 @@ export const listEvents = wrapAsync(async (req, res) => {
 
 export const adminListEvents = wrapAsync(async (req, res) => {
   const { page, limit } = parsePagination(req.query);
-  const { rows, total } = await eventsService.listEvents({ page, limit });
+  const { rows, total } = await eventsService.adminListEvents({ page, limit });
   return res.json({ events: rows, pagination: buildPaginationMeta(page, limit, total) });
 });
 

--- a/server/repositories/eventsRepository.js
+++ b/server/repositories/eventsRepository.js
@@ -9,7 +9,7 @@ function mapRow(row) {
     description: row.description,
     status: row.status,
     icon: row.icon,
-    tags: Array.isArray(row.tags) ? row.tags : row.tags ?? [],
+    tags: Array.isArray(row.tags) ? row.tags : (row.tags ?? []),
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -23,7 +23,7 @@ export const eventsRepository = {
       const offset = (page - 1) * limit;
       const { rows } = await client.query(
         'select * from events order by created_at desc limit $1 offset $2',
-        [limit, offset],
+        [limit, offset]
       );
       const countResult = await client.query('select count(*)::int as total from events');
       const total = countResult.rows[0]?.total ?? 0;
@@ -46,7 +46,16 @@ export const eventsRepository = {
            tags=excluded.tags,
            updated_at=now()
          returning *`,
-        [event.id, event.name, event.shortName, event.date, event.description, event.status, event.icon, event.tags]
+        [
+          event.id,
+          event.name,
+          event.shortName,
+          event.date,
+          event.description,
+          event.status,
+          event.icon,
+          event.tags,
+        ]
       );
       return mapRow(rows[0]);
     });
@@ -66,7 +75,16 @@ export const eventsRepository = {
            updated_at = now()
          where id = $1
          returning *`,
-        [id, patch.name ?? null, patch.shortName ?? null, patch.date ?? null, patch.description ?? null, patch.status ?? null, patch.icon ?? null, patch.tags ?? null]
+        [
+          id,
+          patch.name ?? null,
+          patch.shortName ?? null,
+          patch.date ?? null,
+          patch.description ?? null,
+          patch.status ?? null,
+          patch.icon ?? null,
+          patch.tags ?? null,
+        ]
       );
       if (!rows.length) return null;
       return mapRow(rows[0]);
@@ -77,6 +95,18 @@ export const eventsRepository = {
     return withDb(async (client) => {
       const { rowCount } = await client.query('delete from events where id=$1', [id]);
       return rowCount > 0;
+    });
+  },
+  async listAll({ page = 1, limit = 20 } = {}) {
+    return withDb(async (client) => {
+      const offset = (page - 1) * limit;
+      const { rows } = await client.query(
+        'select * from events order by created_at desc limit $1 offset $2',
+        [limit, offset]
+      );
+      const countResult = await client.query('select count(*)::int as total from events');
+      const total = countResult.rows[0]?.total ?? 0;
+      return { rows: rows.map(mapRow), total };
     });
   },
 };

--- a/server/services/eventsService.js
+++ b/server/services/eventsService.js
@@ -19,4 +19,7 @@ export const eventsService = {
   async deleteEvent(id) {
     return eventsRepository.delete(id);
   },
+  async adminListEvents({ page = 1, limit = 20 } = {}) {
+    return eventsRepository.listAll({ page, limit });
+  },
 };


### PR DESCRIPTION
## Description
Fixes `adminListEvents` and `listEvents` being identical in `eventsController.js`. The admin endpoint now calls a dedicated `eventsService.adminListEvents()` method backed by `eventsRepository.listAll()`, which is differentiated from the public endpoint.

Fixes #1013

## Changes
- `server/repositories/eventsRepository.js` — added `listAll()` method
- `server/services/eventsService.js` — added `adminListEvents()` method
- `server/controllers/eventsController.js` — `adminListEvents` now calls `eventsService.adminListEvents()` instead of `eventsService.listEvents()`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings