### PR TITLE
fix: resolve race condition in admin session renewal

### DIFF
--- a/server/repositories/adminSessionsRepository.js
+++ b/server/repositories/adminSessionsRepository.js
@@ -158,7 +158,7 @@ export async function getAdminSession(token) {
       // Async non-blocking deferred persistence: execute outside the request query thread context
       withDb(async (dbClient) => {
         await dbClient.query(
-          'update admin_sessions set last_seen_at = now() where token_hash = $1',
+          "update admin_sessions set last_seen_at = now() where token_hash = $1 and last_seen_at < now() - interval '1 minute'",
           [tokenHash]
         );
       }).catch((error) => {


### PR DESCRIPTION
closes #1023 
## Description
This PR resolves a race condition that occurs during admin session validation under heavy concurrent load. By moving the concurrency protection to the SQL level (appending an interval check to the `last_seen_at` update query), we prevent database row-lock storms and state invalidation that previously caused abrupt logouts.

Fixes #1023

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings