### PR TITLE
fix(server): correct withDb import path in registrationsRepository

### DIFF
--- a/server/repositories/registrationsRepository.js
+++ b/server/repositories/registrationsRepository.js
@@ -1,4 +1,5 @@
-import { withDb, HAS_SUPABASE } from '../storage/supabaseClient.js';
+import { withDb } from './db.js';
+import { HAS_SUPABASE } from '../storage/supabaseClient.js';
 
 export const registrationsRepository = {
   async findByEventId(eventId) {


### PR DESCRIPTION
## Description
Changes the import path of withDb in 
registrationsRepository.js
 to load from ./db.js instead of the Supabase client file.

Fixes #1341

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
