### PR TITLE
fix(website): add missing icons to ICON_MAP and support emoji renderi…

### DIFF
--- a/website/src/shared/Icons.jsx
+++ b/website/src/shared/Icons.jsx
@@ -44,6 +44,14 @@ import {
   Megaphone,
   Briefcase,
   Link,
+  List,
+  Sparkles,
+  MessageSquare,
+  GitBranch,
+  Trophy,
+  MessageCircle,
+  Clipboard,
+  Loader,
 } from 'lucide-react';
 
 function baseProps(props) {
@@ -209,6 +217,14 @@ export const ICON_MAP = {
   Megaphone,
   Briefcase,
   Link,
+  List,
+  Sparkles,
+  MessageSquare,
+  GitBranch,
+  Trophy,
+  MessageCircle,
+  Clipboard,
+  Loader,
   ShieldCheck: IconShieldCheck,
   Bolt: IconBolt,
   Spark: IconSpark,
@@ -218,6 +234,22 @@ export const ICON_MAP = {
 export function DynamicIcon({ name, size = 24, ...props }) {
   const IconComponent = ICON_MAP[name];
   if (!IconComponent) {
+    // Check if the name looks like an emoji or is not a standard word (e.g. contains non-ASCII characters / emojis / native symbols)
+    const isEmoji = typeof name === 'string' && (/\p{Emoji}/u.test(name) && !/^[a-zA-Z0-9]+$/.test(name));
+    if (isEmoji) {
+      return (
+        <span
+          style={{
+            fontSize: `${size}px`,
+            display: 'inline-block',
+            verticalAlign: '-3px',
+            ...props?.style,
+          }}
+        >
+          {name}
+        </span>
+      );
+    }
     if (!import.meta.env.PROD) {
       console.warn(`Icon "${name}" not found in ICON_MAP`);
     }


### PR DESCRIPTION

## Description
 Fixes runtime console warnings and missing icon states by importing and adding List, Sparkles, MessageSquare, GitBranch, Trophy, MessageCircle, Clipboard, and Loader to the website's ICON_MAP. Also implements a regex-based emoji check inside DynamicIcon to gracefully render native emoji symbols directly when supplied in data objects

Fixes #1249 
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
