### PR TITLE
fix: add noopener to external links

### DIFF
--- a/website/src/components/ResumeAnalyzer/CareerRecommendationCard.jsx
+++ b/website/src/components/ResumeAnalyzer/CareerRecommendationCard.jsx
@@ -10,7 +10,7 @@ export default function CareerRecommendationCard({ recommendations }) {
           <h4 className="rec-title">{rec.title}</h4>
           <p className="rec-desc">{rec.description}</p>
           {rec.link && (
-            <a href={rec.link} target="_blank" rel="noreferrer" className="rec-link">
+            <a href={rec.link} target="_blank" rel="noopener noreferrer" className="rec-link">
               Explore →
             </a>
           )}


### PR DESCRIPTION
## Description

This PR fixes a security issue in `CareerRecommendationCard.jsx` where external links opened with `target="_blank"` were using only `rel="noreferrer"`.

### Changes Made

* Updated external links to use `rel="noopener noreferrer"`
* Improved security against potential reverse tabnabbing attacks
* Ensured consistency with other external links across the codebase

Closes #1262

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] This change requires a documentation update

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
