### PR TITLE
fix(server): ensure schema is created when database recovers after of…

### DIFF
--- a/server/repositories/adminSessionsRepository.js
+++ b/server/repositories/adminSessionsRepository.js
@@ -80,6 +80,9 @@ async function ensureReady() {
   if (!schemaReady) {
     schemaReady = withDb(async (client) => {
       await ensureSchema(client);
+    }).catch((err) => {
+      schemaReady = null;
+      throw err;
     });
   }
 

--- a/server/repositories/portfolioRepository.js
+++ b/server/repositories/portfolioRepository.js
@@ -12,7 +12,7 @@ const portfolioMutex = new Mutex();
 
 const BCRYPT_ROUNDS = 12;
 
-let schemaAttempted = false;
+let schemaReady = null;
 let schemaOk = false;
 let lastDbFailTime = 0;
 const DB_RETRY_TTL = 15000;
@@ -107,35 +107,37 @@ async function ensureSchema(client) {
 async function ensureReady() {
   if (schemaOk) return true;
 
-  if (!schemaAttempted) {
-    schemaAttempted = true;
+  if (schemaReady) {
     try {
-      await withDb(async (client) => {
-        await ensureSchema(client);
-      });
-      schemaOk = true;
-      return true;
-    } catch (err) {
-      console.warn('PostgreSQL not available:', err.message);
-      lastDbFailTime = Date.now();
-      return false;
-    }
-  }
-
-  if (Date.now() - lastDbFailTime > DB_RETRY_TTL) {
-    try {
-      await withDb(async (client) => {
-        await client.query('SELECT 1');
-      });
-      schemaOk = true;
+      await schemaReady;
       return true;
     } catch {
-      lastDbFailTime = Date.now();
       return false;
     }
   }
 
-  return false;
+  const now = Date.now();
+  if (now - lastDbFailTime < DB_RETRY_TTL) {
+    return false;
+  }
+
+  schemaReady = withDb(async (client) => {
+    await ensureSchema(client);
+  }).then(() => {
+    schemaOk = true;
+  }).catch((err) => {
+    schemaReady = null;
+    lastDbFailTime = Date.now();
+    throw err;
+  });
+
+  try {
+    await schemaReady;
+    return true;
+  } catch (err) {
+    console.warn('PostgreSQL not available:', err.message);
+    return false;
+  }
 }
 
 // Local File Store Helpers

--- a/server/test/adminSessions.test.js
+++ b/server/test/adminSessions.test.js
@@ -225,6 +225,49 @@ test('Failed database updates during throttled touches are caught and do not blo
   }
 });
 
+test('adminSessionsRepository recovers from database boot failure on subsequent requests', async () => {
+  let dbOnline = false;
+  let schemaQueriesRun = 0;
+
+  // Intercept connect
+  const connectBackup = pg.Pool.prototype.connect;
+  pg.Pool.prototype.connect = async () => {
+    if (!dbOnline) {
+      throw new Error('Database is offline');
+    }
+    return {
+      query: async (sql, params) => {
+        const sqlLower = sql.toLowerCase();
+        if (sqlLower.includes('create table') || sqlLower.includes('create index')) {
+          schemaQueriesRun++;
+        }
+        return { rows: [], rowCount: 1 };
+      },
+      release: () => {},
+    };
+  };
+
+  try {
+    // Import a fresh copy of the repository to ensure schemaReady is null
+    const freshRepositoryUrl = '../repositories/adminSessionsRepository.js?bust=' + Date.now();
+    const { createAdminSession: freshCreateAdminSession } = await import(freshRepositoryUrl);
+
+    // 1. Database is offline: session creation should fail
+    await assert.rejects(async () => {
+      await freshCreateAdminSession({ username: 'admin' });
+    }, /Database is offline/);
+
+    // 2. Database comes online: session creation should succeed and run schema queries
+    dbOnline = true;
+    const session = await freshCreateAdminSession({ username: 'admin' });
+    assert.ok(session.token);
+    assert.ok(schemaQueriesRun > 0, 'Schema initialization should run upon database recovery');
+
+  } finally {
+    pg.Pool.prototype.connect = connectBackup;
+  }
+});
+
 // Helper: Calculate SHA-256 hash of mock token to match queries parameter
 import crypto from 'crypto';
 function insertQueryParamHash(token) {

--- a/server/test/portfolioRepository.test.js
+++ b/server/test/portfolioRepository.test.js
@@ -49,3 +49,60 @@ test('ensureSchema repairs case-variant duplicates before adding unique lower(us
     'duplicates are repaired before the unique index is created'
   );
 });
+
+test('database recovery triggers schema creation and succeeds', async () => {
+  const originalDateNow = Date.now;
+  let currentTime = 100000;
+  Date.now = () => currentTime;
+
+  let dbOnline = false;
+  let queries = [];
+
+  const { setWithDbOverride } = await import('../repositories/db.js');
+  const { portfolioRepository } = await import('../repositories/portfolioRepository.js');
+
+  setWithDbOverride(async (fn) => {
+    if (!dbOnline) {
+      throw new Error('Database connection failed');
+    }
+    const mockClient = {
+      async query(sql, params) {
+        queries.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+        return { rows: [] };
+      }
+    };
+    return await fn(mockClient);
+  });
+
+  try {
+    // 1. Initial attempt with database offline
+    await portfolioRepository.getByUsername('alice');
+    
+    // Check that no queries were executed because database was offline
+    assert.equal(queries.length, 0);
+
+    // 2. Database comes online, but TTL (15s) has not elapsed yet
+    dbOnline = true;
+    currentTime += 5000; // only 5s passed
+    await portfolioRepository.getByUsername('alice');
+    
+    // Still shouldn't execute queries because of TTL cache
+    assert.equal(queries.length, 0);
+
+    // 3. TTL elapses (15s elapsed)
+    currentTime += 11000; // total 16s passed since last failure
+    await portfolioRepository.getByUsername('alice');
+
+    // Now it should retry, which means running ensureSchema AND then the SELECT query!
+    const schemaCreated = queries.some(q => q.sql.includes('CREATE TABLE IF NOT EXISTS portfolios'));
+    assert.ok(schemaCreated, 'ensureSchema should be run upon database recovery');
+
+    const selectQuery = queries.some(q => q.sql.includes('SELECT * FROM portfolios'));
+    assert.ok(selectQuery, 'SELECT * query should be run after database recovery');
+
+  } finally {
+    // Restore mocks
+    Date.now = originalDateNow;
+    setWithDbOverride(null);
+  }
+});


### PR DESCRIPTION
## Description
This Pull Request resolves the issue where the PostgreSQL database schema is never created if the database is offline/unavailable when the server starts up (e.g., during Docker Compose initialization).

Specifically, it addresses two main issues:
1. **`portfolioRepository.js`**: If the database was offline at startup, the schema creation failed, but the retry mechanism (which ran after 15 seconds) was only executing `SELECT 1` instead of running `ensureSchema`. If `SELECT 1` succeeded, the connection was marked as ready (`schemaOk = true`) without executing the table migrations, causing subsequent queries to crash. The retry block now correctly executes `ensureSchema(client)`. We also refactored the initialization sequence using a promise-based queue pattern to prevent concurrent incoming requests from initiating duplicate schema queries.
2. **`adminSessionsRepository.js`**: The `schemaReady` initialization promise was stored on boot. If the database was offline, the promise was rejected and subsequent requests kept returning the same rejected promise without retrying. The initialization promise now resets to `null` on failure, allowing subsequent requests to retry and successfully initialize the schema once the database is online.

Fixes #1159

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
