### PR TITLE
fix(roadmaps): remove unused Plus and AlertCircle imports from NodeCanvas

### DIFF
--- a/website/src/components/roadmaps/NodeCanvas.tsx
+++ b/website/src/components/roadmaps/NodeCanvas.tsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useRoadmapBuilder } from '../../hooks/useRoadmapBuilder';
 import { RoadmapNode } from '../../context/RoadmapBuilderContext';
-import { Edit2, Trash2, Plus, Sparkles, AlertCircle } from 'lucide-react';
+import { Edit2, Trash2, Sparkles } from 'lucide-react';
 
 interface NodeCanvasProps {
   theme: 'dark' | 'light';


### PR DESCRIPTION

## Description
Removes unused Plus and AlertCircle imports from the lucide-react import statement on line 5 of NodeCanvas.tsx.

Fixes #1378 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
