### PR TITLE
feat: implement API request tracing and correlation IDs

### DIFF
--- a/server/config/appContext.js
+++ b/server/config/appContext.js
@@ -1,0 +1,39 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import pg from 'pg';
+
+export const appContext = new AsyncLocalStorage();
+
+// Global patch for pg module to automatically append the Correlation ID to all queries
+const originalClientQuery = pg.Client.prototype.query;
+pg.Client.prototype.query = function (config, values, callback) {
+  const store = appContext.getStore();
+  if (store?.reqId) {
+    if (typeof config === 'string') {
+      config = `/* reqId: ${store.reqId} */ ${config}`;
+    } else if (config && typeof config.text === 'string') {
+      config.text = `/* reqId: ${store.reqId} */ ${config.text}`;
+    }
+  }
+  return originalClientQuery.call(this, config, values, callback);
+};
+
+// Global patch for fetch to automatically append the Correlation ID header to downstream requests
+const originalFetch = global.fetch;
+global.fetch = function (url, options) {
+  const store = appContext.getStore();
+  if (store?.reqId) {
+    options = options || {};
+
+    // We must clone or create headers to avoid mutating a shared object unexpectedly,
+    // but typically fetch options are per-request.
+    if (options.headers instanceof Headers) {
+      options.headers.set('X-Request-ID', store.reqId);
+    } else {
+      options.headers = {
+        ...options.headers,
+        'X-Request-ID': store.reqId,
+      };
+    }
+  }
+  return originalFetch.call(this, url, options);
+};

--- a/server/index.js
+++ b/server/index.js
@@ -14,6 +14,7 @@ import adminStreamRouter from './routes/adminStream.js';
 import documentationRouter from './routes/documentation.js';
 import monitoringRouter from './routes/monitoring.js';
 import { performanceMonitor } from './middleware/performanceMonitor.js';
+import { tracingMiddleware } from './middleware/tracingMiddleware.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
 import { initializeSentry, addSentryErrorHandler } from './utils/sentry.js';
 import {
@@ -73,6 +74,8 @@ const allowedOrigins = process.env.CORS_ORIGIN.split(',')
 app.use(helmet());
 app.use(cors({ origin: allowedOrigins, credentials: true }));
 
+app.use(tracingMiddleware);
+
 app.use(express.json({ limit: '512kb' }));
 app.use(morgan('combined'));
 app.use(performanceMonitor);
@@ -82,12 +85,13 @@ app.use('/api', apiRateLimiter);
 
 function requestLogger(req, res, next) {
   const start = process.hrtime.bigint();
-  const { method, path } = req;
+  const { method, path, reqId } = req;
 
   res.on('finish', () => {
     const duration = Number(process.hrtime.bigint() - start) / 1e6;
     const status = res.statusCode;
-    const message = `[${method}] ${path} → ${status} (${Math.round(duration)}ms)`;
+    const prefix = reqId ? `[${reqId}] ` : '';
+    const message = `${prefix}[${method}] ${path} → ${status} (${Math.round(duration)}ms)`;
 
     if (status >= 500) {
       console.error(message);

--- a/server/middleware/tracingMiddleware.js
+++ b/server/middleware/tracingMiddleware.js
@@ -1,0 +1,17 @@
+import crypto from 'crypto';
+import { appContext } from '../config/appContext.js';
+
+export function tracingMiddleware(req, res, next) {
+  // Use existing header if provided (useful for tracing across services)
+  // Otherwise, generate a new UUID for this request
+  const reqId = req.headers['x-request-id'] || crypto.randomUUID();
+
+  // Expose on the request and response objects for immediate access if needed
+  req.reqId = reqId;
+  res.setHeader('X-Request-ID', reqId);
+
+  // Wrap the remainder of the request execution within this context
+  appContext.run({ reqId }, () => {
+    next();
+  });
+}

--- a/server/test/tracing.test.js
+++ b/server/test/tracing.test.js
@@ -1,0 +1,101 @@
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import http from 'http';
+import express from 'express';
+import pg from 'pg';
+import { appContext } from '../config/appContext.js';
+import { tracingMiddleware } from '../middleware/tracingMiddleware.js';
+
+describe('API Request Tracing and Distributed Correlation IDs', () => {
+  test('generates a new X-Request-ID if not provided', async () => {
+    const app = express();
+    app.use(tracingMiddleware);
+    let capturedReqId = null;
+    let asyncContextReqId = null;
+    app.get('/', (req, res) => {
+      capturedReqId = req.reqId;
+      asyncContextReqId = appContext.getStore()?.reqId;
+      res.send('ok');
+    });
+
+    const server = app.listen(0);
+    const port = server.address().port;
+
+    const res = await fetch(`http://127.0.0.1:${port}/`);
+    assert.equal(res.status, 200);
+    const headerReqId = res.headers.get('x-request-id');
+
+    server.close();
+
+    assert.ok(capturedReqId, 'reqId should be generated on the request');
+    assert.equal(capturedReqId, headerReqId, 'reqId should be exposed in response headers');
+    assert.equal(
+      asyncContextReqId,
+      capturedReqId,
+      'reqId should be available in AsyncLocalStorage'
+    );
+  });
+
+  test('preserves existing X-Request-ID if provided', async () => {
+    const app = express();
+    app.use(tracingMiddleware);
+    app.get('/', (req, res) => res.send('ok'));
+
+    const server = app.listen(0);
+    const port = server.address().port;
+
+    const testId = 'test-correlation-id-123';
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { 'X-Request-ID': testId },
+    });
+    server.close();
+
+    assert.equal(res.headers.get('x-request-id'), testId, 'Should preserve incoming request ID');
+  });
+
+  test('prepends reqId to pg client queries', async () => {
+    // Create a mock client
+    const client = new pg.Client({ connectionString: 'postgres://localhost/mock' });
+
+    // We prevent actual execution by throwing inside a mock of the internal method, or just let it fail
+    // But since the patch mutates the config object, we can just inspect the object after calling it!
+    const testId = 'db-tracing-test-id';
+    const config = { text: 'SELECT * FROM users' };
+
+    appContext.run({ reqId: testId }, () => {
+      client.query(config).catch(() => {}); // Catch any errors, we don't need it to succeed
+    });
+
+    // Close the client so the event loop doesn't hang
+    client.end();
+
+    assert.ok(
+      config.text.includes(`/* reqId: ${testId} */`),
+      'SQL should include the reqId comment'
+    );
+    assert.ok(config.text.includes('SELECT * FROM users'), 'SQL should include the original query');
+  });
+
+  test('injects X-Request-ID into downstream fetch calls', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ header: req.headers['x-request-id'] }));
+    });
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    const testId = 'fetch-tracing-test-id';
+    await appContext.run({ reqId: testId }, async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/test`);
+      const data = await res.json();
+      assert.equal(
+        data.header,
+        testId,
+        'Downstream fetch should have the X-Request-ID header injected'
+      );
+    });
+
+    server.close();
+  });
+});

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -3,13 +3,14 @@
  * Structured logging for all backend operations
  */
 
-import winston from "winston";
-import path from "path";
-import DailyRotateFile from "winston-daily-rotate-file";
+import winston from 'winston';
+import { appContext } from '../config/appContext.js';
+import path from 'path';
+import DailyRotateFile from 'winston-daily-rotate-file';
 
 // Create logs directory if it doesn't exist
-import fs from "fs";
-const logsDir = path.join(process.cwd(), "logs");
+import fs from 'fs';
+const logsDir = path.join(process.cwd(), 'logs');
 if (!fs.existsSync(logsDir)) {
   fs.mkdirSync(logsDir, { recursive: true });
 }
@@ -25,26 +26,24 @@ const levels = {
 
 // Define colors for console output
 const colors = {
-  error: "red",
-  warn: "yellow",
-  info: "green",
-  http: "magenta",
-  debug: "white",
+  error: 'red',
+  warn: 'yellow',
+  info: 'green',
+  http: 'magenta',
+  debug: 'white',
 };
 
 winston.addColors(colors);
 
 // Define log format
 const format = winston.format.combine(
-  winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss:ms" }),
+  winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss:ms' }),
   winston.format.errors({ stack: true }),
   winston.format.printf((info) => {
-    const { timestamp, level, message, ...args } = info;
-
-    const ts = timestamp.slice(0, 19).replace("T", " ");
-
-    return `${ts} [${level}]: ${message} ${
-      Object.keys(args).length ? JSON.stringify(args, null, 2) : ""
+    const store = appContext.getStore();
+    const reqId = store?.reqId ? `[${store.reqId}] ` : '';
+    return `${info.timestamp} ${reqId}[${info.level}]: ${info.message} ${
+      info.stack ? `\n${info.stack}` : ''
     }`;
   })
 );
@@ -53,31 +52,28 @@ const format = winston.format.combine(
 const transports = [
   // Console transport
   new winston.transports.Console({
-    format: winston.format.combine(
-      winston.format.colorize({ all: true }),
-      format
-    ),
+    format: winston.format.combine(winston.format.colorize({ all: true }), format),
   }),
 
   // Error logs
   new winston.transports.File({
-    filename: path.join(logsDir, "error.log"),
-    level: "error",
+    filename: path.join(logsDir, 'error.log'),
+    level: 'error',
     format: winston.format.uncolorize(),
   }),
 
   // Combined logs
   new winston.transports.File({
-    filename: path.join(logsDir, "combined.log"),
+    filename: path.join(logsDir, 'combined.log'),
     format: winston.format.uncolorize(),
   }),
 
   // Daily rotate logs (requires winston-daily-rotate-file)
   new DailyRotateFile({
-    filename: path.join(logsDir, "application-%DATE%.log"),
-    datePattern: "YYYY-MM-DD",
-    maxSize: "20m",
-    maxFiles: "14d",
+    filename: path.join(logsDir, 'application-%DATE%.log'),
+    datePattern: 'YYYY-MM-DD',
+    maxSize: '20m',
+    maxFiles: '14d',
     format: winston.format.uncolorize(),
     utc: true,
   }),
@@ -85,26 +81,26 @@ const transports = [
 
 // Create logger instance
 const logger = winston.createLogger({
-  level: process.env.LOG_LEVEL || "info",
+  level: process.env.LOG_LEVEL || 'info',
   levels,
   format,
   transports,
   exceptionHandlers: [
     new DailyRotateFile({
-      filename: path.join(logsDir, "exceptions-%DATE%.log"),
-      datePattern: "YYYY-MM-DD",
-      maxSize: "20m",
-      maxFiles: "14d",
+      filename: path.join(logsDir, 'exceptions-%DATE%.log'),
+      datePattern: 'YYYY-MM-DD',
+      maxSize: '20m',
+      maxFiles: '14d',
       format: winston.format.uncolorize(),
       utc: true,
     }),
   ],
   rejectionHandlers: [
     new DailyRotateFile({
-      filename: path.join(logsDir, "rejections-%DATE%.log"),
-      datePattern: "YYYY-MM-DD",
-      maxSize: "20m",
-      maxFiles: "14d",
+      filename: path.join(logsDir, 'rejections-%DATE%.log'),
+      datePattern: 'YYYY-MM-DD',
+      maxSize: '20m',
+      maxFiles: '14d',
       format: winston.format.uncolorize(),
       utc: true,
     }),


### PR DESCRIPTION

closes #1026
## Description
This PR implements a distributed Correlation ID (`X-Request-ID`) system to trace API requests seamlessly across different components, allowing for significantly easier debugging of production issues. 

- Introduced a global context using Node's `AsyncLocalStorage` to hold the request lifecycle.
- Created `tracingMiddleware` to parse or generate `X-Request-ID` and attach it to the asynchronous context.
- Modified the Winston logger configuration to automatically extract the correlation ID and prepend it `[<reqId>]` to all log messages.
- Patched the global `pg.Client.prototype.query` method to prepend `/* reqId: <id> */` comments directly into all downstream SQL queries.
- Patched the global `fetch` API to automatically inject the `X-Request-ID` header into any downstream HTTP requests.

Fixes #1026

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings