### PR TITLE
fix: resolve websocket connection leak during reconnection

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -305,7 +305,25 @@ export function _onConnection(socket) {
       return;
     }
 
-    // 4. Safe Deep Copy (Persist sanitized primitives)
+    // 4. Prevent Connection Leaks: Disconnect existing stale sockets for this user
+    const existingEntries = Array.from(connectedUsers.values()).filter(
+      (u) => u.id === String(userId) && u.socketId !== socket.id
+    );
+    for (const entry of existingEntries) {
+      if (io && io.sockets && io.sockets.sockets) {
+        const oldSocket = io.sockets.sockets.get(entry.socketId);
+        if (oldSocket) {
+          logger.info('Disconnecting stale socket for user', {
+            userId,
+            oldSocketId: entry.socketId,
+          });
+          oldSocket.disconnect(true);
+        }
+      }
+      connectedUsers.delete(entry.socketId);
+    }
+
+    // 5. Safe Deep Copy (Persist sanitized primitives)
     connectedUsers.set(socket.id, {
       id: String(userId),
       email: String(email),


### PR DESCRIPTION

closes #1025
## Description
This PR fixes a critical memory leak caused by orphaned WebSocket connections during reconnection storms. When a client identifies itself with the `user:identify` event, the server now scans the connection map for any stale sockets matching that user ID and forcefully disconnects and purges them. This strictly guarantees a single active connection per user session and prevents unbounded Socket object accumulation.

Fixes #1025

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings