### PR TITLE
fix(portfolio): remove unused useEffect import

### DIFF
--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import apiClient from '../../utils/apiClient.js';
 import { projectsData } from '../../data/projectsData';
 import { roadmapData } from '../../data/roadmapData';


### PR DESCRIPTION
## Description
Removes the unused useEffect import from react at the top of PortfolioBuilder.jsx to clean up the file.

Fixes #1377 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
