### PR TITLE
fix(bookmarks): prefix unused interface parameters with underscores

### DIFF
--- a/website/src/components/bookmarks/BookmarksDrawer.tsx
+++ b/website/src/components/bookmarks/BookmarksDrawer.tsx
@@ -6,7 +6,7 @@ import { BookmarkType } from '../../utils/bookmarkStorage';
 interface BookmarksDrawerProps {
   isOpen: boolean;
   onClose: () => void;
-  onNavigate?: (type: string, key: string) => void;
+  onNavigate?: (_type: string, _key: string) => void;
 }
 
 export default function BookmarksDrawer({ isOpen, onClose, onNavigate }: BookmarksDrawerProps) {


### PR DESCRIPTION
## Description
Prefixes unused parameters type and key with underscores (_type, _key) in the BookmarksDrawerProps interface signature in BookmarksDrawer.tsx to resolve TS/ESLint unused vars warnings.

Fixes #1373 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
