### PR TITLE
fix: skip already-fired elements in ActivitiesPage IntersectionObserver

### DIFF
--- a/website/src/pages/activities/ActivitiesPage.jsx
+++ b/website/src/pages/activities/ActivitiesPage.jsx
@@ -316,9 +316,17 @@ export default function ActivitiesPage({ onNavigate, onBack }) {
       },
       { threshold: 0, rootMargin: '0px 0px -10px 0px' }
     );
+    // Filter out elements that already have the 'fired' class — on re-mount
+    // (user navigates away and back) querySelectorAll finds all elements again
+    // including ones that already animated in the previous mount. Re-observing
+    // them wastes observer slots and may re-trigger animations.
     document
       .querySelectorAll('#activities-page .pop-in, #activities-page .pop-word')
-      .forEach((el) => obs.observe(el));
+      .forEach((el) => {
+        if (!el.classList.contains('fired')) {
+          obs.observe(el);
+        }
+      });
     return () => obs.disconnect();
   }, []);
 


### PR DESCRIPTION
## Description
`ActivitiesPage.jsx` registered all `.pop-in` and `.pop-word` elements with an `IntersectionObserver` on every mount:

```js
document
  .querySelectorAll('#activities-page .pop-in, #activities-page .pop-word')
  .forEach((el) => obs.observe(el));
```

On re-mount (user navigates away and back to the Activities page), `querySelectorAll` found all elements again — including ones that already had the `fired` class from the previous mount. Re-observing these elements wasted observer slots and could re-trigger entrance animations on elements already visible in the viewport.

Changes made:
- Added a `classList.contains('fired')` check before calling `obs.observe(el)` — only elements that have not yet animated are registered with the `IntersectionObserver`
- Elements that already have `fired` from a previous mount are skipped entirely
- Added a comment explaining why the filter is needed
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors with `npx tsc --noEmit`

Fixes #1266

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings