### PR TITLE
fix(website): resolve ModerationDashboard loadData hoisting warning

### DIFF
--- a/website/src/components/moderation/ModerationDashboard.jsx
+++ b/website/src/components/moderation/ModerationDashboard.jsx
@@ -12,10 +12,6 @@ export default function ModerationDashboard() {
   const [selectedTab, setSelectedTab] = useState('pending');
   const [stats, setStats] = useState({ pending: 0, reviewed: 0, blocked: 0 });
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
   const loadData = () => {
     const flagged = moderationService.getFlaggedContent();
     setFlaggedContent(flagged.filter((f) => f.status === selectedTab));
@@ -26,6 +22,10 @@ export default function ModerationDashboard() {
     });
     setUserReputations(moderationService.getUserReputationSummary());
   };
+
+  useEffect(() => {
+    loadData();
+  }, []);
 
   const handleResolve = (flagId, action) => {
     moderationService.resolveFlag(flagId, action);


### PR DESCRIPTION
## Description
Moves loadData above the useEffect hook in 
ModerationDashboard.jsx to clear the hoisting warning.

Fixes #1339

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
