### PR TITLE
fix(moderation): remove unused imports MODERATION_CATEGORIES and SEVERITY

### DIFF
--- a/website/src/components/moderation/ModerationDashboard.jsx
+++ b/website/src/components/moderation/ModerationDashboard.jsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from 'react';
 import {
   moderationService,
-  MODERATION_CATEGORIES,
-  SEVERITY,
   REPUTATION,
 } from '../../services/moderationService';
 


### PR DESCRIPTION


## Description
Removes unused imports MODERATION_CATEGORIES and SEVERITY from the moderationService import list in ModerationDashboard.jsx to clean up the file.

Fixes #1376 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
