### PR TITLE
fix: prevent join requests in demo mode

### DIFF
--- a/website/src/pages/collab/CollabPage.jsx
+++ b/website/src/pages/collab/CollabPage.jsx
@@ -66,8 +66,14 @@ export default function CollabPage({ onBack }) {
   }, []);
 
   const handleJoinSubmit = async (requestData) => {
+    if (isDemo) {
+      alert('Demo mode: Join requests are disabled.');
+      return;
+    }
+
     const requestsUrl = buildUrl(getApiBase(), '/api/collab/requests');
     if (!requestsUrl) return;
+
     await fetch(requestsUrl, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Description

This PR prevents join requests from being sent when the Collaboration Hub is running in demo mode.

### Changes Made

* Added an `isDemo` guard in `handleJoinSubmit`
* Prevented API requests from being sent for mock teams (`t1`, `t2`, `t3`)
* Added user feedback when a join request is attempted in demo mode

Closes #1264

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist:

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
