### PR TITLE
fix(website): implement complete localStorage fallbacks in promptStor…

### DIFF
--- a/website/src/lib/__tests__/promptStore.test.js
+++ b/website/src/lib/__tests__/promptStore.test.js
@@ -14,7 +14,7 @@ import {
   deletePrompt,
   clearWorkspace,
   getRecentPrompts,
-} from '../lib/promptStore';
+} from '../promptStore';
 
 // Mock IndexedDB for testing
 const mockDb = {

--- a/website/src/lib/promptStore.js
+++ b/website/src/lib/promptStore.js
@@ -72,7 +72,7 @@ export const savePrompt = async (prompt, response, workspace = 'default') => {
   } catch (error) {
     logger.error('Error saving prompt to IndexedDB:', error);
     // Fallback to localStorage
-    savePromptToLocalStorage(prompt, response, workspace);
+    return savePromptToLocalStorage(prompt, response, workspace);
   }
 };
 
@@ -150,7 +150,7 @@ export const getPinnedPrompts = async (workspace = null) => {
     });
   } catch (error) {
     logger.error('Error retrieving pinned prompts:', error);
-    return [];
+    return getPinnedPromptsFromLocalStorage(workspace);
   }
 };
 
@@ -181,6 +181,7 @@ export const togglePinPrompt = async (id, pinned) => {
     });
   } catch (error) {
     logger.error('Error toggling pin status:', error);
+    return togglePinPromptInLocalStorage(id);
   }
 };
 
@@ -201,6 +202,7 @@ export const deletePrompt = async (id) => {
     });
   } catch (error) {
     logger.error('Error deleting prompt:', error);
+    return deletePromptFromLocalStorage(id);
   }
 };
 
@@ -218,6 +220,7 @@ export const clearWorkspace = async (workspace = 'default') => {
     return true;
   } catch (error) {
     logger.error('Error clearing workspace:', error);
+    return clearWorkspaceFromLocalStorage(workspace);
   }
 };
 
@@ -241,8 +244,9 @@ const LOCALSTORAGE_KEY = 'nexasphere_prompts';
 const savePromptToLocalStorage = (prompt, response, workspace = 'default') => {
   try {
     const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const id = Date.now() + Math.random();
     stored.push({
-      id: Date.now(),
+      id,
       userPrompt: prompt,
       botResponse: response,
       workspace,
@@ -250,8 +254,67 @@ const savePromptToLocalStorage = (prompt, response, workspace = 'default') => {
       pinned: false,
     });
     localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(stored));
+    return id;
   } catch (error) {
     logger.error('Error saving to localStorage:', error);
+  }
+};
+
+const getPinnedPromptsFromLocalStorage = (workspace = null) => {
+  try {
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    let results = stored.filter((p) => p.pinned === true);
+    if (workspace) {
+      results = results.filter((p) => p.workspace === workspace);
+    }
+    return results.sort((a, b) => b.timestamp - a.timestamp);
+  } catch (error) {
+    logger.error('Error retrieving pinned prompts from localStorage:', error);
+    return [];
+  }
+};
+
+const togglePinPromptInLocalStorage = (id) => {
+  try {
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const prompt = stored.find((p) => p.id === id);
+    if (prompt) {
+      prompt.pinned = !prompt.pinned;
+      localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(stored));
+      return prompt;
+    }
+    return null;
+  } catch (error) {
+    logger.error('Error toggling pin in localStorage:', error);
+    return null;
+  }
+};
+
+const deletePromptFromLocalStorage = (id) => {
+  try {
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const index = stored.findIndex((p) => p.id === id);
+    if (index >= 0) {
+      stored.splice(index, 1);
+      localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(stored));
+      return true;
+    }
+    return false;
+  } catch (error) {
+    logger.error('Error deleting from localStorage:', error);
+    return false;
+  }
+};
+
+const clearWorkspaceFromLocalStorage = (workspace = 'default') => {
+  try {
+    const stored = JSON.parse(localStorage.getItem(LOCALSTORAGE_KEY) || '[]');
+    const filtered = stored.filter((p) => p.workspace !== workspace);
+    localStorage.setItem(LOCALSTORAGE_KEY, JSON.stringify(filtered));
+    return true;
+  } catch (error) {
+    logger.error('Error clearing workspace in localStorage:', error);
+    return false;
   }
 };
 

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -11,12 +11,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.{ts,tsx}'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
       exclude: [
         'src/**/*.d.ts',
         'src/**/__tests__',
-        'src/**/*.test.{ts,tsx}',
-        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.test.{ts,tsx,js,jsx}',
+        'src/**/*.spec.{ts,tsx,js,jsx}',
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
@@ -27,7 +27,7 @@ export default defineConfig({
         statements: 70,
       },
     },
-    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx,js,jsx}', 'src/**/*.spec.{ts,tsx,js,jsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION

## Description
Adds full localStorage fallbacks to database actions (save, get, togglePin, delete, and clear) inside 
promptStore.js
Returns the generated ID from the localStorage fallback helper.
Fixes the incorrect relative import path inside 
promptStore.test.js
 from ../lib/promptStore to ../promptStore.

Fixes #1273 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
