### PR TITLE
fix(server): prevent connection leaks and hanging process in backend …

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -643,19 +643,21 @@ process.on('uncaughtException', (err) => {
 const port = Number(process.env.PORT || 8787);
 let server;
 
-if (!process.env.VERCEL) {
-  const boot = HAS_SUPABASE ? Promise.resolve() : ensureContentFile();
-  boot.then(() => {
+if (process.env.NODE_ENV !== 'test') {
+  if (!process.env.VERCEL) {
+    const boot = HAS_SUPABASE ? Promise.resolve() : ensureContentFile();
+    boot.then(() => {
+      server = app.listen(port, () => {
+        console.log(`NexaSphere server listening on http://localhost:${port}`);
+      });
+      initializeSocketIO(server);
+    });
+  } else {
     server = app.listen(port, () => {
       console.log(`NexaSphere server listening on http://localhost:${port}`);
     });
     initializeSocketIO(server);
-  });
-} else {
-  server = app.listen(port, () => {
-    console.log(`NexaSphere server listening on http://localhost:${port}`);
-  });
-  initializeSocketIO(server);
+  }
 }
 
 export default app;

--- a/server/test/notificationSubscription.test.js
+++ b/server/test/notificationSubscription.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import http from 'node:http';
 
+process.env.NODE_ENV = 'test';
 process.env.ADMIN_USERNAME = 'admin';
 process.env.ADMIN_PASSWORD = 'StrongPassword123!';
 process.env.ADMIN_EVENT_PASSWORD = 'StrongEventPassword123!';

--- a/server/test/portfolioAuth.test.js
+++ b/server/test/portfolioAuth.test.js
@@ -1,3 +1,4 @@
+process.env.NODE_ENV = 'test';
 process.env.ADMIN_USERNAME = 'admin';
 process.env.ADMIN_PASSWORD = 'StrongPassword123!';
 process.env.ADMIN_EVENT_PASSWORD = 'StrongEventPassword123!';


### PR DESCRIPTION

## Description
Restricts 
index.js
 from booting the HTTP server and Socket.IO connection pool during testing, allowing test suites to spin up their own servers and terminate cleanly without hanging the test execution.

Fixes #1173

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
