### PR TITLE
fix(chatbot): add offline knowledge-base fallback when AI service is unavailable

### DIFF
--- a/website/src/shared/Chatbot.jsx
+++ b/website/src/shared/Chatbot.jsx
@@ -15,8 +15,16 @@ const knowledgeBase = [
       'NexaSphere is the official technology and developer community at GL Bajaj Group of Institutions.',
   },
   {
-    keywords: ['event', 'workshop', 'hackathon'],
-    answer: 'NexaSphere regularly organizes workshops, hackathons, and technical events.',
+    keywords: ['hackathon'],
+    answer: 'NexaSphere hosts hackathons that encourage innovation and problem solving.',
+  },
+  {
+    keywords: ['workshop'],
+    answer: 'NexaSphere conducts workshops on emerging technologies and practical skills.',
+  },
+  {
+    keywords: ['event'],
+    answer: 'NexaSphere organizes technical events and community activities throughout the year.',
   },
   {
     keywords: ['team', 'mentor', 'leader'],
@@ -87,6 +95,19 @@ const Chatbot = () => {
     }
   }, [messages, currentWorkspace]);
 
+  const sendFallbackResponse = (query) => {
+    const fallbackResponse = queryLocalKnowledge(query);
+
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `msg-${Date.now()}-bot`,
+        role: 'bot',
+        text: fallbackResponse,
+      },
+    ]);
+  };
+
   const handleSend = async () => {
     if (!input.trim() || isSending) return;
     const userMsg = { id: `msg-${Date.now()}-user`, role: 'user', text: input };
@@ -98,18 +119,10 @@ const Chatbot = () => {
     const aiChatUrl = buildUrl(getAiApiBase(), '/ai/chat');
 
     if (!aiChatUrl) {
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `msg-${Date.now()}-bot`,
-          role: 'bot',
-          text: 'Nexa-AI is offline right now. The AI service URL is not configured for this deployment.',
-        },
-      ]);
+      sendFallbackResponse(currentInput);
       setIsSending(false);
       return;
     }
-
     try {
       const data = await apiClient(aiChatUrl, {
         method: 'POST',
@@ -123,17 +136,7 @@ const Chatbot = () => {
       ]);
     } catch (e) {
       console.error('AI chat request failed', e);
-
-      const fallbackResponse = queryLocalKnowledge(currentInput);
-
-      setMessages((prev) => [
-        ...prev,
-        {
-          id: `msg-${Date.now()}-bot`,
-          role: 'bot',
-          text: fallbackResponse,
-        },
-      ]);
+      sendFallbackResponse(currentInput);
     } finally {
       setIsSending(false);
     }


### PR DESCRIPTION
## Description
This PR updates the chatbot behavior when the AI service endpoint is unavailable or not configured.

Previously, when the AI service URL could not be resolved, the chatbot displayed a configuration error message and did not provide any response to the user.

## Changes Made
* Added a fallback to the existing local knowledge base when the AI service URL is unavailable.
* Moved fallback response handling into a helper function to avoid duplicate code.
* Added separate responses for events, workshops, and hackathons.
* Kept the existing fallback behavior for failed AI requests.

## Benefits
* Users can still interact with the chatbot when the AI endpoint is unavailable.
* The chatbot returns local knowledge-base responses instead of a configuration error.
* Event, workshop, and hackathon queries now return more specific responses.

## Test Cases
**Case 1**
Input:
```text
What is NexaSphere?
```
Expected Result:
The chatbot returns a knowledge-base response instead of displaying the AI service configuration error.

**Case 2**
Input:
```text
Tell me about workshops
```
Expected Result:
The chatbot returns the workshop-related fallback response when the AI endpoint is unavailable.

## Type of changes

- [ ] Linked the related issue
- [ ] Tested the changes locally
- [ ] Followed the project's coding guidelines
- [ ] Added a clear description of the changes

## Checklist

- [x] Linked the related issue
- [x] Tested the changes locally
- [x] Reviewed the changes before submitting
- [x] No additional dependencies were introduced


Closes #1145