### PR TITLE
fix: use run_in_executor for blocking gspread calls in sheets service

### DIFF
--- a/server-python/services/sheets.py
+++ b/server-python/services/sheets.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from datetime import datetime
 from typing import Any, Dict
@@ -48,12 +49,15 @@ class SheetsService:
         sheet.append_row(row)
 
     async def append_membership(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("Membership", form_data)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._append_to_worksheet, "Membership", form_data)
 
     async def append_recruitment(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("Recruitment", form_data)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._append_to_worksheet, "Recruitment", form_data)
 
     async def append_core_team_application(self, form_data: Dict[str, Any]) -> None:
-        self._append_to_worksheet("CoreTeamApplications", form_data)
+        loop = asyncio.get_event_loop()
+        await loop.run_in_executor(None, self._append_to_worksheet, "CoreTeamApplications", form_data)
 
 sheets_service = SheetsService()


### PR DESCRIPTION
## Description
Fixes blocking synchronous `gspread` calls inside async methods in `server-python/services/sheets.py`. The `_append_to_worksheet()` method is a blocking I/O operation that was being called directly inside `async` functions, blocking the entire FastAPI event loop during every Google Sheets write.

Fixes #1400

## Changes
- Added `import asyncio` to `sheets.py`
- Wrapped all three `_append_to_worksheet()` calls with `asyncio.run_in_executor()` in `append_membership()`, `append_recruitment()`, and `append_core_team_application()`

```py
# Before  blocks event loop
async def append_membership(self, form_data: Dict[str, Any]) -> None:
    self._append_to_worksheet("Membership", form_data)

# After  offloads to thread pool
async def append_membership(self, form_data: Dict[str, Any]) -> None:
    loop = asyncio.get_event_loop()
    await loop.run_in_executor(None, self._append_to_worksheet, "Membership", form_data)
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings