### PR TITLE
fix(roadmaps): remove unused Sparkles and Save imports from RoadmapBuilder

### DIFF
--- a/website/src/components/roadmaps/RoadmapBuilder.tsx
+++ b/website/src/components/roadmaps/RoadmapBuilder.tsx
@@ -17,12 +17,10 @@ import {
   Download,
   Upload,
   RotateCcw,
-  Sparkles,
   Layers,
   BookOpen,
   AlertCircle,
   Edit,
-  Save,
   Check,
 } from 'lucide-react';
 


### PR DESCRIPTION

## Description
Removes the unused imports Sparkles and Save from the lucide-react import statement in RoadmapBuilder.tsx.

Fixes #1380 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
