### PR TITLE
fix(website): await rejected expectation in coreTeamService test

### DIFF
--- a/website/src/__tests__/coreTeamService.integration.test.ts
+++ b/website/src/__tests__/coreTeamService.integration.test.ts
@@ -50,8 +50,12 @@ describe('Core Team Service', () => {
   });
 
   it('should handle validation errors for invalid members', async () => {
-    mockCoreTeamService.addMember.mockRejectedValue(new Error('Invalid member data'));
-    expect(() => mockCoreTeamService.addMember({})).rejects.toThrow('Invalid member data');
+    mockCoreTeamService.addMember.mockRejectedValue(
+      new Error('Invalid member data')
+    );
+    await expect(mockCoreTeamService.addMember({})).rejects.toThrow(
+      'Invalid member data'
+    );
   });
 
   it('should filter members by role', async () => {


### PR DESCRIPTION
## Description
Fixes a Vitest warning by correctly awaiting the promise rejection check (await expect(mockCoreTeamService.addMember({})).rejects.toThrow()).

Fixes #1168

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
