### PR TITLE
fix(website): resolve GamificationDashboard loadData hoisting warning

### DIFF
--- a/website/src/components/gamification/GamificationDashboard.jsx
+++ b/website/src/components/gamification/GamificationDashboard.jsx
@@ -8,15 +8,15 @@ export default function GamificationDashboard() {
   const [activeTab, setActiveTab] = useState('overview');
   const [toasts, setToasts] = useState([]);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
   const loadData = async () => {
     setUserStats(gamificationService.getUserStats());
     const lb = await gamificationService.getLeaderboard();
     setLeaderboard(lb);
   };
+
+  useEffect(() => {
+    loadData();
+  }, []);
 
   const handleAction = (action) => {
     const result = gamificationService.trackAction(action);


### PR DESCRIPTION
## Description
Moves loadData above the useEffect hook in 
GamificationDashboard.jsx to eliminate hoisting warnings.

Fixes #1340

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
