### PR TITLE
Add automatic markdown linter

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -1,0 +1,23 @@
+name: Markdown Linter
+
+# 1. WHEN to run: Whenever someone opens a Pull Request to the main branch
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - '**/*.md' # Only run if a Markdown (.md) file was changed
+
+# 2. WHAT to do:
+jobs:
+  lint:
+    runs-on: ubuntu-latest # Run this on a clean, cloud-based computer
+
+    steps:
+      - name: Copy project files
+        uses: actions/checkout@v4 # This grabs your code so the tool can look at it
+
+      - name: Check markdown formatting
+        uses: davidanson/markdownlint-cli2-action@v16 # This is the official community tool
+        with:
+          globs: '**/*.md' # Tell it to scan every single .md file


### PR DESCRIPTION
## Description

This pull request introduces automated Markdown linting to the repository using GitHub Actions. 

As the project grows, keeping documentation files (`README.md`, `CONTRIBUTING.md`) consistent by manually reviewing line breaks, heading increments, and trailing spaces becomes highly inefficient. This change implements the standard community `davidanson/markdownlint-cli2-action` workflow to automatically scan and enforce Markdown styling guidelines on every pull request targeting the `main` branch.

##Issue No. #832 

### Key Changes:
* Created `.github/workflows/lint-markdown.yml` to define the CI/CD linting process.
* Configured the workflow to trigger only when Markdown (`.md`) files are modified, saving GitHub Actions runner minutes.
* Automated style enforcement to capture formatting errors before manual maintainer review.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update (Adds a CI configuration file for documentation tracking)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

---

## How Has This Been Tested?

To verify that the linter acts as expected, please check the **"Checks"** or **"Actions"** tab on this Pull Request:
1. Trigger Verification: Ensure the `Markdown Linter` job initiates automatically upon PR creation.
2. Execution Success: Verify that the `markdownlint-cli2` successfully scans the repository workspace files.
3. Log Output: Review the workflow log outputs to see if existing documentation conforms to community layout configurations or flags errors correctly.