### PR TITLE
fix: replace unconditional 4s polling with visibilitychange in TeamSection

### DIFF
--- a/website/src/pages/team/TeamSection.jsx
+++ b/website/src/pages/team/TeamSection.jsx
@@ -127,7 +127,17 @@ export default function TeamSection({ onApply }) {
     };
 
     fetchTeam();
-    const interval = setInterval(fetchTeam, 4000);
+
+    // Replace unconditional 4s polling with a visibilitychange listener —
+    // refetch only when the user returns to the tab instead of hammering
+    // the API every 4 seconds regardless of tab visibility or user activity.
+    // The socket listener below already handles real-time admin updates.
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        fetchTeam();
+      }
+    };
+    document.addEventListener('visibilitychange', handleVisibilityChange);
 
     // Socket: refetch immediately when admin updates team
     const onContentUpdated = (data) => {
@@ -139,7 +149,7 @@ export default function TeamSection({ onApply }) {
 
     return () => {
       alive = false;
-      clearInterval(interval);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
       off('content:updated', onContentUpdated);
     };
   }, []);


### PR DESCRIPTION
## Description
`TeamSection.jsx` polled the team API every 4 seconds unconditionally via `setInterval`:

```js
fetchTeam();
const interval = setInterval(fetchTeam, 4000);
```

This fired a network request every 4 seconds regardless of whether the user was actively viewing the page, whether the tab was visible, or whether the data had changed. On a page with multiple visitors this generated a continuous stream of API requests even when users had switched to another tab or minimised the browser.

The component already had a socket listener (`on('content:updated', onContentUpdated)`) that triggers an immediate refetch when the admin updates team data — making the polling interval redundant in environments where the socket is connected.

Changes made:
- Removed `setInterval(fetchTeam, 4000)` and `clearInterval` from cleanup
- Added a `visibilitychange` listener that calls `fetchTeam()` only when `document.visibilityState === 'visible'` — data is refreshed when the user returns to the tab rather than on a blind 4-second cadence
- The socket `content:updated` listener is preserved for real-time admin-triggered updates
- Added a comment explaining the rationale for the replacement
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1193

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings