### PR TITLE
fix(website): remove unnecessary escape character from SAFE_URL_PATTE…

### DIFF
--- a/website/src/utils/safeHref.js
+++ b/website/src/utils/safeHref.js
@@ -12,7 +12,7 @@
  * it is non-null.
  */
 
-const SAFE_URL_PATTERN = /^(https?:\/|\/[^\/])/i;
+const SAFE_URL_PATTERN = /^(https?:\/|\/[^/])/i;
 const UNSAFE_PROTOCOL_PATTERN = /^\s*(javascript|data|vbscript|file|about|chrome|jar|mocha):/i;
 const URL_MAX = 2048;
 


### PR DESCRIPTION

## Description
 Removes the redundant slash escape \/ from the character class inside 
safeHref.js to resolve the ESLint rule warning.

Fixes #1292 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
