### PR TITLE
test(website): modernize socket lifecycle test to use React Testing Library, removing deprecation warnings

### DIFF
--- a/website/src/tests/socketLifecycle.test.jsx
+++ b/website/src/tests/socketLifecycle.test.jsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, unmountComponentAtNode } from 'react-dom';
-import { act } from 'react-dom/test-utils';
-import React, { useEffect } from 'react';
+import { render, cleanup } from '@testing-library/react';
+import React from 'react';
 import socketClient from '../utils/socketClient';
 import { SocketProvider } from '../context/SocketContext';
 import { useSocket } from '../hooks/useSocketConnection';
@@ -19,34 +18,24 @@ function PageMock() {
 }
 
 describe('Socket.IO Lifecycle Management', () => {
-  let container = null;
-  let socketInstance = null;
-
   beforeEach(() => {
     vi.stubEnv('VITE_SOCKET_URL', 'http://test-server');
-    container = document.createElement('div');
-    document.body.appendChild(container);
     vi.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    unmountComponentAtNode(container);
-    container.remove();
-    container = null;
+    cleanup();
     socketClient.destroySocket();
     vi.restoreAllMocks();
   });
 
   it('Scenario 1: Initial page load should establish exactly one socket connection', () => {
-    act(() => {
-      render(
-        <SocketProvider>
-          <NotificationsMock />
-          <PageMock />
-        </SocketProvider>,
-        container
-      );
-    });
+    render(
+      <SocketProvider>
+        <NotificationsMock />
+        <PageMock />
+      </SocketProvider>
+    );
 
     const socket = socketClient.getSocket();
     expect(socket).toBeDefined();
@@ -58,22 +47,17 @@ describe('Socket.IO Lifecycle Management', () => {
   });
 
   it('Scenario 2: Component unmount should not destroy the shared connection', () => {
-    act(() => {
-      render(
-        <SocketProvider>
-          <NotificationsMock />
-        </SocketProvider>,
-        container
-      );
-    });
+    const { rerender } = render(
+      <SocketProvider>
+        <NotificationsMock />
+      </SocketProvider>
+    );
 
     const socket = socketClient.getSocket();
     const disconnectSpy = vi.spyOn(socket, 'disconnect');
 
-    // Unmount NotificationsMock
-    act(() => {
-      render(<SocketProvider></SocketProvider>, container);
-    });
+    // Unmount NotificationsMock by rerendering empty provider
+    rerender(<SocketProvider></SocketProvider>);
 
     // The shared socket should NOT have been disconnected
     expect(disconnectSpy).not.toHaveBeenCalled();
@@ -90,20 +74,15 @@ describe('Socket.IO Lifecycle Management', () => {
 
     // Cycle 10 times
     for (let i = 0; i < 10; i++) {
-      act(() => {
-        render(
-          <SocketProvider>
-            <NotificationsMock />
-            <PageMock />
-          </SocketProvider>,
-          container
-        );
-      });
+      const { unmount } = render(
+        <SocketProvider>
+          <NotificationsMock />
+          <PageMock />
+        </SocketProvider>
+      );
 
       // Unmount between routes
-      act(() => {
-        unmountComponentAtNode(container);
-      });
+      unmount();
     }
 
     // Every 'on' for custom events should have a matching 'off'


### PR DESCRIPTION


## Description
 Refactors 
socketLifecycle.test.jsx
 to import and use React Testing Library (render / cleanup), eliminating deprecation warnings.

Fixes #1294 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
