### PR TITLE
fix: remove redundant request body validation from DELETE activity events

### DIFF
--- a/server/controllers/activityEventsController.js
+++ b/server/controllers/activityEventsController.js
@@ -31,7 +31,7 @@ export const addActivityEvent = wrapAsync(async (req, res) => {
 export const deleteActivityEvent = wrapAsync(async (req, res) => {
   const activityKey = String(req.params.activityKey || '').trim();
   const eventId = String(req.params.eventId || '').trim();
-  const deleted = await activityEventsService.deleteActivityEvent(activityKey, eventId, req.body);
+  const deleted = await activityEventsService.deleteActivityEvent(activityKey, eventId);
   if (!deleted) throw new NotFoundError('Event not found in manual activity events.');
   return res.json({ ok: true });
 });

--- a/server/services/activityEventsService.js
+++ b/server/services/activityEventsService.js
@@ -17,10 +17,9 @@ export const activityEventsService = {
     return activityEventsRepository.create(activityKey, parsed);
   },
 
-  async deleteActivityEvent(activityKey, eventId, input) {
-    // Auth check uses only the gate credentials (coreTeamName/Email/Phone + password).
-    // The full event schema is not required for deletion.
-    await this.assertCanManage(input);
+  async deleteActivityEvent(activityKey, eventId) {
+    // Authorization is handled upstream by the requireAdmin middleware
+    // via req.adminSession. No request body is needed for deletion.
     return activityEventsRepository.delete(activityKey, eventId);
   },
 };


### PR DESCRIPTION
## Description

Removed the redundant `assertCanManage(input)` call from the `deleteActivityEvent` 
service method and the corresponding `req.body` argument from the controller. 
Authorization is already handled upstream by the `requireAdmin` middleware via 
`req.adminSession`. Many reverse proxies and CDNs (e.g. Cloudflare) strip request 
bodies from DELETE requests by default, causing Zod validation errors. This makes 
the route compliant with standard RESTful HTTP DELETE semantics.

Closes #1164

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings