### PR TITLE
fix(website): resolve SearchBar handleClick hoisting declaration order and React Compiler warning

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -76,6 +76,18 @@ export default function SearchBar({ open, onClose, activities, events, onNavigat
     setFocusIdx(-1);
   }, [results]);
 
+  const handleClick = useCallback(
+    (result) => {
+      if (result.type === 'activity') onNavigate('activity', result.key || result.id);
+      else if (result.type === 'event')
+        onEventClick(result.event || { id: result.id, name: result.title });
+      else if (result.type === 'member') window.location.href = result.url || '/team';
+      onClose();
+      clearSearch();
+    },
+    [onNavigate, onEventClick, onClose, clearSearch]
+  );
+
   useEffect(() => {
     const fn = (e) => {
       if (e.key === 'Escape') onClose();
@@ -103,18 +115,6 @@ export default function SearchBar({ open, onClose, activities, events, onNavigat
       if (el) el.scrollIntoView?.({ block: 'nearest' });
     }
   }, [focusIdx]);
-
-  const handleClick = useCallback(
-    (result) => {
-      if (result.type === 'activity') onNavigate('activity', result.key || result.id);
-      else if (result.type === 'event')
-        onEventClick(result.event || { id: result.id, name: result.title });
-      else if (result.type === 'member') window.location.href = result.url || '/team';
-      onClose();
-      clearSearch();
-    },
-    [onNavigate, onEventClick, onClose, clearSearch]
-  );
 
   return (
     <AnimatePresence>


### PR DESCRIPTION


## Description
Moves the definition of handleClick above the keydown useEffect block in 
SearchBar.jsx to resolve hoisting warnings and allow React Compiler optimizations.

Fixes #1336

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
