### PR TITLE
fix(website): use correct connection hook import and stub socket env …

### DIFF
--- a/website/src/tests/socketLifecycle.test.jsx
+++ b/website/src/tests/socketLifecycle.test.jsx
@@ -4,7 +4,7 @@ import { act } from 'react-dom/test-utils';
 import React, { useEffect } from 'react';
 import socketClient from '../utils/socketClient';
 import { SocketProvider } from '../context/SocketContext';
-import { useSocket } from '../hooks/useSocket';
+import { useSocket } from '../hooks/useSocketConnection';
 import { useNotifications } from '../hooks/useNotifications';
 
 // Mock components to simulate app navigation
@@ -23,6 +23,7 @@ describe('Socket.IO Lifecycle Management', () => {
   let socketInstance = null;
 
   beforeEach(() => {
+    vi.stubEnv('VITE_SOCKET_URL', 'http://test-server');
     container = document.createElement('div');
     document.body.appendChild(container);
     vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/website/vitest.config.ts
+++ b/website/vitest.config.ts
@@ -11,12 +11,12 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html', 'lcov'],
-      include: ['src/**/*.{ts,tsx}'],
+      include: ['src/**/*.{ts,tsx,js,jsx}'],
       exclude: [
         'src/**/*.d.ts',
         'src/**/__tests__',
-        'src/**/*.test.{ts,tsx}',
-        'src/**/*.spec.{ts,tsx}',
+        'src/**/*.test.{ts,tsx,js,jsx}',
+        'src/**/*.spec.{ts,tsx,js,jsx}',
         'src/main.tsx',
         'src/vite-env.d.ts',
       ],
@@ -27,7 +27,7 @@ export default defineConfig({
         statements: 70,
       },
     },
-    include: ['src/**/*.test.{ts,tsx}', 'src/**/*.spec.{ts,tsx}'],
+    include: ['src/**/*.test.{ts,tsx,js,jsx}', 'src/**/*.spec.{ts,tsx,js,jsx}'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION

## Description
Changes the import inside 
socketLifecycle.test.jsx
 to target the connection manager hook (useSocketConnection).
Stubs VITE_SOCKET_URL to 'http://test-server' in the test setup block (beforeEach) to prevent empty connection URL warnings.

Fixes #1277 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
