### PR TITLE
fix(explore): replace unused X import with Search icon import

### DIFF
--- a/website/src/components/explore/AdvancedFilters.jsx
+++ b/website/src/components/explore/AdvancedFilters.jsx
@@ -1,6 +1,6 @@
 import { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Filter, X, Calendar, Tag, ChevronDown } from 'lucide-react';
+import { Filter, Search, Calendar, Tag, ChevronDown } from 'lucide-react';
 
 export default function AdvancedFilters({ events, onFilterChange }) {
   const [open, setOpen] = useState(false);


### PR DESCRIPTION
## Description
Replaces the unused X import with the missing Search icon import in the lucide-react import statement on line 3 of AdvancedFilters.jsx. This resolves the unused import warning and the undefined Search reference error.

Fixes #1375 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
