### PR TITLE
fix(website): resolve PinnedChats loadPinnedPrompts hoisting warning

### DIFF
--- a/website/src/components/history/PinnedChats.jsx
+++ b/website/src/components/history/PinnedChats.jsx
@@ -6,10 +6,6 @@ const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
   const [pinnedPrompts, setPinnedPrompts] = useState([]);
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    loadPinnedPrompts();
-  }, [workspace]);
-
   const loadPinnedPrompts = async () => {
     setLoading(true);
     try {
@@ -21,6 +17,10 @@ const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    loadPinnedPrompts();
+  }, [workspace]);
 
   const handleUnpin = async (e, id) => {
     e.stopPropagation();


### PR DESCRIPTION
## Description
Moves the loadPinnedPrompts function above the useEffect block in 
PinnedChats.jsx to prevent TDZ warnings.

Fixes #1337

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
