### PR TITLE
feat: fallback mechanism for websocket real-time synchronization

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -222,6 +222,7 @@ export function initializeSocketIO(httpServer) {
     reconnectionAttempts: 5,
     pingTimeout: 20000,
     pingInterval: 10000,
+    transports: ['websocket', 'polling'],
   });
 
   // Connection auth middleware — checks handshake auth token

--- a/website/src/services/socket.ts
+++ b/website/src/services/socket.ts
@@ -31,7 +31,7 @@ export const initializeSocket = (
       reconnectionDelayMax: 5000,
       timeout: 20000,
       autoConnect: true,
-      transports: ['websocket'],
+      transports: ['websocket', 'polling'],
     });
 
     socketInstance.on('connect', () => {


### PR DESCRIPTION
closes #1027
## Description
This PR resolves the issue where users on strict corporate networks or firewalls miss out on real-time updates because WebSockets are blocked.

It explicitly configures Socket.IO to support `polling` (long-polling/SSE) as a fallback mechanism alongside `websocket` on both the frontend client and the backend server. If the initial WebSocket handshake fails or times out, the client will now seamlessly fall back to HTTP long-polling to maintain a connection.

Fixes #1027

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings