### PR TITLE
fix: add missing axiosInstance module for admin list pages

### DIFF
--- a/admin-dashboard/src/api/axiosInstance.js
+++ b/admin-dashboard/src/api/axiosInstance.js
@@ -1,0 +1,59 @@
+// Thin fetch-based HTTP client with an axios-compatible interface.
+// Reads VITE_API_BASE from the environment; defaults to an empty string
+// (same-origin) when not set.
+
+const BASE_URL = (import.meta.env?.VITE_API_BASE ?? '').replace(/\/$/, '');
+
+function getAuthHeader() {
+  const token = localStorage.getItem('admin_token');
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+async function request(method, url, { data, params } = {}) {
+  let fullUrl = `${BASE_URL}${url}`;
+
+  if (params) {
+    const qs = new URLSearchParams(
+      Object.entries(params).filter(([, v]) => v !== undefined && v !== null)
+    ).toString();
+    if (qs) fullUrl += `?${qs}`;
+  }
+
+  const options = {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...getAuthHeader(),
+    },
+  };
+
+  if (data !== undefined) {
+    options.body = JSON.stringify(data);
+  }
+
+  const response = await fetch(fullUrl, options);
+
+  if (!response.ok) {
+    const error = new Error(`Request failed: ${response.status} ${response.statusText}`);
+    error.response = { status: response.status, data: null };
+    try {
+      error.response.data = await response.json();
+    } catch {
+      // non-JSON body — leave data as null
+    }
+    throw error;
+  }
+
+  const responseData = response.status === 204 ? null : await response.json();
+  return { data: responseData, status: response.status };
+}
+
+const axiosInstance = {
+  get: (url, config) => request('GET', url, config),
+  post: (url, data, config) => request('POST', url, { ...config, data }),
+  put: (url, data, config) => request('PUT', url, { ...config, data }),
+  patch: (url, data, config) => request('PATCH', url, { ...config, data }),
+  delete: (url, config) => request('DELETE', url, config),
+};
+
+export default axiosInstance;


### PR DESCRIPTION
## Description

`RegistrationsList.jsx`, `EventsList.jsx`, `UsersList.jsx`, and `FormsList.jsx` all import `axiosInstance` from `../api/axiosInstance`, but `admin-dashboard/src/api/axiosInstance.js` did not exist. This caused module resolution failures at build and test time.

This PR adds the missing module as a thin `fetch`-based HTTP client that exposes an axios-compatible interface (`get`, `post`, `put`, `patch`, `delete`). It:

- Reads `VITE_API_BASE` for the server base URL (defaults to same-origin).
- Attaches the `admin_token` Bearer header automatically on every request.
- Returns `{ data, status }` to match the shape the list pages expect.
- Throws a structured error with `error.response` on non-2xx responses.

No changes to the four list pages were required.

Fixes #1322

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings