### PR TITLE
fix(monitoring): stop leaking NODE_ENV and uptime from health probe

### DIFF
--- a/server/routes/monitoring.js
+++ b/server/routes/monitoring.js
@@ -32,14 +32,16 @@ function requireMonitoringAuth(req, res, next) {
 
 /**
  * GET /api/monitoring/health
- * Health check endpoint — no auth required
+ * Public liveness probe with no auth required.
+ * Returns only liveness status and a timestamp. Operational details such as
+ * process uptime and NODE_ENV are deliberately omitted so unauthenticated
+ * callers cannot fingerprint the environment or infer deployment timing. The
+ * authenticated /metrics endpoint remains the source for detailed telemetry.
  */
 router.get('/health', (req, res) => {
   res.status(200).json({
     status: 'healthy',
     timestamp: new Date(),
-    uptime: process.uptime(),
-    environment: process.env.NODE_ENV,
   });
 });
 


### PR DESCRIPTION
## Description

The public `GET /api/monitoring/health` endpoint returned `process.uptime()` and `process.env.NODE_ENV` to unauthenticated callers. This allowed anyone to confirm whether the server runs in `production` or `development`, infer the time of the last deploy from the uptime value, and decide which error detail level and environment-guarded endpoints to expect.

This change reduces the public response to `status` and `timestamp` only, which is all a liveness probe needs for load balancers and uptime monitors. Detailed telemetry such as uptime and environment remains available through the authenticated `/api/monitoring/metrics` endpoint, which is unchanged.

## Related Issue

Closes #1120

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

Not applicable. This is a server-side response change with no UI surface.

Before:
```json
{ "status": "healthy", "timestamp": "...", "uptime": 38211.4, "environment": "production" }
```

After:
```json
{ "status": "healthy", "timestamp": "..." }
```
