### PR TITLE
fix: use validated payload instead of raw body in verification email

### DIFF
--- a/server/services/formsService.js
+++ b/server/services/formsService.js
@@ -92,8 +92,8 @@ export const formsService = {
 
       // Trigger standard welcome verification email
       try {
-        const verifyUrl = `${getPublicAppUrl()}/verify?email=${encodeURIComponent(body.collegeEmail)}`;
-        await sendWelcomeVerificationEmail(body.collegeEmail, body.fullName, verifyUrl);
+        const verifyUrl = `${getPublicAppUrl()}/verify?email=${encodeURIComponent(payload.collegeEmail)}`;
+        await sendWelcomeVerificationEmail(payload.collegeEmail, payload.fullName, verifyUrl);
       } catch (emailErr) {
         console.error('[Forms Service] Failed to send welcome verification email:', emailErr);
       }


### PR DESCRIPTION
## Description
Fixes #1050

In `handleForm`, the verification email URL and recipient details were 
being read from the raw `body` object instead of the validated `payload` 
returned by `normalizeFormSubmission()`. This meant sanitization applied 
by the validator (e.g. trimming whitespace) was bypassed for the email service.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings