### PR TITLE
fix(website): remove unused getSocketPath import from socketClient.js

### DIFF
--- a/website/src/utils/socketClient.js
+++ b/website/src/utils/socketClient.js
@@ -5,7 +5,7 @@
  */
 
 import { captureHandledException } from './errorTracking';
-import { getSocketPath, getSocketServerUrl } from './runtimeConfig';
+import { getSocketServerUrl } from './runtimeConfig';
 import {
   initializeSocket as initCoreSocket,
   getSocket as getCoreSocket,


### PR DESCRIPTION
## Description
Removes the unused getSocketPath member from the import statement inside 
socketClient.js to resolve the ESLint warning.

Fixes #1306 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
