### PR TITLE
fix(backup): resolve __dirname ReferenceError in ESM run-backup.ts

### DIFF
--- a/server/scripts/run-backup.ts
+++ b/server/scripts/run-backup.ts
@@ -2,10 +2,14 @@
 import { exec } from 'child_process';
 import util from 'util';
 import path from 'path';
+import { fileURLToPath } from 'url';
 import { BackupStorageService } from '../services/backupStorage';
 import { BackupVerifierService } from '../services/backupVerifier';
 
 const execAsync = util.promisify(exec);
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 async function run() {
   console.log('Starting automated backup process...');


### PR DESCRIPTION
fix(backup): resolve __dirname ReferenceError in ESM run-backup.ts

## Description

This pull request resolves a runtime crash in the automated database backup script [run-backup.ts](file:///d:/work/NexaSphere/server/scripts/run-backup.ts) where Node.js throws `ReferenceError: __dirname is not defined`. Because the script runs in an ES Module context, global variables like `__dirname` are unavailable. We resolved this by deriving `__dirname` dynamically using `import.meta.url` and Node's `fileURLToPath`.

Fixes #1162

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
