### PR TITLE
Improve email verification and optimize Sheets client usage

### DIFF
--- a/server/services/formsService.js
+++ b/server/services/formsService.js
@@ -12,6 +12,19 @@ import { sendWelcomeVerificationEmail } from './emailService.js';
 import { broadcastSSEEvent } from './sseService.js';
 import { emitToRoom, getRoom } from '../config/socket.js';
 
+let _sheetsClient = null;
+
+function getSheetsClient() {
+  if (_sheetsClient) return _sheetsClient;
+  const auth = new google.auth.JWT({
+    email: requiredEnv('GOOGLE_SERVICE_ACCOUNT_EMAIL'),
+    key: normalizePrivateKey(requiredEnv('GOOGLE_PRIVATE_KEY')),
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+  _sheetsClient = google.sheets({ version: 'v4', auth });
+  return _sheetsClient;
+}
+
 function toSafeString(value, max = 4000) {
   return String(value ?? '')
     .trim()
@@ -41,9 +54,8 @@ export const formsService = {
   },
 
   async appendFormToSheet(formType, payload) {
-    const clientEmail = requiredEnv('GOOGLE_SERVICE_ACCOUNT_EMAIL');
-    const privateKey = normalizePrivateKey(requiredEnv('GOOGLE_PRIVATE_KEY'));
     const spreadsheetId = requiredEnv('GOOGLE_SHEET_ID');
+    const sheets = getSheetsClient();
 
     const defaultTab = process.env.GOOGLE_SHEET_TAB_NAME || 'Responses';
     const tabMap = {
@@ -52,14 +64,6 @@ export const formsService = {
       core_team: process.env.GOOGLE_CORE_TEAM_TAB_NAME || 'CoreTeamResponses',
     };
     const sheetName = tabMap[formType] || defaultTab;
-
-    const auth = new google.auth.JWT({
-      email: clientEmail,
-      key: privateKey,
-      scopes: ['https://www.googleapis.com/auth/spreadsheets'],
-    });
-
-    const sheets = google.sheets({ version: 'v4', auth });
 
     const now = new Date().toISOString();
     const row = [

--- a/server/services/formsService.js
+++ b/server/services/formsService.js
@@ -92,8 +92,8 @@ export const formsService = {
 
       // Trigger standard welcome verification email
       try {
-        const verifyUrl = `${getPublicAppUrl()}/verify?email=${encodeURIComponent(body.collegeEmail)}`;
-        await sendWelcomeVerificationEmail(body.collegeEmail, body.fullName, verifyUrl);
+        const verifyUrl = `${getPublicAppUrl()}/verify?email=${encodeURIComponent(payload.collegeEmail)}`;
+        await sendWelcomeVerificationEmail(payload.collegeEmail, payload.fullName, verifyUrl);
       } catch (emailErr) {
         console.error('[Forms Service] Failed to send welcome verification email:', emailErr);
       }

--- a/server/services/formsService.js
+++ b/server/services/formsService.js
@@ -91,6 +91,7 @@ export const formsService = {
       try {
         await this.appendFormToSheet(formType, payload);
       } catch (sheetErr) {
+        console.error('[Forms Service] Failed to append to Google Sheet:', sheetErr);
         if (!savedToSupabase) throw sheetErr;
       }
 


### PR DESCRIPTION
Fixes #1051

## Description
`handleForm` was silently swallowing `appendFormToSheet` failures whenever
the Supabase write succeeded. The catch block only re-threw `sheetErr`
if `savedToSupabase` was false — meaning Sheet errors were completely
invisible in logs when Supabase was healthy.

Fix: added `console.error` logging for all Sheet failures regardless
of Supabase outcome. The error is still only propagated to the caller
when both storage paths fail (no fallback available).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings