### PR TITLE
fix(roadmaps): replace unused imports with missing AlertCircle in Nod…

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { motion } from 'framer-motion';
 import { useRoadmapBuilder } from '../../hooks/useRoadmapBuilder';
-import { X, Plus, Trash2, Globe, Link, CheckSquare, ListPlus } from 'lucide-react';
+import { X, Plus, Trash2, Globe, AlertCircle } from 'lucide-react';
 
 interface NodeModalProps {
   theme: 'dark' | 'light';


### PR DESCRIPTION

## Description
Substituted unused imports Link, CheckSquare, and ListPlus with AlertCircle on line 4 of NodeModal.tsx to fix both the unused import warnings and the undefined AlertCircle icon reference error on line 402.

Fixes #1379 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
