### PR TITLE
feat(events): add reusable event countdown widget with status badges

### DIFF
--- a/website/src/components/events/EventCountdown.css
+++ b/website/src/components/events/EventCountdown.css
@@ -1,0 +1,142 @@
+.event-countdown-card {
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.03);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: var(--t1);
+  box-shadow: var(--shadow-card);
+  transition: border-color 0.3s ease, background 0.3s ease, transform 0.3s ease;
+}
+
+.event-countdown-card:hover {
+  transform: translateY(-1px);
+}
+
+.event-countdown-head {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+  min-width: 0;
+}
+
+.event-countdown-title {
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.event-countdown-subtitle {
+  font-size: 0.78rem;
+  color: var(--t2);
+  margin-top: 2px;
+}
+
+.event-countdown-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  white-space: nowrap;
+}
+
+.event-countdown-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+  width: 100%;
+}
+
+.event-countdown-segment {
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 14px 10px;
+  min-width: 0;
+  text-align: center;
+}
+
+.event-countdown-value {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 800;
+  color: var(--t1);
+}
+
+.event-countdown-label {
+  display: block;
+  margin-top: 6px;
+  font-size: 0.72rem;
+  color: var(--t2);
+  letter-spacing: 0.05em;
+}
+
+.event-countdown-empty {
+  color: var(--t2);
+  font-size: 0.88rem;
+}
+
+.event-countdown-card.upcoming {
+  background: rgba(14, 165, 233, 0.08);
+  border-color: rgba(14, 165, 233, 0.18);
+}
+
+.event-countdown-card.starting-soon {
+  background: rgba(251, 191, 36, 0.12);
+  border-color: rgba(251, 191, 36, 0.28);
+}
+
+.event-countdown-card.live {
+  background: rgba(34, 197, 94, 0.12);
+  border-color: rgba(34, 197, 94, 0.24);
+}
+
+.event-countdown-card.completed {
+  background: rgba(100, 116, 139, 0.12);
+  border-color: rgba(100, 116, 139, 0.18);
+}
+
+.event-countdown-badge.upcoming {
+  background: rgba(14, 165, 233, 0.18);
+  color: #0ea5e9;
+}
+
+.event-countdown-badge.starting-soon {
+  background: rgba(251, 191, 36, 0.24);
+  color: #b45309;
+}
+
+.event-countdown-badge.live {
+  background: rgba(34, 197, 94, 0.2);
+  color: #16a34a;
+}
+
+.event-countdown-badge.completed {
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--t2);
+}
+
+@media (max-width: 720px) {
+  .event-countdown-card {
+    padding: 14px;
+  }
+
+  .event-countdown-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 520px) {
+  .event-countdown-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/website/src/components/events/EventCountdown.jsx
+++ b/website/src/components/events/EventCountdown.jsx
@@ -1,0 +1,79 @@
+import { DynamicIcon } from '../../shared/Icons';
+import useCountdown from '../../hooks/useCountdown';
+import './EventCountdown.css';
+
+const STATUS_META = {
+  upcoming: {
+    label: 'Upcoming',
+    subtitle: 'Starts in',
+    icon: 'Calendar',
+  },
+  'starting-soon': {
+    label: 'Starting Soon',
+    subtitle: 'Starts in',
+    icon: 'Clock',
+  },
+  live: {
+    label: 'Live Now',
+    subtitle: 'Ends in',
+    icon: 'PlayCircle',
+  },
+  completed: {
+    label: 'Completed',
+    subtitle: 'Event completed',
+    icon: 'CheckCircle',
+  },
+};
+
+function pad(value) {
+  return String(value).padStart(2, '0');
+}
+
+export default function EventCountdown({ event, soonThreshold }) {
+  const { status, days, hours, minutes, seconds } = useCountdown({
+    startDate: event.startDate ?? event.date,
+    endDate: event.endDate,
+    soonThreshold,
+  });
+
+  const meta = STATUS_META[status] ?? STATUS_META.upcoming;
+  const showTimer = status !== 'completed';
+
+  return (
+    <div className={`event-countdown-card ${status}`}>
+      <div className="event-countdown-head">
+        <div>
+          <div className="event-countdown-title">{meta.label}</div>
+          <div className="event-countdown-subtitle">{meta.subtitle}</div>
+        </div>
+        <span className={`event-countdown-badge ${status}`}>
+          <DynamicIcon name={meta.icon} size={14} />
+          {meta.label}
+        </span>
+      </div>
+
+      {showTimer ? (
+        <div className="event-countdown-grid">
+          <div className="event-countdown-segment">
+            <span className="event-countdown-value">{pad(days)}</span>
+            <span className="event-countdown-label">Days</span>
+          </div>
+          <div className="event-countdown-segment">
+            <span className="event-countdown-value">{pad(hours)}</span>
+            <span className="event-countdown-label">Hours</span>
+          </div>
+          <div className="event-countdown-segment">
+            <span className="event-countdown-value">{pad(minutes)}</span>
+            <span className="event-countdown-label">Minutes</span>
+          </div>
+          <div className="event-countdown-segment">
+            <span className="event-countdown-value">{pad(seconds)}</span>
+            <span className="event-countdown-label">Seconds</span>
+          </div>
+        </div>
+      ) : (
+        <div className="event-countdown-empty">This event is completed.</div>
+      )}
+    </div>
+  );
+}

--- a/website/src/hooks/useCountdown.js
+++ b/website/src/hooks/useCountdown.js
@@ -1,0 +1,83 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_SOON_THRESHOLD = 60 * 60 * 1000;
+
+function parseDate(value) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function getEventCountdownStatus({ startDate, endDate, soonThreshold = DEFAULT_SOON_THRESHOLD, now = Date.now() }) {
+  const start = parseDate(startDate);
+  const end = parseDate(endDate);
+  const startTime = start?.getTime();
+  const endTime = end?.getTime();
+  const isCompleted = endTime && now > endTime;
+  const isLive = startTime && now >= startTime && (!endTime || now <= endTime);
+  const isStartingSoon = startTime && startTime > now && startTime - now <= soonThreshold;
+
+  if (isCompleted) return 'completed';
+  if (isLive) return 'live';
+  if (isStartingSoon) return 'starting-soon';
+  return 'upcoming';
+}
+
+export default function useCountdown({ startDate, endDate, soonThreshold = DEFAULT_SOON_THRESHOLD }) {
+  const start = useMemo(() => parseDate(startDate), [startDate]);
+  const end = useMemo(() => parseDate(endDate), [endDate]);
+
+  const computeCountdown = () => {
+    const now = Date.now();
+    const startTime = start?.getTime();
+    const endTime = end?.getTime();
+
+    let status = 'upcoming';
+    let remaining = 0;
+
+    const isCompleted = endTime && now > endTime;
+    const isLive = startTime && now >= startTime && (!endTime || now <= endTime);
+    const isStartingSoon = startTime && startTime > now && startTime - now <= soonThreshold;
+
+    if (isCompleted) {
+      status = 'completed';
+      remaining = 0;
+    } else if (isLive) {
+      status = 'live';
+      remaining = endTime ? Math.max(endTime - now, 0) : 0;
+    } else if (isStartingSoon) {
+      status = 'starting-soon';
+      remaining = Math.max(startTime - now, 0);
+    } else {
+      status = 'upcoming';
+      remaining = startTime ? Math.max(startTime - now, 0) : 0;
+    }
+
+    const days = Math.floor(remaining / 86_400_000);
+    const hours = Math.floor((remaining % 86_400_000) / 3_600_000);
+    const minutes = Math.floor((remaining % 3_600_000) / 60_000);
+    const seconds = Math.floor((remaining % 60_000) / 1000);
+
+    return {
+      status,
+      remaining,
+      days,
+      hours,
+      minutes,
+      seconds,
+      start,
+      end,
+    };
+  };
+
+  const [countdown, setCountdown] = useState(computeCountdown);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setCountdown(computeCountdown());
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [start, end, soonThreshold]);
+
+  return countdown;
+}

--- a/website/src/pages/events/EventsPage.jsx
+++ b/website/src/pages/events/EventsPage.jsx
@@ -4,7 +4,9 @@ import { BannerOrbs } from '../../shared/MotionLayer';
 import Footer from '../../shared/Footer';
 import { DynamicIcon } from '../../shared/Icons';
 import PersonalizedFeed from '../../components/recommendation/PersonalizedFeed';
+import EventCountdown from '../../components/events/EventCountdown.jsx';
 import { useRecommendations } from '../../hooks/useRecommendations';
+import { getEventCountdownStatus } from '../../hooks/useCountdown.js';
 import EventCalendarView from '../../components/calendar/EventCalendarView';
 
 export default function EventsPage({ onBack, onEventClick, events = fallbackEvents }) {
@@ -12,16 +14,11 @@ export default function EventsPage({ onBack, onEventClick, events = fallbackEven
   const [recommendationView, setRecommendationView] = useState(false);
   const [now] = useState(() => Date.now());
 
-  const parseDate = (ev) => {
-    const raw = ev.dateText ?? ev.date ?? '';
-    const d = new Date(raw);
-    return isNaN(d) ? null : d;
-  };
   const getEffectiveStatus = (ev) => {
     if (ev.status === 'completed') return 'completed';
-    const d = parseDate(ev);
-    if (d && d.getTime() < now) return 'completed'; // date passed → auto-complete
-    return ev.status || 'upcoming';
+    const startDate = ev.startDate ?? ev.date;
+    const endDate = ev.endDate ?? ev.date;
+    return getEventCountdownStatus({ startDate, endDate });
   };
 
   const sortedEvents = useMemo(() => {
@@ -241,7 +238,7 @@ export default function EventsPage({ onBack, onEventClick, events = fallbackEven
               const glowColor = ev.gradientColors?.[0] || null;
               return (
                 <div className="timeline-item" key={ev.id}>
-                  <div className={`timeline-dot${ev.status === 'upcoming' ? ' upcoming' : ''}`} />
+                  <div className={`timeline-dot${ev.status !== 'completed' ? ' upcoming' : ''}`} />
                   <div
                     className={`timeline-card shimmer ${i % 2 === 0 ? 'pop-left' : 'pop-right'}`}
                     style={{
@@ -365,6 +362,7 @@ export default function EventsPage({ onBack, onEventClick, events = fallbackEven
                     >
                       {ev.description}
                     </p>
+                    <EventCountdown event={ev} />
                     <div
                       style={{
                         display: 'flex',
@@ -385,6 +383,24 @@ export default function EventsPage({ onBack, onEventClick, events = fallbackEven
                               style={{ marginRight: '4px' }}
                             />{' '}
                             Completed
+                          </>
+                        ) : ev.status === 'live' ? (
+                          <>
+                            <DynamicIcon
+                              name="PlayCircle"
+                              size={11}
+                              style={{ marginRight: '4px' }}
+                            />{' '}
+                            Live Now
+                          </>
+                        ) : ev.status === 'starting-soon' ? (
+                          <>
+                            <DynamicIcon
+                              name="Clock"
+                              size={11}
+                              style={{ marginRight: '4px' }}
+                            />{' '}
+                            Starting Soon
                           </>
                         ) : (
                           <>

--- a/website/src/pages/events/EventsSection.css
+++ b/website/src/pages/events/EventsSection.css
@@ -74,6 +74,30 @@
   letter-spacing: 0.05em;
 }
 
+.timeline-badge.upcoming {
+  background: rgba(255, 255, 255, 0.05);
+  color: var(--t1);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.timeline-badge.starting-soon {
+  background: rgba(251, 191, 36, 0.16);
+  color: #b45309;
+  border: 1px solid rgba(251, 191, 36, 0.22);
+}
+
+.timeline-badge.live {
+  background: rgba(34, 197, 94, 0.16);
+  color: #16a34a;
+  border: 1px solid rgba(34, 197, 94, 0.22);
+}
+
+.timeline-badge.completed {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--t3);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
 .tag-badge {
   font-size: 0.62rem;
   padding: 2px 10px;

--- a/website/src/pages/events/EventsSection.jsx
+++ b/website/src/pages/events/EventsSection.jsx
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
 import { DynamicIcon } from '../../shared/Icons';
+import EventCountdown from '../../components/events/EventCountdown.jsx';
+import { getEventCountdownStatus } from '../../hooks/useCountdown.js';
+import './EventsSection.css';
 
 export default function EventsSection({ onEventClick, events = [] }) {
   const buildGradient = (ev) => {
@@ -40,18 +43,11 @@ export default function EventsSection({ onEventClick, events = [] }) {
     return () => obs.disconnect();
   }, []);
 
-  // Auto-detect: if date has passed, treat as completed regardless of stored status
-  const now = Date.now();
-  const parseDate = (ev) => {
-    const raw = ev.dateText ?? ev.date ?? '';
-    const d = new Date(raw);
-    return isNaN(d) ? null : d;
-  };
   const getEffectiveStatus = (ev) => {
     if (ev.status === 'completed') return 'completed';
-    const d = parseDate(ev);
-    if (d && d.getTime() < now) return 'completed'; // date passed → auto-complete
-    return ev.status || 'upcoming';
+    const startDate = ev.startDate ?? ev.date;
+    const endDate = ev.endDate ?? ev.date;
+    return getEventCountdownStatus({ startDate, endDate });
   };
 
   // Sort: upcoming first (earliest date first), then completed (most recent first)
@@ -83,7 +79,7 @@ export default function EventsSection({ onEventClick, events = [] }) {
             return (
               <div className="timeline-item" key={ev.id}>
                 <div
-                  className={`timeline-dot${ev._effectiveStatus === 'upcoming' ? ' upcoming' : ''}`}
+                  className={`timeline-dot${ev._effectiveStatus !== 'completed' ? ' upcoming' : ''}`}
                 />
                 <div
                   className={`timeline-card shimmer ${i % 2 === 0 ? 'pop-left' : 'pop-right'}`}
@@ -206,6 +202,7 @@ export default function EventsSection({ onEventClick, events = [] }) {
                   >
                     {ev.description}
                   </p>
+                  <EventCountdown event={ev} />
                   <div
                     style={{
                       display: 'flex',
@@ -226,6 +223,24 @@ export default function EventsSection({ onEventClick, events = [] }) {
                             style={{ marginRight: '4px' }}
                           />{' '}
                           Completed
+                        </>
+                      ) : ev._effectiveStatus === 'live' ? (
+                        <>
+                          <DynamicIcon
+                            name="PlayCircle"
+                            size={11}
+                            style={{ marginRight: '4px' }}
+                          />{' '}
+                          Live Now
+                        </>
+                      ) : ev._effectiveStatus === 'starting-soon' ? (
+                        <>
+                          <DynamicIcon
+                            name="Clock"
+                            size={11}
+                            style={{ marginRight: '4px' }}
+                          />{' '}
+                          Starting Soon
                         </>
                       ) : (
                         <>


### PR DESCRIPTION
## Description

Added a reusable `EventCountdown` widget and `useCountdown` hook for NexaSphere events. The countdown uses existing event `startDate` / `endDate` values, updates in real time, and supports four states: `Upcoming`, `Starting Soon`, `Live Now`, and `Completed`. Status badges and responsive dark-mode-friendly styling were included.

Fixes #1269

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings