### PR TITLE
fix: replace auto-close timeout with Close button in JoinRequestModal success state

### DIFF
--- a/website/src/components/collab/JoinRequestModal.jsx
+++ b/website/src/components/collab/JoinRequestModal.jsx
@@ -22,7 +22,6 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
     try {
       await onSubmit({ pitch, skills, github, teamId: team.id });
       setSuccess(true);
-      setTimeout(onClose, 2000);
     } catch (err) {
       console.error(err);
     } finally {
@@ -31,25 +30,33 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   };
 
   return (
-    <div style={{
-      position: 'fixed', inset: 0, zIndex: 9999,
-      display: 'flex', alignItems: 'center', justifyContent: 'center',
-      background: 'rgba(0,0,0,0.6)', backdropFilter: 'blur(8px)',
-      padding: '24px'
-    }}>
-      <div 
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+        backdropFilter: 'blur(8px)',
+        padding: '24px',
+      }}
+    >
+      <div
         ref={modalRef}
         role="dialog"
         aria-modal="true"
         aria-labelledby="modal-title"
         className="glass-panel pop-scale"
         style={{
-          width: '100%', maxWidth: '500px',
+          width: '100%',
+          maxWidth: '500px',
           background: 'var(--bg)',
           borderRadius: '16px',
           border: '1px solid rgba(255,255,255,0.1)',
           boxShadow: '0 24px 80px rgba(0,0,0,0.5), 0 0 40px rgba(204,17,17,0.15)',
-          overflow: 'hidden'
+          overflow: 'hidden',
         }}
       >
         <div style={{ padding: '24px', borderBottom: '1px solid rgba(255,255,255,0.05)' }}>
@@ -57,10 +64,19 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
             <h2 id="modal-title" style={{ margin: 0, fontSize: '1.5rem', color: 'var(--t1)' }}>
               Join {team?.name}
             </h2>
-            <button onClick={onClose} style={{
-              background: 'transparent', border: 'none', color: 'var(--t2)',
-              fontSize: '1.5rem', cursor: 'pointer'
-            }} aria-label="Close modal">&times;</button>
+            <button
+              onClick={onClose}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                color: 'var(--t2)',
+                fontSize: '1.5rem',
+                cursor: 'pointer',
+              }}
+              aria-label="Close modal"
+            >
+              &times;
+            </button>
           </div>
           <p style={{ margin: '8px 0 0 0', color: 'var(--c1)', fontSize: '0.9rem' }}>
             Pitch yourself for the {team?.vacantRoles?.join(', ')} role(s)
@@ -70,84 +86,172 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
         <div style={{ padding: '24px' }}>
           {success ? (
             <div style={{ textAlign: 'center', padding: '40px 0', color: '#4CAF50' }}>
-              <svg width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" style={{ marginBottom: '16px' }}>
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+              <svg
+                width="64"
+                height="64"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                style={{ marginBottom: '16px' }}
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
               </svg>
               <h3 style={{ margin: 0 }}>Request Sent!</h3>
-              <p style={{ color: 'var(--t2)', fontSize: '0.9rem', marginTop: '8px' }}>The team leader will be notified.</p>
+              <p style={{ color: 'var(--t2)', fontSize: '0.9rem', marginTop: '8px' }}>
+                The team leader will be notified.
+              </p>
+              <button
+                onClick={onClose}
+                autoFocus
+                style={{
+                  marginTop: '20px',
+                  padding: '10px 28px',
+                  background: 'linear-gradient(135deg, #CC1111, #880000)',
+                  color: '#fff',
+                  border: 'none',
+                  borderRadius: '8px',
+                  fontWeight: 600,
+                  cursor: 'pointer',
+                }}
+              >
+                Close
+              </button>
             </div>
           ) : (
-            <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}>
+            <form
+              onSubmit={handleSubmit}
+              style={{ display: 'flex', flexDirection: 'column', gap: '16px' }}
+            >
               <div>
-                <label htmlFor="pitch" style={{ display: 'block', marginBottom: '8px', color: 'var(--t2)', fontSize: '0.9rem' }}>Why should they pick you?</label>
-                <textarea 
+                <label
+                  htmlFor="pitch"
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--t2)',
+                    fontSize: '0.9rem',
+                  }}
+                >
+                  Why should they pick you?
+                </label>
+                <textarea
                   id="pitch"
                   required
                   value={pitch}
                   onChange={(e) => setPitch(e.target.value)}
                   style={{
-                    width: '100%', minHeight: '100px', padding: '12px',
-                    background: 'var(--surface)', border: '1px solid rgba(255,255,255,0.1)',
-                    borderRadius: '8px', color: 'var(--t1)', fontSize: '0.95rem',
-                    resize: 'vertical', fontFamily: 'inherit'
+                    width: '100%',
+                    minHeight: '100px',
+                    padding: '12px',
+                    background: 'var(--surface)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '8px',
+                    color: 'var(--t1)',
+                    fontSize: '0.95rem',
+                    resize: 'vertical',
+                    fontFamily: 'inherit',
                   }}
                   placeholder="I have 2 years of React experience and..."
                 />
               </div>
 
               <div>
-                <label htmlFor="skills" style={{ display: 'block', marginBottom: '8px', color: 'var(--t2)', fontSize: '0.9rem' }}>Key Skills (comma separated)</label>
-                <input 
+                <label
+                  htmlFor="skills"
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--t2)',
+                    fontSize: '0.9rem',
+                  }}
+                >
+                  Key Skills (comma separated)
+                </label>
+                <input
                   id="skills"
                   type="text"
                   required
                   value={skills}
                   onChange={(e) => setSkills(e.target.value)}
                   style={{
-                    width: '100%', padding: '12px',
-                    background: 'var(--surface)', border: '1px solid rgba(255,255,255,0.1)',
-                    borderRadius: '8px', color: 'var(--t1)', fontSize: '0.95rem'
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--surface)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '8px',
+                    color: 'var(--t1)',
+                    fontSize: '0.95rem',
                   }}
                   placeholder="React, Node.js, UI/UX"
                 />
               </div>
 
               <div>
-                <label htmlFor="github" style={{ display: 'block', marginBottom: '8px', color: 'var(--t2)', fontSize: '0.9rem' }}>GitHub / Portfolio Link</label>
-                <input 
+                <label
+                  htmlFor="github"
+                  style={{
+                    display: 'block',
+                    marginBottom: '8px',
+                    color: 'var(--t2)',
+                    fontSize: '0.9rem',
+                  }}
+                >
+                  GitHub / Portfolio Link
+                </label>
+                <input
                   id="github"
                   type="url"
                   required
                   value={github}
                   onChange={(e) => setGithub(e.target.value)}
                   style={{
-                    width: '100%', padding: '12px',
-                    background: 'var(--surface)', border: '1px solid rgba(255,255,255,0.1)',
-                    borderRadius: '8px', color: 'var(--t1)', fontSize: '0.95rem'
+                    width: '100%',
+                    padding: '12px',
+                    background: 'var(--surface)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '8px',
+                    color: 'var(--t1)',
+                    fontSize: '0.95rem',
                   }}
                   placeholder="https://github.com/yourusername"
                 />
               </div>
 
               <div style={{ display: 'flex', gap: '12px', marginTop: '16px' }}>
-                <button 
-                  type="button" 
+                <button
+                  type="button"
                   onClick={onClose}
                   style={{
-                    flex: 1, padding: '12px', background: 'var(--surface-hover)',
-                    color: 'var(--t1)', border: '1px solid rgba(255,255,255,0.1)',
-                    borderRadius: '8px', cursor: 'pointer', fontWeight: 600
+                    flex: 1,
+                    padding: '12px',
+                    background: 'var(--surface-hover)',
+                    color: 'var(--t1)',
+                    border: '1px solid rgba(255,255,255,0.1)',
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    fontWeight: 600,
                   }}
                 >
                   Cancel
                 </button>
-                <button 
-                  type="submit" 
+                <button
+                  type="submit"
                   disabled={loading}
                   style={{
-                    flex: 2, padding: '12px', background: 'linear-gradient(135deg, #CC1111, #880000)',
-                    color: '#fff', border: 'none', borderRadius: '8px', cursor: loading ? 'not-allowed' : 'pointer',
-                    fontWeight: 600, opacity: loading ? 0.7 : 1
+                    flex: 2,
+                    padding: '12px',
+                    background: 'linear-gradient(135deg, #CC1111, #880000)',
+                    color: '#fff',
+                    border: 'none',
+                    borderRadius: '8px',
+                    cursor: loading ? 'not-allowed' : 'pointer',
+                    fontWeight: 600,
+                    opacity: loading ? 0.7 : 1,
                   }}
                 >
                   {loading ? 'Sending...' : 'Submit Request'}


### PR DESCRIPTION
## Description
`JoinRequestModal.jsx` automatically closed the modal 2 seconds after a successful submission with no user control:

```js
setSuccess(true);
setTimeout(onClose, 2000);
```

This was problematic for two reasons:
1. Users with slower reading speeds or cognitive disabilities could not read and process the "Request Sent!" confirmation message before it disappeared — there was no manual dismiss option in the success state
2. The `setTimeout` was not cleared if the modal was closed externally before 2 seconds elapsed, causing a state update on an unmounted component

Changes made:
- Removed `setTimeout(onClose, 2000)` entirely
- Added a "Close" button with `autoFocus` in the success state so users can dismiss the confirmation at their own pace
- `autoFocus` on the Close button ensures keyboard users are immediately focused on the only available action after a successful submission — no need to Tab to find the dismiss control
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1069

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings