### PR TITLE
fix: replace bypassed quality-gate scripts in website/package.json

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -11,9 +11,9 @@
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "analyze": "cross-env ANALYZE=true vite build",
-    "lint": "echo 'Linting bypassed' && exit 0",
-    "format:check": "echo 'Format check bypassed' && exit 0",
-    "typecheck": "echo 'Typecheck bypassed' && exit 0"
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "format:check": "prettier --check src",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@fullcalendar/daygrid": "^6.1.20",


### PR DESCRIPTION
## Description

The `lint`, `format:check`, and `typecheck` scripts in `website/package.json` were stub commands that echoed a bypass message and exited with code 0. This allowed syntax errors, type violations, and formatting issues to pass local checks and CI undetected.

All three tools — ESLint, Prettier, and TypeScript — are already installed as devDependencies. This PR replaces the bypass stubs with the real commands:

- `lint` → `eslint src --ext .js,.jsx,.ts,.tsx`
- `format:check` → `prettier --check src`
- `typecheck` → `tsc --noEmit`

Fixes #1321

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings