### PR TITLE
fix: support multi-word page names in terminal nav command

### DIFF
--- a/website/src/utils/terminalCommands.ts
+++ b/website/src/utils/terminalCommands.ts
@@ -15,13 +15,13 @@ export const parseCommand = (input: string, context: CommandContext) => {
     case 'help':
       printToTerminal(
         'Available commands:\n' +
-        '  help       - Show this help message\n' +
-        '  events     - Show upcoming events\n' +
-        '  theme      - Change theme (usage: theme light|dark)\n' +
-        '  nav <page> - Navigate to a specific page\n' +
-        '  clear      - Clear terminal output\n' +
-        '  exit       - Close the terminal\n' +
-        '  sudo root  - ???'
+          '  help       - Show this help message\n' +
+          '  events     - Show upcoming events\n' +
+          '  theme      - Change theme (usage: theme light|dark)\n' +
+          '  nav <page> - Navigate to a specific page\n' +
+          '  clear      - Clear terminal output\n' +
+          '  exit       - Close the terminal\n' +
+          '  sudo root  - ???'
       );
       break;
 
@@ -48,22 +48,38 @@ export const parseCommand = (input: string, context: CommandContext) => {
 
     case 'nav':
       if (args.length > 1) {
-        const targetPage = args[1];
-        // Capitalize the first letter for the tab navigation
-        const formattedPage = targetPage.charAt(0).toUpperCase() + targetPage.slice(1).toLowerCase();
-        const validPages = ['Home', 'Activities', 'Events', 'Projects', 'Roadmaps', 'About', 'Team', 'Contact'];
+        // Join all args after 'nav' to support multi-word page names
+        // e.g. 'nav core team' → 'core team' → matched to 'Core Team'
+        const targetPage = args.slice(1).join(' ');
+        const validPages = [
+          'Home',
+          'Activities',
+          'Events',
+          'Projects',
+          'Roadmaps',
+          'About',
+          'Team',
+          'Contact',
+          'Core Team',
+        ];
 
-        if (validPages.includes(formattedPage)) {
-          printToTerminal(`Navigating to ${formattedPage}...`);
+        // Case-insensitive match so 'nav core team', 'nav Core Team',
+        // and 'nav CORE TEAM' all resolve correctly
+        const matchedPage = validPages.find((p) => p.toLowerCase() === targetPage.toLowerCase());
+
+        if (matchedPage) {
+          printToTerminal(`Navigating to ${matchedPage}...`);
           setTimeout(() => {
-            navigate(formattedPage);
+            navigate(matchedPage);
             closeTerminal();
           }, 500);
         } else {
-          printToTerminal(`Error: Unknown page '${targetPage}'. Valid pages are: ${validPages.join(', ')}`);
+          printToTerminal(
+            `Error: Unknown page '${targetPage}'. Valid pages are: ${validPages.join(', ')}`
+          );
         }
       } else {
-        printToTerminal('Usage: nav <page> (e.g., nav About)');
+        printToTerminal('Usage: nav <page> (e.g., nav About, nav Core Team)');
       }
       break;
 


### PR DESCRIPTION
## Description
The `nav` command in `terminalCommands.ts` only passed `args[1]` (the first word after `nav`) and capitalised only the first letter:

```ts
const targetPage = args[1];
const formattedPage = targetPage.charAt(0).toUpperCase() + targetPage.slice(1).toLowerCase();
```

This had two problems:
1. `nav core team` only passed `'core'` to the formatter — `'team'` was silently ignored
2. The formatter produced `'Core team'` which never matched `'Core Team'` in `validPages` — the command always returned "Unknown page" for multi-word destinations

Additionally `'Core Team'` was missing from `validPages` entirely, making it unreachable even if the formatting had worked.

Changes made:
- Replaced `args[1]` with `args.slice(1).join(' ')` to capture the full multi-word input after `nav`
- Replaced the simple first-letter capitalisation with a case-insensitive `Array.find()` match against `validPages` — `nav core team`, `nav Core Team`, and `nav CORE TEAM` all now resolve to `'Core Team'` correctly
- Added `'Core Team'` to `validPages` which was missing
- Updated the usage hint to include a multi-word example: `nav Core Team`
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1079

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings