### PR TITLE
fix(server): restore missing portfolio content sanitization functions

### DIFF
--- a/server/utils/sanitize.js
+++ b/server/utils/sanitize.js
@@ -122,6 +122,226 @@ function validateSection(str) {
   return v;
 }
 
+function stripHtml(value) {
+  if (value == null) return '';
+  let text = String(value);
+  text = text.replace(SCRIPT_PATTERN, '');
+  text = text.replace(STYLE_PATTERN, '');
+  text = text.replace(HTML_COMMENT_PATTERN, '');
+  text = text.replace(HTML_TAG_PATTERN, '');
+  text = text.replace(CONTROL_CHAR_PATTERN, '');
+  text = text.replace(NULL_BYTE_PATTERN, '');
+  return text;
+}
+
+function stripHtmlTruncated(value, max) {
+  return stripHtml(value).trim().slice(0, max);
+}
+
+function isSafeUrl(value) {
+  if (typeof value !== 'string') return false;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return false;
+  if (trimmed.length > URL_MAX_LENGTH) return false;
+  // Reject known dangerous protocols explicitly.  The regex below
+  // also catches javascript:, data:, vbscript:, file:, etc.
+  if (/^\s*(javascript|data|vbscript|file|about|chrome|jar|mocha):/i.test(trimmed)) {
+    return false;
+  }
+  return SAFE_URL_PROTOCOLS.test(trimmed);
+}
+
+function sanitizeUrlField(value) {
+  if (value == null) return '';
+  if (!isSafeUrl(value)) return '';
+  return String(value).trim().slice(0, URL_MAX_LENGTH);
+}
+
+function sanitizeStringArray(values, maxItems, perItemMax) {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map((entry) => stripHtmlTruncated(entry, perItemMax))
+    .filter((entry) => entry.length > 0)
+    .slice(0, maxItems);
+}
+
+function sanitizeSkill(skill) {
+  if (!skill || typeof skill !== 'object') return null;
+  const name = stripHtmlTruncated(skill.name, 100);
+  if (!name) return null;
+  const out = { name };
+  if (skill.level != null) {
+    const level = stripHtmlTruncated(skill.level, 40);
+    if (level) out.level = level;
+  }
+  if (skill.category != null) {
+    const category = stripHtmlTruncated(skill.category, 60);
+    if (category) out.category = category;
+  }
+  return out;
+}
+
+function sanitizeProject(project) {
+  if (!project || typeof project !== 'object') return null;
+  const name = stripHtmlTruncated(project.name, 200);
+  if (!name) return null;
+  const out = { name };
+  if (project.description != null) {
+    out.description = stripHtmlTruncated(project.description, 5000);
+  }
+  if (project.shortDesc != null) {
+    out.shortDesc = stripHtmlTruncated(project.shortDesc, 500);
+  }
+  if (project.techStack != null) {
+    out.techStack = sanitizeStringArray(project.techStack, 30, 60);
+  }
+  const link = sanitizeUrlField(project.link);
+  if (link) out.link = link;
+  const github = sanitizeUrlField(project.github);
+  if (github) out.github = github;
+  const demo = sanitizeUrlField(project.demo);
+  if (demo) out.demo = demo;
+  return out;
+}
+
+function sanitizeRoadmap(roadmap) {
+  if (!roadmap || typeof roadmap !== 'object') return null;
+  const title = stripHtmlTruncated(roadmap.title, 200);
+  if (!title) return null;
+  const out = { title };
+  if (roadmap.description != null) {
+    out.description = stripHtmlTruncated(roadmap.description, 5000);
+  }
+  if (Array.isArray(roadmap.milestones)) {
+    out.milestones = roadmap.milestones
+      .map((m) => {
+        if (!m || typeof m !== 'object') return null;
+        const t = stripHtmlTruncated(m.title, 200);
+        if (!t) return null;
+        const entry = { title: t };
+        if (m.description != null) {
+          entry.description = stripHtmlTruncated(m.description, 2000);
+        }
+        if (m.completed != null && typeof m.completed === 'boolean') {
+          entry.completed = m.completed;
+        }
+        return entry;
+      })
+      .filter(Boolean)
+      .slice(0, 100);
+  }
+  return out;
+}
+
+function sanitizeBadge(badge) {
+  if (!badge || typeof badge !== 'object') return null;
+  const name = stripHtmlTruncated(badge.name, 120);
+  if (!name) return null;
+  const out = { name };
+  if (badge.description != null) {
+    out.description = stripHtmlTruncated(badge.description, 1000);
+  }
+  if (badge.tier != null) {
+    out.tier = stripHtmlTruncated(badge.tier, 40);
+  }
+  if (badge.iconUrl) {
+    const iconUrl = sanitizeUrlField(badge.iconUrl);
+    if (iconUrl) out.iconUrl = iconUrl;
+  }
+  return out;
+}
+
+function sanitizeSocialLinks(socialLinks) {
+  if (!socialLinks || typeof socialLinks !== 'object' || Array.isArray(socialLinks)) {
+    return {};
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(socialLinks)) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 40) continue;
+    const safe = sanitizeUrlField(value);
+    if (safe) out[key] = safe;
+  }
+  return out;
+}
+
+function sanitizeSeoMetadata(seo) {
+  if (!seo || typeof seo !== 'object' || Array.isArray(seo)) return {};
+  const out = {};
+  for (const [key, value] of Object.entries(seo)) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 60) continue;
+    out[key] = stripHtmlTruncated(value, 500);
+  }
+  return out;
+}
+
+function sanitizeVisibleSections(sections) {
+  if (!sections || typeof sections !== 'object' || Array.isArray(sections)) {
+    return { quests: true, roadmaps: true, projects: true, analytics: false };
+  }
+  const out = {};
+  for (const [key, value] of Object.entries(sections)) {
+    if (typeof key !== 'string' || key.length === 0 || key.length > 40) continue;
+    if (typeof value === 'boolean') out[key] = value;
+  }
+  return out;
+}
+
+export function sanitizePortfolioRecord(data = {}) {
+  const out = {};
+  if (data.username != null)
+    out.username = String(data.username).trim().toLowerCase().slice(0, 100);
+  if (data.passkey != null) out.passkey = String(data.passkey).slice(0, 256);
+  if (data.theme != null) {
+    const theme = stripHtmlTruncated(data.theme, 50);
+    if (theme) out.theme = theme;
+  }
+  out.visibleSections = sanitizeVisibleSections(data.visibleSections);
+  out.socialLinks = sanitizeSocialLinks(data.socialLinks);
+  if (data.customDomain != null) {
+    const domain = stripHtmlTruncated(data.customDomain, 255);
+    if (domain) out.customDomain = domain;
+  }
+  out.seoMetadata = sanitizeSeoMetadata(data.seoMetadata);
+  if (Array.isArray(data.skills)) {
+    out.skills = data.skills.map(sanitizeSkill).filter(Boolean).slice(0, 100);
+  } else {
+    out.skills = [];
+  }
+  if (Array.isArray(data.badges)) {
+    out.badges = data.badges.map(sanitizeBadge).filter(Boolean).slice(0, 100);
+  } else {
+    out.badges = [];
+  }
+  if (Array.isArray(data.projects)) {
+    out.projects = data.projects.map(sanitizeProject).filter(Boolean).slice(0, 50);
+  } else {
+    out.projects = [];
+  }
+  if (Array.isArray(data.roadmaps)) {
+    out.roadmaps = data.roadmaps.map(sanitizeRoadmap).filter(Boolean).slice(0, 50);
+  } else {
+    out.roadmaps = [];
+  }
+  out.bio = stripHtmlTruncated(data.bio, 5000);
+  out.title = stripHtmlTruncated(data.title, 200);
+  return out;
+}
+
+export function sanitizePortfolioOutput(record) {
+  if (!record || typeof record !== 'object') return null;
+  return sanitizePortfolioRecord(record);
+}
+
+export function isSafePortfolioUrl(value) {
+  return isSafeUrl(value);
+}
+
+function validateWhatsApp(str) {
+  const v = String(str || '').replace(/[^\d]/g, '');
+  if (v.length !== 10) throw new Error('WhatsApp must be exactly 10 digits');
+  return v;
+}
+
 export {
   escapeHtml,
   sanitizeNullableText,
@@ -132,5 +352,4 @@ export {
   toSafeString,
   normalizePhone,
   validateWhatsApp,
-  validateSection,
 };


### PR DESCRIPTION
## Description
 Restores stripHtml, stripHtmlTruncated, isSafePortfolioUrl, sanitizePortfolioRecord, and sanitizePortfolioOutput utility helpers inside sanitize.js to resolve route validation crashes.

Fixes #1304 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
