### PR TITLE
fix(website): enable js/jsx in vitest configuration and fix certifica…

### DIFF
--- a/website/src/__tests__/CertificateVerifyPage.test.jsx
+++ b/website/src/__tests__/CertificateVerifyPage.test.jsx
@@ -65,7 +65,7 @@ describe('CertificateVerifyPage', () => {
     render(<CertificateVerifyPage certificateId={CERT_ID} onGoHome={() => {}} />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Certificate Verified/i)).toBeInTheDocument();
+      expect(screen.getByText('Certificate Verified')).toBeInTheDocument();
     });
 
     expect(screen.getByText('Anshika Rai')).toBeInTheDocument();

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -11,12 +11,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.{ts,tsx}'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
       exclude: [
         'src/**/*.d.ts',
         'src/**/__tests__',
-        'src/**/*.test.{ts,tsx}',
-        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.test.{ts,tsx,js,jsx}',
+        'src/**/*.spec.{ts,tsx,js,jsx}',
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
@@ -27,7 +27,7 @@ export default defineConfig({
         statements: 70,
       },
     },
-    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx,js,jsx}', 'src/**/*.spec.{ts,tsx,js,jsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION

## Description
Updates 
website/vitest.config.ts
 to include .js and .jsx extensions in test and coverage paths.
Updates 
CertificateVerifyPage.test.jsx
 to match the exact string 'Certificate Verified' rather than a general regex pattern, resolving the duplicate DOM match error.

Fixes #1275 
## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
