### PR TITLE
fix(#1119): Persist web push subscriptions to database

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,7 @@ import {
 import { portfolioRepository } from './repositories/portfolioRepository.js';
 import { portfolioContentSchema, portfolioPutSchema } from './validators/portfolioSchemas.js';
 import { searchController } from './controllers/searchController.js';
+import { pushSubscriptionsRepository } from './repositories/pushSubscriptionsRepository.js';
 import { getPublicAppUrl } from './utils/publicAppUrl.js';
 import * as eventsController from './controllers/eventsController.js';
 import * as activityEventsController from './controllers/activityEventsController.js';
@@ -316,8 +317,48 @@ app.get('/api/admin/me', adminAuth, (req, res) => {
   return res.json({ username: req.adminSession.username });
 });
 
-// Real-time Push Subscriber channels
+// Real-time Push Subscriber channels.
+// The in-memory Set is a fast local mirror. When a PostgreSQL database is
+// configured (DATABASE_URL present), subscriptions are also persisted to the
+// push_subscriptions table so they survive server restarts, deploys, and
+// crashes. When no database is configured the store degrades to memory-only,
+// preserving the previous behavior for local development.
 const pushSubscriptions = new Set();
+
+const PUSH_PERSISTENCE_ENABLED = Boolean(process.env.DATABASE_URL);
+
+// Load any previously persisted subscriptions into the in-memory mirror at
+// startup so a restart does not silently drop registered subscribers.
+async function loadPersistedPushSubscriptions() {
+  if (!PUSH_PERSISTENCE_ENABLED) return;
+  try {
+    const rows = await pushSubscriptionsRepository.list({ limit: 10000 });
+    for (const sub of rows) {
+      pushSubscriptions.add(JSON.stringify(sub));
+    }
+    console.log(`Loaded ${rows.length} persisted push subscription(s).`);
+  } catch (err) {
+    console.error('Failed to load persisted push subscriptions:', err.message);
+  }
+}
+
+async function persistPushSubscription(subscription) {
+  if (!PUSH_PERSISTENCE_ENABLED) return;
+  try {
+    await pushSubscriptionsRepository.add(subscription);
+  } catch (err) {
+    console.error('Failed to persist push subscription:', err.message);
+  }
+}
+
+async function removePersistedPushSubscription(subscription) {
+  if (!PUSH_PERSISTENCE_ENABLED) return;
+  try {
+    await pushSubscriptionsRepository.remove(subscription.endpoint);
+  } catch (err) {
+    console.error('Failed to remove persisted push subscription:', err.message);
+  }
+}
 
 const validatePushSubscription = [
   body('subscription').isObject().withMessage('subscription must be an object'),
@@ -353,7 +394,7 @@ const validatePushSubscription = [
   },
 ];
 
-app.post('/api/notifications/subscribe', validatePushSubscription, (req, res) => {
+app.post('/api/notifications/subscribe', validatePushSubscription, async (req, res) => {
   try {
     const { subscription } = req.body;
     if (subscription) {
@@ -362,6 +403,7 @@ app.post('/api/notifications/subscribe', validatePushSubscription, (req, res) =>
         const oldest = pushSubscriptions.values().next().value;
         pushSubscriptions.delete(oldest);
       }
+      await persistPushSubscription(subscription);
     }
     return res.json({ success: true });
   } catch (err) {
@@ -369,10 +411,13 @@ app.post('/api/notifications/subscribe', validatePushSubscription, (req, res) =>
   }
 });
 
-app.post('/api/notifications/unsubscribe', validatePushSubscription, (req, res) => {
+app.post('/api/notifications/unsubscribe', validatePushSubscription, async (req, res) => {
   try {
     const { subscription } = req.body;
-    if (subscription) pushSubscriptions.delete(JSON.stringify(subscription));
+    if (subscription) {
+      pushSubscriptions.delete(JSON.stringify(subscription));
+      await removePersistedPushSubscription(subscription);
+    }
     return res.json({ success: true });
   } catch (err) {
     return res.status(500).json({ error: err.message });
@@ -673,13 +718,16 @@ let server;
 if (process.env.NODE_ENV !== 'test') {
   if (!process.env.VERCEL) {
     const boot = HAS_SUPABASE ? Promise.resolve() : ensureContentFile();
-    boot.then(() => {
-      server = app.listen(port, () => {
-        console.log(`NexaSphere server listening on http://localhost:${port}`);
+    boot
+      .then(() => loadPersistedPushSubscriptions())
+      .then(() => {
+        server = app.listen(port, () => {
+          console.log(`NexaSphere server listening on http://localhost:${port}`);
+        });
+        initializeSocketIO(server);
       });
-      initializeSocketIO(server);
-    });
   } else {
+    loadPersistedPushSubscriptions();
     server = app.listen(port, () => {
       console.log(`NexaSphere server listening on http://localhost:${port}`);
     });

--- a/server/repositories/pushSubscriptionsRepository.js
+++ b/server/repositories/pushSubscriptionsRepository.js
@@ -1,0 +1,48 @@
+import { withDb } from './db.js';
+
+function mapRow(row) {
+  return {
+    endpoint: row.endpoint,
+    keys: {
+      p256dh: row.p256dh,
+      auth: row.auth,
+    },
+  };
+}
+
+export const pushSubscriptionsRepository = {
+  async list({ limit = 10000 } = {}) {
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        'select endpoint, p256dh, auth from push_subscriptions order by created_at desc limit $1',
+        [limit]
+      );
+      return rows.map(mapRow);
+    });
+  },
+
+  async add(subscription) {
+    return withDb(async (client) => {
+      await client.query(
+        `insert into push_subscriptions (endpoint, p256dh, auth, subscription)
+         values ($1, $2, $3, $4)
+         on conflict (endpoint) do update set
+           p256dh = excluded.p256dh,
+           auth = excluded.auth,
+           subscription = excluded.subscription`,
+        [
+          subscription.endpoint,
+          subscription.keys.p256dh,
+          subscription.keys.auth,
+          JSON.stringify(subscription),
+        ]
+      );
+    });
+  },
+
+  async remove(endpoint) {
+    return withDb(async (client) => {
+      await client.query('delete from push_subscriptions where endpoint = $1', [endpoint]);
+    });
+  },
+};

--- a/server/supabase-schema.sql
+++ b/server/supabase-schema.sql
@@ -109,3 +109,13 @@ create table if not exists form_submissions (
   payload jsonb not null,
   created_at timestamptz not null default now()
 );
+
+create table if not exists push_subscriptions (
+  endpoint text primary key,
+  p256dh text not null,
+  auth text not null,
+  subscription jsonb not null,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_push_subscriptions_created on push_subscriptions (created_at desc);


### PR DESCRIPTION
## Description

Web push subscriptions were stored in a volatile in-memory `Set`, causing all registered subscribers to be silently lost on every server restart, crash, or deploy. This fix implements durable storage by persisting subscriptions to a `push_subscriptions` table in the Supabase database, following the same repository pattern already established in the project. When `DATABASE_URL` is not configured (local development), the store degrades gracefully to the existing in-memory behavior.

Resolves #1119

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Changes

- Add `push_subscriptions` table to `supabase-schema.sql` with `endpoint` as primary key
- Create `pushSubscriptionsRepository` with `list`, `add`, and `remove` operations using `withDb`
- Load persisted subscriptions at server startup via `loadPersistedPushSubscriptions()` (only when `DATABASE_URL` is set)
- Update `/api/notifications/subscribe` and `/api/notifications/unsubscribe` endpoints to persist changes asynchronously
- Gate all database operations behind `PUSH_PERSISTENCE_ENABLED` check so zero-database environments work unchanged
- Wrap server boot in `process.env.NODE_ENV !== 'test'` guard (from upstream) with persistence load chained in

## Test Plan

- [x] Server boots without `DATABASE_URL` (memory-only mode, existing behavior preserved)
- [x] Server boots with `DATABASE_URL` configured (persistent mode)
- [x] Subscribe endpoint accepts valid push subscriptions and returns 200
- [x] Unsubscribe endpoint removes subscriptions and returns 200
- [x] Subscription cap (10,000 items) enforced
- [x] No merge conflicts with main branch (rebased onto latest upstream)
- [x] All code syntax valid (`node --check server/index.js` passes)
- [x] Existing notification subscription tests pass in memory-only mode

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings