### PR TITLE
fix: replace Tailwind classes with inline styles on analytics page

### DIFF
--- a/website/src/components/analytics/ChartComponents.tsx
+++ b/website/src/components/analytics/ChartComponents.tsx
@@ -9,25 +9,87 @@ interface ChartWrapperProps {
   loading?: boolean;
 }
 
-export const ChartWrapper: React.FC<ChartWrapperProps> = ({ 
-  title, 
-  subtitle, 
-  children, 
+export const ChartWrapper: React.FC<ChartWrapperProps> = ({
+  title,
+  subtitle,
+  children,
   height = 300,
-  loading = false 
+  loading = false,
 }) => {
+  const [hovered, setHovered] = React.useState(false);
+
   return (
-    <div className="bg-[#111] border border-[#222] rounded-xl p-6 shadow-lg hover:shadow-xl transition-shadow flex flex-col h-full w-full">
-      <div className="mb-6">
-        <h3 className="text-xl font-bold text-white mb-1">{title}</h3>
-        {subtitle && <p className="text-sm text-gray-400">{subtitle}</p>}
+    <div
+      style={{
+        background: 'rgba(255,255,255,0.03)',
+        border: `1px solid ${hovered ? 'rgba(204,17,17,0.25)' : 'rgba(255,255,255,0.07)'}`,
+        borderRadius: '14px',
+        padding: '1.4rem 1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        width: '100%',
+        boxSizing: 'border-box',
+        transition: 'border-color 0.25s, transform 0.25s',
+        transform: hovered ? 'translateY(-2px)' : 'none',
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <div style={{ marginBottom: '1.25rem' }}>
+        <h3
+          style={{
+            fontFamily: "'Orbitron', sans-serif",
+            fontSize: '1rem',
+            fontWeight: 700,
+            color: '#fff',
+            letterSpacing: '0.05em',
+            margin: '0 0 0.25rem',
+          }}
+        >
+          {title}
+        </h3>
+        {subtitle && (
+          <p
+            style={{
+              fontFamily: "'Rajdhani', sans-serif",
+              fontSize: '0.78rem',
+              letterSpacing: '0.08em',
+              textTransform: 'uppercase',
+              color: 'rgba(255,255,255,0.35)',
+              margin: 0,
+            }}
+          >
+            {subtitle}
+          </p>
+        )}
       </div>
-      <div className="flex-1 w-full relative" style={{ minHeight: height }}>
-        {loading ? (
-          <div className="absolute inset-0 flex items-center justify-center bg-[#111] z-10 bg-opacity-80">
-            <div className="w-8 h-8 border-4 border-[#333] border-t-red-500 rounded-full animate-spin"></div>
+
+      <div style={{ width: '100%', position: 'relative', height: height }}>
+        {loading && (
+          <div
+            style={{
+              position: 'absolute',
+              inset: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'rgba(10,10,10,0.8)',
+              zIndex: 10,
+              borderRadius: '8px',
+            }}
+          >
+            <div
+              style={{
+                width: '28px',
+                height: '28px',
+                borderRadius: '50%',
+                border: '3px solid rgba(255,255,255,0.08)',
+                borderTop: '3px solid #CC1111',
+                animation: 'spin 0.7s linear infinite',
+              }}
+            />
           </div>
-        ) : null}
+        )}
         <ResponsiveContainer width="100%" height="100%">
           {children as React.ReactElement}
         </ResponsiveContainer>
@@ -39,13 +101,53 @@ export const ChartWrapper: React.FC<ChartWrapperProps> = ({
 export const CustomTooltip: React.FC<any> = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
     return (
-      <div className="bg-[#0a0a0a] border border-[#333] p-4 rounded-lg shadow-2xl">
-        <p className="text-gray-300 font-semibold mb-2 pb-2 border-b border-[#222]">{label}</p>
+      <div
+        style={{
+          background: '#0d0d0d',
+          border: '1px solid rgba(255,255,255,0.1)',
+          borderRadius: '10px',
+          padding: '0.75rem 1rem',
+          boxShadow: '0 8px 32px rgba(0,0,0,0.5)',
+          fontFamily: "'Rajdhani', sans-serif",
+        }}
+      >
+        <p
+          style={{
+            color: 'rgba(255,255,255,0.7)',
+            fontWeight: 600,
+            marginBottom: '0.5rem',
+            paddingBottom: '0.5rem',
+            borderBottom: '1px solid rgba(255,255,255,0.08)',
+            margin: '0 0 0.5rem',
+          }}
+        >
+          {label}
+        </p>
         {payload.map((entry: any, index: number) => (
-          <div key={`item-${index}`} className="flex items-center gap-2 mb-1">
-            <div className="w-3 h-3 rounded-full" style={{ backgroundColor: entry.color }} />
-            <span className="text-gray-400 text-sm">{entry.name}:</span>
-            <span className="text-white font-bold text-sm">{entry.value.toLocaleString()}</span>
+          <div
+            key={`item-${index}`}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '8px',
+              marginBottom: '4px',
+            }}
+          >
+            <div
+              style={{
+                width: '10px',
+                height: '10px',
+                borderRadius: '50%',
+                background: entry.color,
+                flexShrink: 0,
+              }}
+            />
+            <span style={{ color: 'rgba(255,255,255,0.45)', fontSize: '0.82rem' }}>
+              {entry.name}:
+            </span>
+            <span style={{ color: '#fff', fontWeight: 700, fontSize: '0.82rem' }}>
+              {entry.value.toLocaleString()}
+            </span>
           </div>
         ))}
       </div>

--- a/website/src/pages/analytics/AnalyticsPage.tsx
+++ b/website/src/pages/analytics/AnalyticsPage.tsx
@@ -7,18 +7,247 @@ import { ActivityComparisonChart } from '../../features/analytics/ActivityCompar
 import { formatNumber } from '../../utils/chartDataFormatters';
 import html2canvas from 'html2canvas';
 import jsPDF from 'jspdf';
-import { Download, Calendar, Filter, ChevronLeft } from 'lucide-react';
+import { Download, ChevronLeft } from 'lucide-react';
 
 interface AnalyticsPageProps {
   onBack?: () => void;
 }
 
+/* ── Shared style tokens (match site's CSS vars) ── */
+const S = {
+  page: {
+    minHeight: '100vh',
+    background: 'var(--bg, #0a0a0a)',
+    color: 'var(--t1, #fff)',
+    padding: '2rem 1.5rem',
+    fontFamily: "'Rajdhani', sans-serif",
+  } as React.CSSProperties,
+
+  inner: {
+    maxWidth: '1200px',
+    margin: '0 auto',
+  } as React.CSSProperties,
+
+  header: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    gap: '1rem',
+    marginBottom: '2rem',
+  } as React.CSSProperties,
+
+  backBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    background: 'none',
+    border: 'none',
+    color: 'rgba(255,255,255,0.45)',
+    cursor: 'pointer',
+    fontSize: '0.85rem',
+    padding: '0 0 0.5rem 0',
+    fontFamily: "'Rajdhani', sans-serif",
+    letterSpacing: '0.06em',
+    transition: 'color 0.2s',
+  } as React.CSSProperties,
+
+  title: {
+    fontFamily: "'Orbitron', sans-serif",
+    fontSize: 'clamp(1.5rem, 4vw, 2.2rem)',
+    fontWeight: 700,
+    color: '#fff',
+    margin: '0 0 0.3rem',
+    letterSpacing: '0.04em',
+    textShadow: '0 0 24px rgba(204,17,17,0.4)',
+  } as React.CSSProperties,
+
+  subtitle: {
+    color: 'rgba(255,255,255,0.4)',
+    fontSize: '0.85rem',
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    margin: 0,
+  } as React.CSSProperties,
+
+  offlineBadge: {
+    color: '#fbbf24',
+    fontSize: '0.75rem',
+    marginTop: '0.3rem',
+  } as React.CSSProperties,
+
+  controls: {
+    display: 'flex',
+    flexWrap: 'wrap' as const,
+    alignItems: 'center',
+    gap: '0.75rem',
+  } as React.CSSProperties,
+
+  toggleWrap: {
+    display: 'flex',
+    alignItems: 'center',
+    background: 'rgba(255,255,255,0.04)',
+    border: '1px solid rgba(255,255,255,0.08)',
+    borderRadius: '8px',
+    overflow: 'hidden',
+  } as React.CSSProperties,
+
+  toggleBtnBase: {
+    fontFamily: "'Rajdhani', sans-serif",
+    fontSize: '0.82rem',
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    padding: '0.4rem 1rem',
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    transition: 'background 0.2s, color 0.2s',
+  } as React.CSSProperties,
+
+  exportBtn: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '6px',
+    fontFamily: "'Rajdhani', sans-serif",
+    fontSize: '0.82rem',
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase' as const,
+    padding: '0.5rem 1.1rem',
+    background: 'linear-gradient(135deg, #CC1111, #880000)',
+    border: 'none',
+    borderRadius: '8px',
+    color: '#fff',
+    cursor: 'pointer',
+    boxShadow: '0 4px 16px rgba(204,17,17,0.35)',
+    transition: 'opacity 0.2s, box-shadow 0.2s',
+  } as React.CSSProperties,
+
+  grid4: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(220px, 1fr))',
+    gap: '1rem',
+    marginBottom: '1.25rem',
+  } as React.CSSProperties,
+
+  grid3: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+    gap: '1.25rem',
+    marginBottom: '1.25rem',
+  } as React.CSSProperties,
+
+  card: {
+    background: 'rgba(255,255,255,0.03)',
+    border: '1px solid rgba(255,255,255,0.07)',
+    borderRadius: '14px',
+    padding: '1.25rem 1.4rem',
+    position: 'relative' as const,
+    overflow: 'hidden',
+    transition: 'border-color 0.25s, transform 0.25s',
+  } as React.CSSProperties,
+
+  metricTitle: {
+    fontFamily: "'Rajdhani', sans-serif",
+    fontSize: '0.78rem',
+    letterSpacing: '0.1em',
+    textTransform: 'uppercase' as const,
+    color: 'rgba(255,255,255,0.4)',
+    marginBottom: '0.6rem',
+  } as React.CSSProperties,
+
+  metricRow: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+  } as React.CSSProperties,
+
+  metricValue: {
+    fontFamily: "'Orbitron', sans-serif",
+    fontSize: '1.9rem',
+    fontWeight: 700,
+    color: '#fff',
+    lineHeight: 1,
+  } as React.CSSProperties,
+
+  spinnerWrap: {
+    position: 'absolute' as const,
+    inset: 0,
+    background: 'rgba(10,10,10,0.85)',
+    zIndex: 10,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+  } as React.CSSProperties,
+
+  spinner: {
+    width: '20px',
+    height: '20px',
+    borderRadius: '50%',
+    border: '2px solid rgba(255,255,255,0.1)',
+    borderTop: '2px solid #CC1111',
+    animation: 'spin 0.7s linear infinite',
+  } as React.CSSProperties,
+};
+
+/* ── Metric card ── */
+const MetricBadge: React.FC<{
+  title: string;
+  value: string;
+  trend?: number;
+  loading?: boolean;
+}> = ({ title, value, trend, loading }) => {
+  const [hovered, setHovered] = React.useState(false);
+
+  return (
+    <div
+      style={{
+        ...S.card,
+        borderColor: hovered ? 'rgba(204,17,17,0.3)' : 'rgba(255,255,255,0.07)',
+        transform: hovered ? 'translateY(-2px)' : 'none',
+      }}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      {loading && (
+        <div style={S.spinnerWrap}>
+          <div style={S.spinner} />
+        </div>
+      )}
+      <p style={S.metricTitle}>{title}</p>
+      <div style={S.metricRow}>
+        <span style={S.metricValue}>{value}</span>
+        {trend !== undefined && (
+          <span
+            style={{
+              fontSize: '0.82rem',
+              fontWeight: 700,
+              fontFamily: "'Space Mono', monospace",
+              padding: '0.2rem 0.5rem',
+              borderRadius: '20px',
+              background: trend >= 0 ? 'rgba(74,222,128,0.12)' : 'rgba(204,17,17,0.12)',
+              color: trend >= 0 ? '#4ade80' : '#f87171',
+              border: `1px solid ${trend >= 0 ? 'rgba(74,222,128,0.25)' : 'rgba(204,17,17,0.25)'}`,
+            }}
+          >
+            {trend >= 0 ? '+' : ''}
+            {trend}%
+          </span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+/* ── Dashboard content ── */
 const AnalyticsDashboardContent: React.FC<AnalyticsPageProps> = ({ onBack }) => {
   const { filters, updateFilter } = useAnalyticsFilters();
   const { loading, isOffline, trendData, distributionData, comparisonData, overviewMetrics } =
     useAnalyticsData();
   const dashboardRef = useRef<HTMLDivElement>(null);
   const [exporting, setExporting] = React.useState(false);
+  const [exportHover, setExportHover] = React.useState(false);
 
   const handleExport = async () => {
     if (!dashboardRef.current) return;
@@ -33,7 +262,6 @@ const AnalyticsDashboardContent: React.FC<AnalyticsPageProps> = ({ onBack }) => 
       const pdf = new jsPDF('p', 'mm', 'a4');
       const pdfWidth = pdf.internal.pageSize.getWidth();
       const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
-
       pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
       pdf.save(`NexaSphere_Analytics_${new Date().toISOString().split('T')[0]}.pdf`);
     } catch (err) {
@@ -43,65 +271,76 @@ const AnalyticsDashboardContent: React.FC<AnalyticsPageProps> = ({ onBack }) => 
     }
   };
 
+  const granularity = filters.timeGranularity;
+
   return (
-    <div className="min-h-screen bg-[#0a0a0a] text-white p-4 md:p-8 font-sans">
-      <div className="max-w-7xl mx-auto">
-        <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-8 gap-4">
+    <div style={S.page}>
+      <div style={S.inner}>
+        {/* ── Header ── */}
+        <div style={S.header}>
           <div>
             {onBack && (
               <button
                 onClick={onBack}
-                className="flex items-center gap-2 text-gray-400 hover:text-white transition-colors mb-2"
+                style={S.backBtn}
+                onMouseEnter={(e) => (e.currentTarget.style.color = '#fff')}
+                onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(255,255,255,0.45)')}
               >
-                <ChevronLeft size={16} /> Back
+                <ChevronLeft size={15} /> Back
               </button>
             )}
-            <h1 className="text-3xl md:text-4xl font-bold bg-gradient-to-r from-white to-gray-400 bg-clip-text text-transparent">
-              Platform Intelligence
-            </h1>
-            <p className="text-gray-400 mt-1">Real-time analytics and platform metrics</p>
+            <h1 style={S.title}>Platform Intelligence</h1>
+            <p style={S.subtitle}>Real-time analytics and platform metrics</p>
             {isOffline && (
-              <p className="text-yellow-500 text-xs mt-1">
-                ⚠ Demo mode — API unavailable. Showing generated data.
-              </p>
+              <p style={S.offlineBadge}>⚠ Demo mode — API unavailable. Showing generated data.</p>
             )}
           </div>
 
-          <div className="flex flex-wrap items-center gap-3">
-            <div className="flex items-center gap-2 bg-[#111] border border-[#333] rounded-lg p-1">
-              <button
-                onClick={() => updateFilter('timeGranularity', 'daily')}
-                className={`px-3 py-1.5 text-sm rounded-md transition-colors ${filters.timeGranularity === 'daily' ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-gray-200'}`}
-              >
-                Daily
-              </button>
-              <button
-                onClick={() => updateFilter('timeGranularity', 'weekly')}
-                className={`px-3 py-1.5 text-sm rounded-md transition-colors ${filters.timeGranularity === 'weekly' ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-gray-200'}`}
-              >
-                Weekly
-              </button>
-              <button
-                onClick={() => updateFilter('timeGranularity', 'monthly')}
-                className={`px-3 py-1.5 text-sm rounded-md transition-colors ${filters.timeGranularity === 'monthly' ? 'bg-[#333] text-white' : 'text-gray-400 hover:text-gray-200'}`}
-              >
-                Monthly
-              </button>
+          <div style={S.controls}>
+            {/* Period toggle */}
+            <div style={S.toggleWrap}>
+              {(['daily', 'weekly', 'monthly'] as const).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => updateFilter('timeGranularity', p)}
+                  style={{
+                    ...S.toggleBtnBase,
+                    background: granularity === p ? 'rgba(204,17,17,0.85)' : 'transparent',
+                    color: granularity === p ? '#fff' : 'rgba(255,255,255,0.4)',
+                  }}
+                >
+                  {p.charAt(0).toUpperCase() + p.slice(1)}
+                </button>
+              ))}
             </div>
+
+            {/* Export button */}
             <button
               onClick={handleExport}
               disabled={exporting || loading}
-              className="flex items-center gap-2 bg-gradient-to-r from-blue-600 to-indigo-600 hover:from-blue-500 hover:to-indigo-500 text-white px-4 py-2.5 rounded-lg font-medium transition-all disabled:opacity-50"
+              style={{
+                ...S.exportBtn,
+                opacity: exporting || loading ? 0.5 : 1,
+                boxShadow: exportHover
+                  ? '0 6px 24px rgba(204,17,17,0.55)'
+                  : '0 4px 16px rgba(204,17,17,0.35)',
+              }}
+              onMouseEnter={() => setExportHover(true)}
+              onMouseLeave={() => setExportHover(false)}
             >
-              <Download size={18} />
+              <Download size={15} />
               {exporting ? 'Exporting...' : 'Export Report'}
             </button>
           </div>
         </div>
 
-        <div ref={dashboardRef} className="flex flex-col gap-6">
-          {/* Overview Metrics */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {/* ── Dashboard ── */}
+        <div
+          ref={dashboardRef}
+          style={{ display: 'flex', flexDirection: 'column', gap: '1.25rem' }}
+        >
+          {/* Metric cards */}
+          <div style={S.grid4}>
             <MetricBadge
               title="Total Users"
               value={formatNumber(overviewMetrics.totalUsers)}
@@ -125,49 +364,23 @@ const AnalyticsDashboardContent: React.FC<AnalyticsPageProps> = ({ onBack }) => 
             />
           </div>
 
-          {/* Main Charts */}
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            <div className="lg:col-span-2">
+          {/* Trend + Distribution */}
+          <div style={S.grid3}>
+            <div style={{ gridColumn: 'span 2' }}>
               <TrendChart data={trendData} loading={loading} />
             </div>
-            <div className="lg:col-span-1">
+            <div>
               <DistributionChart data={distributionData} loading={loading} />
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-6">
-            <ActivityComparisonChart data={comparisonData} loading={loading} />
-          </div>
+          {/* Activity comparison */}
+          <ActivityComparisonChart data={comparisonData} loading={loading} />
         </div>
       </div>
     </div>
   );
 };
-
-const MetricBadge: React.FC<{
-  title: string;
-  value: string;
-  trend?: number;
-  loading?: boolean;
-}> = ({ title, value, trend, loading }) => (
-  <div className="bg-[#111] border border-[#222] rounded-xl p-5 shadow-sm relative overflow-hidden">
-    {loading && (
-      <div className="absolute inset-0 bg-[#111] z-10 flex items-center justify-center">
-        <div className="w-5 h-5 border-2 border-[#333] border-t-blue-500 rounded-full animate-spin"></div>
-      </div>
-    )}
-    <h4 className="text-gray-400 text-sm font-medium mb-2">{title}</h4>
-    <div className="flex items-end justify-between">
-      <span className="text-3xl font-bold text-white">{value}</span>
-      {trend !== undefined && (
-        <span className={`text-sm font-medium ${trend >= 0 ? 'text-green-500' : 'text-red-500'}`}>
-          {trend >= 0 ? '+' : ''}
-          {trend}%
-        </span>
-      )}
-    </div>
-  </div>
-);
 
 export default function AnalyticsPage(props: AnalyticsPageProps) {
   return (


### PR DESCRIPTION
## Description

The /analytics (Platform Intelligence) page was rendering all metrics as raw, unstyled plain text with no layout structure. The root cause was that AnalyticsPage.tsx and ChartComponents.tsx were using Tailwind CSS utility classes, but Tailwind is not installed or configured in this project — so none of the styles were being applied.

fix: Replaced all Tailwind className props with inline React styles using the project's existing CSS variables (var(--bg), var(--t1)) and font families (Orbitron, Rajdhani, Space Mono) already loaded globally. No new dependencies added.

### Files changed:
website/src/pages/analytics/AnalyticsPage.tsx
website/src/components/analytics/ChartComponents.tsx

Fixes #1063

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings


### screenshot after change :- 

<img width="1680" height="976" alt="Screenshot 2026-06-04 at 11 56 52 AM" src="https://github.com/user-attachments/assets/a663b069-8862-4b6a-bf4a-06169393bde7" />

<img width="1680" height="976" alt="Screenshot 2026-06-04 at 11 57 15 AM" src="https://github.com/user-attachments/assets/9744d009-7b29-4d4d-8c4b-e7f15af7d1dd" />
