### PR TITLE
feat: implement Redis Adapter for Socket.IO and query caching

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -210,6 +210,9 @@ function parseBearer(authHeader) {
  * Initialize Socket.IO
  * @param {Object} httpServer - HTTP server instance
  */
+import { createAdapter } from '@socket.io/redis-adapter';
+import { getRedisClient } from '../utils/redis.js';
+
 export function initializeSocketIO(httpServer) {
   io = new Server(httpServer, {
     cors: {
@@ -224,6 +227,10 @@ export function initializeSocketIO(httpServer) {
     pingInterval: 10000,
     transports: ['websocket', 'polling'],
   });
+
+  const pubClient = getRedisClient();
+  const subClient = pubClient.duplicate();
+  io.adapter(createAdapter(pubClient, subClient));
 
   // Connection auth middleware — checks handshake auth token
   io.use(async (socket, next) => {

--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -4,9 +4,11 @@
  */
 
 import { Server } from 'socket.io';
+import { createAdapter } from '@socket.io/redis-adapter';
 import logger from '../utils/logger.js';
 import { getAdminSession } from '../repositories/adminSessionsRepository.js';
 import { validationMiddleware } from '../sockets/validationMiddleware.js';
+import { getRedisClient } from '../utils/redis.js';
 
 let io = null;
 const connectedUsers = new Map();
@@ -210,10 +212,7 @@ function parseBearer(authHeader) {
  * Initialize Socket.IO
  * @param {Object} httpServer - HTTP server instance
  */
-import { createAdapter } from '@socket.io/redis-adapter';
-import { getRedisClient } from '../utils/redis.js';
-
-export function initializeSocketIO(httpServer) {
+export async function initializeSocketIO(httpServer) {
   io = new Server(httpServer, {
     cors: {
       origin: process.env.FRONTEND_URL || 'http://localhost:5173',
@@ -230,6 +229,8 @@ export function initializeSocketIO(httpServer) {
 
   const pubClient = getRedisClient();
   const subClient = pubClient.duplicate();
+  // Ensure both pub/sub clients are connected before wiring the adapter
+  await Promise.all([pubClient.connect?.(), subClient.connect?.()].filter(Boolean));
   io.adapter(createAdapter(pubClient, subClient));
 
   // Connection auth middleware — checks handshake auth token

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1057.0",
     "@sendgrid/mail": "^8.1.3",
+    "@socket.io/redis-adapter": "^8.3.0",
     "@sentry/node": "^7.84.0",
     "@sentry/profiling-node": "^7.84.0",
     "async-mutex": "^0.5.0",

--- a/server/utils/redis.js
+++ b/server/utils/redis.js
@@ -1,0 +1,79 @@
+import Redis from 'ioredis';
+import logger from './logger.js';
+
+let redisClient = null;
+
+export function getRedisClient() {
+  if (!redisClient) {
+    const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+    redisClient = new Redis(redisUrl);
+    
+    redisClient.on('error', (err) => {
+      logger.error('Redis connection error:', err);
+    });
+    
+    redisClient.on('connect', () => {
+      logger.info('Connected to Redis');
+    });
+  }
+  return redisClient;
+}
+
+export async function getCachedQuery(key, queryFn, ttlSeconds = 300) {
+  const client = getRedisClient();
+  
+  try {
+    const cached = await client.get(key);
+    if (cached) {
+      return JSON.parse(cached);
+    }
+    
+    const result = await queryFn();
+    
+    // Fire and forget caching
+    client.set(key, JSON.stringify(result), 'EX', ttlSeconds).catch(err => {
+      logger.error('Error setting Redis cache:', err);
+    });
+    
+    return result;
+  } catch (err) {
+    logger.warn('Redis cache error, falling back to database query:', err);
+    return await queryFn();
+  }
+}
+
+export function clearCache(keyPattern) {
+  const client = getRedisClient();
+  
+  return new Promise((resolve, reject) => {
+    const stream = client.scanStream({
+      match: keyPattern,
+      count: 100
+    });
+    
+    const keys = [];
+    
+    stream.on('data', (resultKeys) => {
+      for (let i = 0; i < resultKeys.length; i++) {
+        keys.push(resultKeys[i]);
+      }
+    });
+    
+    stream.on('end', async () => {
+      if (keys.length > 0) {
+        try {
+          await client.del(...keys);
+          resolve(keys.length);
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        resolve(0);
+      }
+    });
+    
+    stream.on('error', (err) => {
+      reject(err);
+    });
+  });
+}

--- a/server/utils/redis.js
+++ b/server/utils/redis.js
@@ -22,24 +22,30 @@ export function getRedisClient() {
 export async function getCachedQuery(key, queryFn, ttlSeconds = 300) {
   const client = getRedisClient();
   
+  // Try to read from cache first
+  let cached = null;
   try {
-    const cached = await client.get(key);
+    cached = await client.get(key);
     if (cached) {
       return JSON.parse(cached);
     }
-    
-    const result = await queryFn();
-    
-    // Fire and forget caching
+  } catch (err) {
+    logger.warn('Redis cache read error, falling back to database query:', err);
+  }
+  
+  // Cache miss or Redis error — run queryFn exactly once
+  const result = await queryFn();
+  
+  // Best-effort cache write
+  try {
     client.set(key, JSON.stringify(result), 'EX', ttlSeconds).catch(err => {
       logger.error('Error setting Redis cache:', err);
     });
-    
-    return result;
   } catch (err) {
-    logger.warn('Redis cache error, falling back to database query:', err);
-    return await queryFn();
+    logger.warn('Redis cache write error:', err);
   }
+  
+  return result;
 }
 
 export function clearCache(keyPattern) {
@@ -51,24 +57,25 @@ export function clearCache(keyPattern) {
       count: 100
     });
     
-    const keys = [];
+    let deletedCount = 0;
+    const deletePromises = [];
     
     stream.on('data', (resultKeys) => {
-      for (let i = 0; i < resultKeys.length; i++) {
-        keys.push(resultKeys[i]);
+      if (resultKeys.length > 0) {
+        // Delete in batches as they arrive to avoid unbounded memory usage
+        const promise = client.del(...resultKeys)
+          .then(count => { deletedCount += count; })
+          .catch(err => { logger.error('Error deleting cache keys batch:', err); });
+        deletePromises.push(promise);
       }
     });
     
     stream.on('end', async () => {
-      if (keys.length > 0) {
-        try {
-          await client.del(...keys);
-          resolve(keys.length);
-        } catch (err) {
-          reject(err);
-        }
-      } else {
-        resolve(0);
+      try {
+        await Promise.all(deletePromises);
+        resolve(deletedCount);
+      } catch (err) {
+        reject(err);
       }
     });
     


### PR DESCRIPTION
# Pull Request

## Description
This PR implements a Redis Adapter for Socket.IO and introduces query caching utilities, resolving Issue #1042.
- Sets up `ioredis` and `@socket.io/redis-adapter` in `server/config/socket.js` to allow Socket.IO to scale across multiple instances.
- Adds a `redis.js` utility in `server/utils` providing `getCachedQuery` and `clearCache` for easy query caching throughout the application.

Closes #1042

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
