### PR TITLE
Add tombstone handling for event deletions and filter tombstoned events in offline cache.

### DIFF
--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -467,6 +467,15 @@ export const api = {
         });
       }
       await fetchWithAuth(`/api/admin/events/${id}`, { method: 'DELETE' });
+      // Record tombstone for offline sync to avoid resurrecting deleted events
+      try {
+        const tombstoneKey = 'ns_tombstone_events';
+        const existing = safeJsonParse(localStorage.getItem(tombstoneKey), []);
+        const updated = Array.isArray(existing) ? [...existing, id] : [id];
+        localStorage.setItem(tombstoneKey, JSON.stringify(updated));
+      } catch (e) {
+        console.warn('Failed to record tombstone for event deletion', e);
+      }
       eventEmitter.emit(EVENTS.EVENT_DELETED, { id });
       eventEmitter.emit(EVENTS.NOTIFY, {
         type: 'success',

--- a/website/src/utils/publicContentStore.js
+++ b/website/src/utils/publicContentStore.js
@@ -48,11 +48,29 @@ export function getLocalEvents(fallbackEvents = []) {
   const stored = toArray(safeJsonParse(window.localStorage.getItem(EVENTS_KEY), []));
   if (!stored.length) return fallbackEvents;
 
-  return mergeEvents(fallbackEvents, stored);
+  // Filter out events that have been tombstoned (deleted while offline)
+  let tombstones = [];
+  try {
+    tombstones = safeJsonParse(window.localStorage.getItem('ns_tombstone_events'), []);
+  } catch (e) {
+    console.warn('Failed to parse tombstone events', e);
+  }
+  const filtered = stored.filter(event => !tombstones.includes(String(event.id)));
+
+  return mergeEvents(fallbackEvents, filtered);
 }
 
 export function mergeEvents(fallbackEvents = [], liveEvents = []) {
-  return mergeById(fallbackEvents, toArray(liveEvents), (previous, event, key) => ({
+  // Filter out tombstoned events from both fallback and live data
+  let tombstones = [];
+  try {
+    tombstones = safeJsonParse(window.localStorage.getItem('ns_tombstone_events'), []);
+  } catch (e) {
+    console.warn('Failed to parse tombstone events', e);
+  }
+  const filteredFallback = fallbackEvents.filter(event => !tombstones.includes(String(event.id)));
+  const filteredLive = liveEvents.filter(event => !tombstones.includes(String(event.id)));
+  return mergeById(filteredFallback, toArray(filteredLive), (previous, event, key) => ({
     ...previous,
     ...event,
     id: event.id ?? previous.id ?? key,


### PR DESCRIPTION
Closes #1017 

### Title
Add tombstone handling for event deletions and filter tombstoned events in offline cache

### Description
Implemented a tombstone mechanism to prevent deleted events from reappearing after an offline‑to‑online transition.

- **Admin API (`api.js`)**
  - On event deletion, records the deleted event ID in `localStorage` under the key `ns_tombstone_events`.
  - Includes safe error handling and logging for tombstone storage.

- **Frontend (`publicContentStore.js`)**
  - `getLocalEvents` now filters out any events listed in the tombstone store before merging.
  - `mergeEvents` also filters tombstoned IDs from both fallback and live data, ensuring they never surface after sync.
  - Added defensive parsing with warnings for malformed tombstone data.

### Fixes
- #1017 

### Type of Change
- [x] Bug fix (non‑breaking change which fixes an issue)

### Checklist
- [x] My code follows the style guidelines of this project  
- [x] I have performed a self‑review of my own code  
- [x] I have commented my code, particularly in hard‑to‑understand areas  
- [x] My changes generate no new warnings  

--- 

**Commit:** `d9c6949` – *Add tombstone handling for event deletions and filter tombstoned events in offline cache*  

Ready for review and merge.