### PR TITLE
fix(website): resolve PromptHistorySidebar loadData hoisting warning

### DIFF
--- a/website/src/components/history/PromptHistorySidebar.jsx
+++ b/website/src/components/history/PromptHistorySidebar.jsx
@@ -10,10 +10,6 @@ const PromptHistorySidebar = ({ isOpen, onSelectPrompt, currentWorkspace = 'defa
   const [loading, setLoading] = useState(true);
   const [deleteTarget, setDeleteTarget] = useState(null);
 
-  useEffect(() => {
-    loadData();
-  }, [selectedWorkspace]);
-
   const loadData = async () => {
     setLoading(true);
     try {
@@ -28,6 +24,10 @@ const PromptHistorySidebar = ({ isOpen, onSelectPrompt, currentWorkspace = 'defa
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    loadData();
+  }, [selectedWorkspace]);
 
   const handleDeletePrompt = async (e, id) => {
     e.stopPropagation();


### PR DESCRIPTION
## Description
Moves loadData above the useEffect hook inside 
PromptHistorySidebar.jsx to avoid temporal dead zone warnings.

Fixes #1338

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
