### PR TITLE
fix: add 200-entry cap and QuotaExceededError handling to moderationService localStorage writes

### DIFF
--- a/website/src/services/moderationService.js
+++ b/website/src/services/moderationService.js
@@ -225,6 +225,11 @@ class ModerationService {
     return 'allow';
   }
 
+  // Maximum number of flagged content entries to retain in localStorage.
+  // Prevents unbounded growth that could overflow the ~5MB quota and
+  // corrupt unrelated localStorage keys (bookmarks, roadmap autosave).
+  static MAX_FLAGGED_ENTRIES = 200;
+
   // Flag content for admin review
   flagForReview(content, userId, result) {
     const flag = {
@@ -238,8 +243,12 @@ class ModerationService {
     };
     this.flaggedContent.unshift(flag);
 
-    // Store in localStorage for persistence
-    localStorage.setItem('moderation_flagged', JSON.stringify(this.flaggedContent));
+    // Evict oldest entries beyond the cap before saving
+    if (this.flaggedContent.length > ModerationService.MAX_FLAGGED_ENTRIES) {
+      this.flaggedContent = this.flaggedContent.slice(0, ModerationService.MAX_FLAGGED_ENTRIES);
+    }
+
+    this._saveFlaggedContent();
   }
 
   // Get flagged content for admin
@@ -258,7 +267,33 @@ class ModerationService {
       flag.status = 'reviewed';
       flag.resolvedAt = new Date().toISOString();
       flag.resolution = action;
+      this._saveFlaggedContent();
+    }
+  }
+
+  // Safe localStorage write — catches QuotaExceededError instead of
+  // letting it propagate and corrupt unrelated localStorage operations.
+  _saveFlaggedContent() {
+    try {
       localStorage.setItem('moderation_flagged', JSON.stringify(this.flaggedContent));
+    } catch (err) {
+      if (err instanceof DOMException && err.name === 'QuotaExceededError') {
+        console.warn(
+          '[ModerationService] localStorage quota exceeded — trimming flagged content and retrying.'
+        );
+        // Aggressively trim to half the cap and retry once
+        this.flaggedContent = this.flaggedContent.slice(
+          0,
+          Math.floor(ModerationService.MAX_FLAGGED_ENTRIES / 2)
+        );
+        try {
+          localStorage.setItem('moderation_flagged', JSON.stringify(this.flaggedContent));
+        } catch (_) {
+          console.warn('[ModerationService] Retry after trim also failed — skipping save.');
+        }
+      } else {
+        throw err;
+      }
     }
   }
 


### PR DESCRIPTION
## Description
`moderationService.js` wrote all flagged content to `localStorage` on every `flagForReview()` and `resolveFlag()` call with no size cap, no TTL, and no error handling:

```js
this.flaggedContent.unshift(flag);
localStorage.setItem('moderation_flagged', JSON.stringify(this.flaggedContent));
```

On an active platform with many flagged items, `this.flaggedContent` grew without bound. Once the `localStorage` quota (~5MB) was exceeded, `localStorage.setItem` threw a `QuotaExceededError` that silently propagated and caused unrelated `setItem` calls (bookmarks, roadmap autosave) to also fail and lose data.

Changes made:
- Added `static MAX_FLAGGED_ENTRIES = 200` constant
- `flagForReview()` now evicts the oldest entries beyond the cap before saving — newest flags are always retained
- Extracted all `localStorage.setItem('moderation_flagged', ...)` calls into a `_saveFlaggedContent()` helper that:
  - Catches `QuotaExceededError` with a clear warning
  - On quota breach: trims to half the cap (`100` entries) and retries the save once
  - If retry also fails, logs a warning and skips the save gracefully instead of throwing
- Both `flagForReview()` and `resolveFlag()` now use `_saveFlaggedContent()`
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1076

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings