### PR TITLE
fix: prevent click listener leak in TeamMemberModal

### DIFF
--- a/website/src/pages/team/TeamMemberModal.jsx
+++ b/website/src/pages/team/TeamMemberModal.jsx
@@ -5,6 +5,7 @@ import { createPortal } from 'react-dom';
 function CopyPopup({ value, onClose }) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef(null);
+
   const handleCopy = () => {
     navigator.clipboard.writeText(value).then(() => {
       setCopied(true);
@@ -16,7 +17,6 @@ function CopyPopup({ value, onClose }) {
     const handler = (e) => {
       if (!e.target.closest('.copy-popup')) onClose();
     };
-
     timeoutRef.current = setTimeout(() => {
       document.addEventListener('click', handler);
     }, 0);
@@ -25,7 +25,6 @@ function CopyPopup({ value, onClose }) {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
       }
-
       document.removeEventListener('click', handler);
     };
   }, [onClose]);

--- a/website/src/pages/team/TeamMemberModal.jsx
+++ b/website/src/pages/team/TeamMemberModal.jsx
@@ -1,10 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 // ── Copy Popup ──
 function CopyPopup({ value, onClose }) {
   const [copied, setCopied] = useState(false);
-
+  const timeoutRef = useRef(null);
   const handleCopy = () => {
     navigator.clipboard.writeText(value).then(() => {
       setCopied(true);
@@ -16,8 +16,18 @@ function CopyPopup({ value, onClose }) {
     const handler = (e) => {
       if (!e.target.closest('.copy-popup')) onClose();
     };
-    setTimeout(() => document.addEventListener('click', handler), 0);
-    return () => document.removeEventListener('click', handler);
+
+    timeoutRef.current = setTimeout(() => {
+      document.addEventListener('click', handler);
+    }, 0);
+
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+
+      document.removeEventListener('click', handler);
+    };
   }, [onClose]);
 
   return (


### PR DESCRIPTION
## Description

This PR fixes a race condition in TeamMemberModal where a click event listener could remain attached after the component unmounted.

### Changes Made
- Added `useRef` to store the timeout ID.
- Cleared pending timeout during cleanup.
- Ensured proper listener registration and deregistration order.
- Prevented potential memory leaks and unexpected click handling after unmount.

Closes #1195

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings