### PR TITLE
fix: replace local getApiBase with runtimeConfig import in UserDashboard.tsx

### DIFF
--- a/website/src/pages/dashboard/UserDashboard.tsx
+++ b/website/src/pages/dashboard/UserDashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getApiBase } from '../../utils/runtimeConfig';
 import {
   Calendar,
   Award,
@@ -105,7 +106,7 @@ const MOCK_METRICS = {
   longestStreak: 12,
 };
 
-const getApiBase = () => ((import.meta as any).env?.VITE_API_BASE || '').replace(/\/+$/, '');
+// getApiBase imported from runtimeConfig — avoids as any cast and duplicated URL logic
 
 export default function UserDashboard() {
   // Anonymous user ID — in a real auth system this would come from a user context


### PR DESCRIPTION
## Description
`UserDashboard.tsx` defined its own `getApiBase` function at module level using an `as any` cast to access `import.meta.env`:

```ts
const getApiBase = () => ((import.meta as any).env?.VITE_API_BASE || '').replace(/\/+$/, '');
```

This had two problems:
1. The `as any` cast bypasses TypeScript's `import.meta` typing — exactly the pattern `runtimeConfig.js` was created to avoid across the codebase
2. The logic is duplicated — `runtimeConfig.js` already exports `getApiBase()` with the same URL resolution. If the logic ever changes in `runtimeConfig.js` (e.g. adding `VITE_API_URL` fallback or changing normalisation), `UserDashboard.tsx` would silently diverge

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Removed the local `getApiBase` definition and its `as any` cast
- Added a comment at the removed line explaining the import replaces it
- `getApiBase()` call site at line 131 is unchanged — no functional change
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1194

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings