### PR TITLE
fix(server): isolate tests from redis and prevent auto-listening on import

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -227,11 +227,13 @@ export async function initializeSocketIO(httpServer) {
     transports: ['websocket', 'polling'],
   });
 
-  const pubClient = getRedisClient();
-  const subClient = pubClient.duplicate();
-  // Ensure both pub/sub clients are connected before wiring the adapter
-  await Promise.all([pubClient.connect?.(), subClient.connect?.()].filter(Boolean));
-  io.adapter(createAdapter(pubClient, subClient));
+  if (process.env.NODE_ENV !== 'test') {
+    const pubClient = getRedisClient();
+    const subClient = pubClient.duplicate();
+    // Ensure both pub/sub clients are connected before wiring the adapter
+    await Promise.all([pubClient.connect?.(), subClient.connect?.()].filter(Boolean));
+    io.adapter(createAdapter(pubClient, subClient));
+  }
 
   // Connection auth middleware — checks handshake auth token
   io.use(async (socket, next) => {

--- a/server/index.js
+++ b/server/index.js
@@ -643,19 +643,21 @@ process.on('uncaughtException', (err) => {
 const port = Number(process.env.PORT || 8787);
 let server;
 
-if (!process.env.VERCEL) {
-  const boot = HAS_SUPABASE ? Promise.resolve() : ensureContentFile();
-  boot.then(() => {
+if (process.env.NODE_ENV !== 'test') {
+  if (!process.env.VERCEL) {
+    const boot = HAS_SUPABASE ? Promise.resolve() : ensureContentFile();
+    boot.then(() => {
+      server = app.listen(port, () => {
+        console.log(`NexaSphere server listening on http://localhost:${port}`);
+      });
+      initializeSocketIO(server);
+    });
+  } else {
     server = app.listen(port, () => {
       console.log(`NexaSphere server listening on http://localhost:${port}`);
     });
     initializeSocketIO(server);
-  });
-} else {
-  server = app.listen(port, () => {
-    console.log(`NexaSphere server listening on http://localhost:${port}`);
-  });
-  initializeSocketIO(server);
+  }
 }
 
 export default app;

--- a/server/test/notificationSubscription.test.js
+++ b/server/test/notificationSubscription.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import http from 'node:http';
 
+process.env.NODE_ENV = 'test';
 process.env.ADMIN_USERNAME = 'admin';
 process.env.ADMIN_PASSWORD = 'StrongPassword123!';
 process.env.ADMIN_EVENT_PASSWORD = 'StrongEventPassword123!';


### PR DESCRIPTION

## Description

Isolates test executions from requiring a running Redis server by conditionally bypassing the Socket.IO Redis adapter setup in server/config/socket.js when process.env.NODE_ENV === 'test'. Also prevents port conflicts and event loop socket leaks by wrapping the automatic HTTP listener startup inside server/index.js in a test environment check and explicitly defining process.env.NODE_ENV = 'test' in the subscription test runner.

Fixes #1267 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
