### PR TITLE
fix: replace index keys with stable keys in ResumeAnalyzer components

### DIFF
--- a/website/src/components/ResumeAnalyzer/CareerRecommendationCard.jsx
+++ b/website/src/components/ResumeAnalyzer/CareerRecommendationCard.jsx
@@ -1,8 +1,8 @@
 export default function CareerRecommendationCard({ recommendations }) {
   return (
     <div className="rec-grid">
-      {recommendations.map((rec, i) => (
-        <div key={i} className="rec-card">
+      {recommendations.map((rec) => (
+        <div key={rec.title} className="rec-card">
           <div className="rec-header">
             <span className="rec-icon">{rec.icon}</span>
             <span className={`rec-badge badge-${rec.type}`}>{rec.type}</span>
@@ -10,7 +10,7 @@ export default function CareerRecommendationCard({ recommendations }) {
           <h4 className="rec-title">{rec.title}</h4>
           <p className="rec-desc">{rec.description}</p>
           {rec.link && (
-            <a href={rec.link} target="_blank" rel="noreferrer" className="rec-link">
+            <a href={rec.link} target="_blank" rel="noopener noreferrer" className="rec-link">
               Explore →
             </a>
           )}

--- a/website/src/components/ResumeAnalyzer/ResumeAnalyzerPage.jsx
+++ b/website/src/components/ResumeAnalyzer/ResumeAnalyzerPage.jsx
@@ -160,8 +160,8 @@ export default function ResumeAnalyzerPage() {
               { label: 'ATS Score', value: result.atsScore, color: '#10b981' },
               { label: 'Skills Detected', value: result.skills.length, color: '#f59e0b' },
               { label: 'Gaps Found', value: result.missingSkills.length, color: '#ef4444' },
-            ].map((s, i) => (
-              <div key={i} className="score-card">
+            ].map((s) => (
+              <div key={s.label} className="score-card">
                 <p className="score-card-label">{s.label}</p>
                 <p className="score-card-value" style={{ color: s.color }}>
                   {s.value}
@@ -186,8 +186,8 @@ export default function ResumeAnalyzerPage() {
           <div className="ra-section">
             <h3 className="section-title">Missing / In-Demand Skills</h3>
             <div className="missing-skills">
-              {result.missingSkills.map((s, i) => (
-                <span key={i} className="skill-tag missing">
+              {result.missingSkills.map((s) => (
+                <span key={s} className="skill-tag missing">
                   {s}
                 </span>
               ))}


### PR DESCRIPTION
## Description
`ResumeAnalyzerPage.jsx` and `CareerRecommendationCard.jsx` used array index as React key on dynamic lists:

```jsx
// Score cards
{[...].map((s, i) => (
  <div key={i} className="score-card">

// Missing skills
{result.missingSkills.map((s, i) => (
  <span key={i} className="skill-tag missing">

// Recommendation cards
{recommendations.map((rec, i) => (
  <div key={i} className="rec-card">
```

Using index as key causes React reconciliation bugs when list order changes or items are added/removed between renders — components may retain stale state, animations may fire incorrectly, and screen readers may not announce updates properly. `missingSkills` and `recommendations` are dynamic data from AI analysis where order and content can change between renders.

Additionally `CareerRecommendationCard.jsx` used `rel="noreferrer"` without `rel="noopener"` on external `target="_blank"` links — inconsistent with the rest of the codebase where all external links correctly use `rel="noopener noreferrer"`.

Changes made:
- Score cards: `key={i}` → `key={s.label}` (label is unique per card)
- Missing skills: `key={i}` → `key={s}` (skill string is unique)
- Recommendation cards: `key={i}` → `key={rec.title}` (title is unique per recommendation)
- Fixed `rel="noreferrer"` → `rel="noopener noreferrer"` in `CareerRecommendationCard`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1263

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings