### PR TITLE
fix: force demo banner when userId is hardcoded in UserDashboard

### DIFF
--- a/website/src/pages/dashboard/UserDashboard.tsx
+++ b/website/src/pages/dashboard/UserDashboard.tsx
@@ -108,7 +108,10 @@ const MOCK_METRICS = {
 const getApiBase = () => ((import.meta as any).env?.VITE_API_BASE || '').replace(/\/+$/, '');
 
 export default function UserDashboard() {
-  // Anonymous user ID — in a real auth system this would come from a user context
+  // No auth system exists yet — userId is hardcoded as a placeholder meaning
+  // every user fetches the same data. isDemo is forced true below to make this
+  // limitation visible. When an auth system is added, replace with the real
+  // user ID from the auth context and remove the forced isDemo = true.
   const userId = 'user_123';
 
   const [activities, setActivities] = useState<Activity[]>([]);
@@ -139,13 +142,17 @@ export default function UserDashboard() {
       return;
     }
 
+    // Force demo banner even when API is reachable — userId is still
+    // hardcoded as 'user_123' so all users see identical placeholder data.
+    setIsDemo(true);
+
     Promise.all([
       fetch(`${base}/api/dashboard/profile/${userId}`).then((r) => r.json()),
       fetch(`${base}/api/dashboard/quests/${userId}`).then((r) => r.json()),
       fetch(`${base}/api/dashboard/leaderboard`).then((r) => r.json()),
     ])
       .then(([profile, quests, leaderboard]) => {
-        setIsDemo(false);
+        // isDemo stays true — userId is still hardcoded as 'user_123'
 
         // Map profile → metrics
         if (profile && typeof profile === 'object') {


### PR DESCRIPTION
## Description
`UserDashboard.tsx` hardcoded `userId` as `'user_123'` for all dashboard API calls:

```ts
// Anonymous user ID — in a real auth system this would come from a user context
const userId = 'user_123';
// ...
fetch(`${base}/api/dashboard/profile/${userId}`),
fetch(`${base}/api/dashboard/quests/${userId}`),
```

When the API was reachable, `setIsDemo(false)` was called in the success handler — meaning the demo banner was hidden and every user silently saw identical placeholder data fetched for `user_123`. There was no visual indication that the data was not personalised to the actual user.

The app has no auth system, so there is no way to obtain a real user ID. The demo banner should always be shown until an auth system is implemented.

Changes made:
- Added `setIsDemo(true)` before the `Promise.all` fetch block so the demo banner is always shown when `userId` is still the hardcoded placeholder — even when the API is reachable
- Replaced `setIsDemo(false)` in the success handler with a comment explaining why `isDemo` stays `true`
- Improved the `userId` comment to clearly explain the limitation and document what needs to change when an auth system is added
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #1196

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings