### PR TITLE
fix(#1197): add MutationObserver in useBackToTop to handle delayed element availability

### DIFF
--- a/website/src/hooks/useScrollLogic.js
+++ b/website/src/hooks/useScrollLogic.js
@@ -1,10 +1,40 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 const AUTO_SCROLL_THRESHOLD = 400;
 
-export function useBackToTop() {
+function useBackToTopElement() {
+  const btnRef = useRef(null);
+
   useEffect(() => {
-    const btn = document.getElementById('back-to-top');
+    const tryGetElement = () => {
+      const el = document.getElementById('back-to-top');
+      if (el && el !== btnRef.current) {
+        btnRef.current = el;
+      }
+      return el;
+    };
+
+    if (tryGetElement()) return;
+
+    const observer = new MutationObserver(() => {
+      if (tryGetElement()) {
+        observer.disconnect();
+      }
+    });
+
+    observer.observe(document.body, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return btnRef;
+}
+
+export function useBackToTop() {
+  const btnRef = useBackToTopElement();
+
+  useEffect(() => {
+    const btn = btnRef.current;
     if (!btn) return;
 
     const handleScroll = () => {
@@ -22,7 +52,7 @@ export function useBackToTop() {
       window.removeEventListener('scroll', handleScroll);
       btn.removeEventListener('click', handleClick);
     };
-  }, []);
+  }, [btnRef.current]);
 }
 
 export function useActiveTabObserver(page, mobile, navTabs, navHeights, setActiveTab) {


### PR DESCRIPTION
Fixes useBackToTop hook failing silently when #back-to-top element is not yet in the DOM on mount (e.g. due to conditional rendering).

Changes:
- Extracts element discovery into useBackToTopElement hook using MutationObserver
- Watches document.body for the #back-to-top element to appear
- Attaches scroll/click listeners only after element is available
- Cleans up observer on unmount

Closes #1197