### PR TITLE
fix(errors): only Slack-alert on 5xx and strip query string from alert

### DIFF
--- a/server/middleware/errorHandler.js
+++ b/server/middleware/errorHandler.js
@@ -46,12 +46,19 @@ const errorHandler = (err, req, res, next) => {
     extra: { errorLog },
   });
 
-  // Send Slack alert for critical errors
-  if (status >= 500 || (status === 401 && !resolveUserId(req))) {
+  // Send Slack alert for server-side incidents only.
+  // 401 responses are expected client behavior (bots, scanners, health checks,
+  // and users acting before login) and previously fired an alert for every
+  // unauthenticated request, flooding the channel and masking real incidents.
+  // Restricting alerts to status >= 500 keeps the signal limited to genuine
+  // server faults. The query string is stripped from the alerted URL so any
+  // sensitive query parameter values are not forwarded to Slack.
+  if (status >= 500) {
+    const pathOnly = req.originalUrl.split('?')[0];
     sendSlackAlert({
       title: `🚨 ${status} Error Detected`,
       message,
-      url: req.originalUrl,
+      url: pathOnly,
       method: req.method,
       userId: resolveUserId(req),
       timestamp: errorLog.timestamp,


### PR DESCRIPTION
## Description

The global error handler in `server/middleware/errorHandler.js` sent a Slack alert for every unauthenticated 401 response, via the condition `status === 401 && !resolveUserId(req)`. A 401 is expected client behavior produced by bots, scanners, misconfigured health checks, and any user acting before login. As a result a single caller could flood the Slack channel with one alert per request, drowning out real 500 incidents and training the operations team to mute the channel.

This change restricts Slack alerts to `status >= 500`, which represents genuine server faults worth paging on. It also strips the query string from the alerted URL so sensitive query parameter values (for example admin filters) are not forwarded into Slack. Logging and Sentry capture are unchanged, so 401s are still recorded for audit, they simply no longer page Slack.

## Related Issue

Closes #1121

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Chore or maintenance

## Checklist

- [x] I have tested these changes locally.
- [x] I have run the relevant lint, build, or test commands.
- [x] I have linked the related issue.
- [x] My changes follow the existing project style.

## Screenshots

Not applicable. This is a server-side alerting change with no UI surface.
