### PR TITLE
fix: offload blocking gspread calls to thread pool in async methods

### DIFF
--- a/server-python/services/sheets.py
+++ b/server-python/services/sheets.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from datetime import datetime
 from typing import Any, Dict
@@ -48,12 +49,12 @@ class SheetsService:
         sheet.append_row(row)
 
     async def append_membership(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("Membership", form_data)
+        await asyncio.to_thread(self._append_to_worksheet, "Membership", form_data)
 
     async def append_recruitment(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("Recruitment", form_data)
+        await asyncio.to_thread(self._append_to_worksheet, "Recruitment", form_data)
 
     async def append_core_team_application(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("CoreTeamApplications", form_data)
+        await asyncio.to_thread(self._append_to_worksheet, "CoreTeamApplications", form_data)
 
 sheets_service = SheetsService()


### PR DESCRIPTION
## Problem

`server-python/services/sheets.py` calls `gspread.append_row()` — a blocking synchronous I/O operation — directly inside `async` methods. This blocks the entire FastAPI event loop during every Google Sheets write, making the server unresponsive to all other requests until the API call completes.

**Closes #1400**

## Fix

Use `asyncio.to_thread()` to offload blocking I/O to a thread pool, keeping the event loop free to handle concurrent requests.

```python
# Before — blocks event loop
async def append_membership(self, form_data):
    self._append_to_worksheet("Membership", form_data)

# After — non-blocking
async def append_membership(self, form_data):
    await asyncio.to_thread(self._append_to_worksheet, "Membership", form_data)
```

Applied to all three async methods:
- `append_membership()`
- `append_recruitment()`
- `append_core_team_application()`