### PR TITLE
fix(website): await rejected expectation in eventsService test

### DIFF
--- a/website/src/__tests__/eventsService.integration.test.ts
+++ b/website/src/__tests__/eventsService.integration.test.ts
@@ -52,6 +52,6 @@ describe('Events Service (Backend Integration)', () => {
 
   it('should handle errors gracefully', async () => {
     mockEventsService.getAll.mockRejectedValue(new Error('Database error'));
-    expect(() => mockEventsService.getAll()).rejects.toThrow('Database error');
+    await expect(mockEventsService.getAll()).rejects.toThrow('Database error');
   });
 });


### PR DESCRIPTION
## Description
Fixes a Vitest warning by correctly awaiting the promise rejection check (await expect(mockEventsService.getAll()).rejects.toThrow()).

Fixes #1172

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
