### PR TITLE
fix(collab): reset form state when JoinRequestModal reopens

### DIFF
--- a/website/src/components/collab/JoinRequestModal.jsx
+++ b/website/src/components/collab/JoinRequestModal.jsx
@@ -15,6 +15,16 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   // returned to it when the modal closes.
   const triggerRef = useRef(document.activeElement);
 
+  // Reset form state whenever the modal opens (team changes)
+  // This ensures users start with a fresh form each time they open the modal
+  useEffect(() => {
+    setPitch('');
+    setSkills('');
+    setGithub('');
+    setSuccess(false);
+    setLoading(false);
+  }, [team?.id]);
+
   // Move focus into the modal on mount and return it on unmount.
   useEffect(() => {
     const modal = modalRef.current;
@@ -28,7 +38,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
         triggerRef.current.focus();
       }
     };
-  }, []);
+  }, [team?.id]);
 
   // Focus trap + Escape key handler
   useEffect(() => {
@@ -66,15 +76,6 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
     return () => document.removeEventListener('keydown', handleKeyDown);
   }, [onClose]);
 
-  useEffect(() => {
-  if (modalRef.current) {
-    const firstFocusable = modalRef.current.querySelector(
-      'button, input, textarea, select, a[href]'
-    );
-
-    firstFocusable?.focus();
-  }
-}, []);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary

Fixes the issue where the JoinRequestModal retains previously entered form data after being closed and reopened. Now the form properly resets to a fresh state each time the modal opens.

## Problem

When a user:
1. Opens the JoinRequestModal for a team
2. Enters some form data (pitch, skills, github link)
3. Closes the modal without submitting
4. Opens the modal again (same or different team)

The previously entered values would still be visible, creating an inconsistent experience and risk of accidental submission of outdated data.

## Solution

Added a `useEffect` hook that resets all form state variables whenever the `team` prop changes (indicated by `team?.id`):

- `pitch` → empty string
- `skills` → empty string
- `github` → empty string
- `success` → false
- `loading` → false

Also removed a duplicate focus management effect that was redundant.

## Changes

**JoinRequestModal.jsx**
- ✅ Added form reset effect triggered by team ID change
- ✅ Removed duplicate focus effect
- ✅ Updated focus management dependency array

## Testing

To verify the fix:
1. Navigate to Collaboration Hub
2. Select a team and open JoinRequestModal
3. Enter data in all fields
4. Close the modal without submitting
5. Reopen the modal
6. Verify all fields are empty
7. Try with a different team - form should still be empty

## Impact

- Prevents accidental submission of outdated data
- Consistent user experience across modal reopen cycles
- No breaking changes

Closes #1458

---
🤖 Generated with Claude Code"