### PR TITLE
fix(calendar): remove unused useRef and useEffect imports

### DIFF
--- a/website/src/components/calendar/EventCalendarView.jsx
+++ b/website/src/components/calendar/EventCalendarView.jsx
@@ -1,4 +1,3 @@
-import { useRef, useEffect } from 'react';
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';


### PR DESCRIPTION
## Description
Removes the unused useRef and useEffect imports from react at the top of EventCalendarView.jsx to clean up the file and resolve linter warnings.

Fixes #1374 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
