### PR TITLE
fix: add Escape key handler to close FloatingDock and return focus to toggle

### DIFF
--- a/website/src/components/common/FloatingDock.jsx
+++ b/website/src/components/common/FloatingDock.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { ChevronUp, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 
@@ -56,6 +56,20 @@ const DOCK_ACTIONS = [
 export default function FloatingDock() {
   const [open, setOpen] = useState(false);
   const navigate = useNavigate();
+  const toggleRef = useRef(null);
+
+  // Close dock on Escape and return focus to toggle button
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape') {
+        setOpen(false);
+        toggleRef.current?.focus();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open]);
 
   const handleAction = (item) => {
     if (item.action === 'scroll-top') {
@@ -129,6 +143,7 @@ export default function FloatingDock() {
 
       {/* Main toggle button */}
       <button
+        ref={toggleRef}
         onClick={() => setOpen((o) => !o)}
         aria-label={open ? 'Close dock' : 'Open dock'}
         aria-expanded={open}


### PR DESCRIPTION
## Description
`FloatingDock.jsx` had no Escape key handler. The ARIA authoring practices for disclosure widgets require that pressing Escape closes the widget and returns focus to the toggle button. Without this, keyboard users who opened the dock had no standard way to dismiss it — they had to Tab back to the toggle button and activate it again manually.

Changes made:
- Added `useEffect` that attaches a `keydown` listener only when `open` is `true` — avoids an unnecessary global listener when the dock is closed
- On `Escape`: sets `open` to `false` and calls `toggleRef.current?.focus()` to return focus to the toggle button for correct keyboard flow
- Added `toggleRef` to the main toggle button so focus can be programmatically returned to it
- Effect cleanup removes the event listener when the dock closes or the component unmounts
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1067

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings