### PR TITLE
feat: implement database connection failover and circuit breaker

### DIFF
--- a/server/repositories/db.js
+++ b/server/repositories/db.js
@@ -31,10 +31,7 @@ function parsePositiveInt(value, fallback) {
 function getPoolConfig() {
   return {
     max: parsePositiveInt(process.env.PG_POOL_MAX, 20),
-    connectionTimeoutMillis: parsePositiveInt(
-      process.env.PG_CONNECTION_TIMEOUT_MS,
-      5_000,
-    ),
+    connectionTimeoutMillis: parsePositiveInt(process.env.PG_CONNECTION_TIMEOUT_MS, 5_000),
     idleTimeoutMillis: parsePositiveInt(process.env.PG_IDLE_TIMEOUT_MS, 30_000),
     // statement_timeout is a Postgres session-level parameter. Passing it via
     // the connection string's options query parameter means every client
@@ -44,25 +41,33 @@ function getPoolConfig() {
 }
 
 let pool = null;
+let replicaPool = null;
+let circuitOpenUntil = 0;
 
-function getPool() {
-  if (pool) return pool;
-  const databaseUrl = process.env.DATABASE_URL;
-  if (!databaseUrl) return null;
+function getPools() {
+  if (!pool && process.env.DATABASE_URL) {
+    pool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL,
+      ...getPoolConfig(),
+    });
 
-  pool = new pg.Pool({
-    connectionString: databaseUrl,
-    ...getPoolConfig(),
-  });
+    pool.on('error', (err) => {
+      console.error('[pg.Pool primary] Unexpected error on idle client:', err.message);
+    });
+  }
 
-  // Surface unexpected errors on idle clients so they do not silently crash
-  // the process or swallow stack traces. The pool itself stays alive — pg
-  // will remove the broken client and replace it on the next checkout.
-  pool.on('error', (err) => {
-    console.error('[pg.Pool] Unexpected error on idle client:', err.message);
-  });
+  if (!replicaPool && process.env.DATABASE_URL_REPLICA) {
+    replicaPool = new pg.Pool({
+      connectionString: process.env.DATABASE_URL_REPLICA,
+      ...getPoolConfig(),
+    });
 
-  return pool;
+    replicaPool.on('error', (err) => {
+      console.error('[pg.Pool replica] Unexpected error on idle client:', err.message);
+    });
+  }
+
+  return { primaryPool: pool, replicaPool };
 }
 
 export let withDbOverride = null;
@@ -71,21 +76,48 @@ export async function withDb(fn) {
   if (withDbOverride) {
     return await withDbOverride(fn);
   }
-  const p = getPool();
-  if (!p) throw new Error('PostgreSQL not configured. Missing DATABASE_URL.');
-  const client = await p.connect();
+  const { primaryPool, replicaPool } = getPools();
+  if (!primaryPool) throw new Error('PostgreSQL not configured. Missing DATABASE_URL.');
+
+  const cooldownMs = parsePositiveInt(process.env.PG_CIRCUIT_BREAKER_COOLDOWN_MS, 30_000);
+  const now = Date.now();
+  let client;
+
+  if (now < circuitOpenUntil && replicaPool) {
+    // Circuit is open, use replica
+    client = await replicaPool.connect();
+  } else {
+    // Circuit is closed (or half-open), try primary
+    try {
+      client = await primaryPool.connect();
+      if (circuitOpenUntil !== 0) {
+        // We successfully connected, close the circuit
+        circuitOpenUntil = 0;
+      }
+    } catch (primaryErr) {
+      console.error('[db] Primary connection failed:', primaryErr.message);
+      if (replicaPool) {
+        console.warn(`[db] Opening circuit for ${cooldownMs}ms. Falling back to read-replica...`);
+        circuitOpenUntil = Date.now() + cooldownMs;
+        try {
+          client = await replicaPool.connect();
+        } catch (replicaErr) {
+          console.error('[db] Replica connection also failed:', replicaErr.message);
+          throw primaryErr;
+        }
+      } else {
+        throw primaryErr;
+      }
+    }
+  }
+
   try {
     return await fn(client);
   } finally {
-    client.release();
+    if (client) client.release();
   }
 }
 
-/**
- * Returns a snapshot of live pool metrics useful for health checks and
- * performance monitoring. Returns null when the pool has not been initialised
- * (DATABASE_URL not set).
- */
 export function getPoolStats() {
   if (!pool) return null;
   return {
@@ -94,9 +126,18 @@ export function getPoolStats() {
     waiting: pool.waitingCount,
   };
 }
+
+// For testing purposes
+export function _resetCircuitBreaker() {
+  circuitOpenUntil = 0;
+}
+export function _resetPools() {
+  pool = null;
+  replicaPool = null;
+}
+
 export function setWithDbOverride(fn) {
   withDbOverride = fn;
 }
 
 export { pg };
-

--- a/server/test/db_failover.test.js
+++ b/server/test/db_failover.test.js
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { _resetCircuitBreaker, _resetPools } from '../repositories/db.js';
+
+// Mock pg to test failover logic
+import pg from 'pg';
+
+let primaryConnectShouldFail = false;
+let replicaConnectShouldFail = false;
+
+pg.Pool = class MockPool {
+  constructor(config) {
+    this.config = config;
+    this.isReplica = config.connectionString && config.connectionString.includes('replica');
+  }
+  on() {}
+  async connect() {
+    if (this.isReplica && replicaConnectShouldFail) {
+      throw new Error('Replica connection error');
+    }
+    if (!this.isReplica && primaryConnectShouldFail) {
+      throw new Error('Primary connection error');
+    }
+    return {
+      isReplica: this.isReplica,
+      release: () => {},
+    };
+  }
+};
+
+// Now import db.js (it will use the mocked pg)
+import { withDb } from '../repositories/db.js';
+
+test.beforeEach(() => {
+  process.env.DATABASE_URL = 'postgres://primary';
+  process.env.DATABASE_URL_REPLICA = 'postgres://replica';
+  process.env.PG_CIRCUIT_BREAKER_COOLDOWN_MS = '1000';
+  _resetCircuitBreaker();
+  _resetPools();
+  primaryConnectShouldFail = false;
+  replicaConnectShouldFail = false;
+});
+
+test('withDb connects to primary when healthy', async () => {
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, false, 'Should connect to primary');
+  });
+});
+
+test('withDb falls back to replica when primary fails and opens circuit', async () => {
+  primaryConnectShouldFail = true;
+
+  // First request: primary fails, falls back to replica
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, true, 'Should connect to replica upon primary failure');
+  });
+
+  // Circuit should now be open, so next request directly uses replica even if primary "recovers"
+  primaryConnectShouldFail = false;
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, true, 'Should use replica directly because circuit is open');
+  });
+});
+
+test('withDb closes circuit after cooldown', async () => {
+  process.env.PG_CIRCUIT_BREAKER_COOLDOWN_MS = '100';
+  primaryConnectShouldFail = true;
+
+  // First request: primary fails, circuit opens
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, true);
+  });
+
+  primaryConnectShouldFail = false;
+
+  // Wait for cooldown
+  await new Promise((r) => setTimeout(r, 150));
+
+  // Second request: cooldown elapsed, should try primary and succeed (circuit closes)
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, false, 'Should reconnect to primary after cooldown');
+  });
+
+  // Third request: circuit is closed, uses primary directly
+  await withDb(async (client) => {
+    assert.equal(client.isReplica, false);
+  });
+});
+
+test('withDb throws when both primary and replica fail', async () => {
+  primaryConnectShouldFail = true;
+  replicaConnectShouldFail = true;
+
+  await assert.rejects(async () => {
+    await withDb(async () => {});
+  }, /Primary connection error/);
+});
+
+test('withDb throws when primary fails and no replica is configured', async () => {
+  delete process.env.DATABASE_URL_REPLICA;
+  primaryConnectShouldFail = true;
+
+  await assert.rejects(async () => {
+    await withDb(async () => {});
+  }, /Primary connection error/);
+});


### PR DESCRIPTION
closes #1028
## Description
This PR introduces automated failover and a Circuit Breaker pattern for the PostgreSQL database connection pool. 
- It configures a secondary connection pool mapped to `DATABASE_URL_REPLICA`.
- When the primary database experiences connection failures (e.g., node goes down or network partition), the circuit breaker opens for a configurable cooldown period (defaulting to 30s via `PG_CIRCUIT_BREAKER_COOLDOWN_MS`).
- During this open state, all incoming database requests gracefully fallback to the `replicaPool`, avoiding Node.js process crashes and enabling read-only functionality instead of cascading 500s across APIs.

Fixes #1028

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings