### PR TITLE
fix(admin-dashboard): harden sync bridge postMessage handling

### DIFF
--- a/admin-dashboard/public/sync-bridge.html
+++ b/admin-dashboard/public/sync-bridge.html
@@ -11,10 +11,9 @@
      * Sync Bridge — runs in an iframe at the ADMIN DASHBOARD origin.
      *
      * Flow:
-     * 1. Admin dashboard (same origin) updates localStorage and posts
-     *    a message here with the key that changed.
-     * 2. This bridge reads the new value from localStorage and relays
-     *    it to the PARENT window (website) via postMessage.
+     * 1. Website embeds this page and requests allowed public content keys.
+     * 2. This bridge validates the parent origin, reads only allowed keys,
+     *    and relays values to that exact parent origin via postMessage.
      * 3. The website receives the message, updates its own localStorage,
      *    and fires the 'ns-content-updated' event for subscribers.
      *
@@ -22,28 +21,68 @@
      * and relays those too.
      */
 
-    function relayToParent(key, value) {
+    const ALLOWED_SYNC_KEYS = new Set([
+      'ns_db_events',
+      'ns_db_core_team',
+      'ns_db_announcements',
+    ]);
+    const TRUSTED_PARENT_ORIGINS = new Set([
+      'https://nexasphere-glbajaj.vercel.app',
+      'http://localhost:5173',
+      'http://localhost:5175',
+      'http://127.0.0.1:5173',
+      'http://127.0.0.1:5175',
+    ]);
+    const selfOrigin = normalizeOrigin(window.location.origin);
+    if (selfOrigin) TRUSTED_PARENT_ORIGINS.add(selfOrigin);
+
+    let trustedParentOrigin = null;
+
+    function normalizeOrigin(value) {
+      try {
+        return new URL(value).origin;
+      } catch {
+        return null;
+      }
+    }
+
+    function isTrustedParent(origin) {
+      const normalizedOrigin = normalizeOrigin(origin);
+      return normalizedOrigin ? TRUSTED_PARENT_ORIGINS.has(normalizedOrigin) : false;
+    }
+
+    function isAllowedSyncKey(key) {
+      return typeof key === 'string' && ALLOWED_SYNC_KEYS.has(key);
+    }
+
+    function relayToParent(key, value, targetOrigin = trustedParentOrigin) {
+      if (!isAllowedSyncKey(key) || !targetOrigin) return;
+
       if (window.parent && window.parent !== window) {
         window.parent.postMessage({
           type: 'ns-content-updated',
           key: key,
           value: value,
-        }, '*');
+        }, targetOrigin);
       }
     }
 
-    // Listen for messages from the admin dashboard (same origin)
+    // Listen for sync requests from the trusted website parent.
     window.addEventListener('message', (event) => {
-      if (event.data && event.data.type === 'ns-sync' && event.data.key) {
+      if (event.source !== window.parent || !isTrustedParent(event.origin)) return;
+
+      if (event.data && event.data.type === 'ns-sync' && isAllowedSyncKey(event.data.key)) {
+        trustedParentOrigin = normalizeOrigin(event.origin);
         // Read the current value from localStorage and relay it
         const value = localStorage.getItem(event.data.key);
-        relayToParent(event.data.key, value);
+        relayToParent(event.data.key, value, trustedParentOrigin);
       }
     });
 
-    // Also watch for native localStorage changes in this origin
+    // Also watch for native localStorage changes in this origin after
+    // a trusted parent has established the expected postMessage target.
     window.addEventListener('storage', (event) => {
-      if (event.key && event.key.startsWith('ns_db_')) {
+      if (trustedParentOrigin && isAllowedSyncKey(event.key)) {
         relayToParent(event.key, event.newValue);
       }
     });

--- a/admin-dashboard/src/__tests__/public/syncBridge.test.js
+++ b/admin-dashboard/src/__tests__/public/syncBridge.test.js
@@ -1,0 +1,148 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, test } from 'vitest';
+
+const BRIDGE_HTML = readFileSync(
+  path.resolve(process.cwd(), 'public/sync-bridge.html'),
+  'utf8'
+);
+const BRIDGE_SCRIPT = BRIDGE_HTML.match(/<script>([\s\S]*?)<\/script>/)?.[1];
+
+function createBridgeHarness({
+  requestOrigin = 'https://nexasphere-glbajaj.vercel.app',
+  storage = {},
+} = {}) {
+  const listeners = new Map();
+  const postedMessages = [];
+  const parent = {
+    postMessage: (message, targetOrigin) => {
+      postedMessages.push({ message, targetOrigin });
+    },
+  };
+  const localStorage = {
+    getItem: (key) => (Object.hasOwn(storage, key) ? storage[key] : null),
+  };
+  const window = {
+    location: {
+      origin: 'https://admin.nexasphere.example',
+    },
+    parent,
+    addEventListener: (type, handler) => {
+      listeners.set(type, handler);
+    },
+  };
+
+  vm.runInNewContext(BRIDGE_SCRIPT, {
+    console,
+    localStorage,
+    URL,
+    window,
+  });
+
+  return {
+    postedMessages,
+    sendMessage(data, origin = requestOrigin, source = parent) {
+      listeners.get('message')?.({ data, origin, source });
+    },
+    sendStorageEvent(key, newValue) {
+      listeners.get('storage')?.({ key, newValue });
+    },
+  };
+}
+
+describe('sync bridge security boundary', () => {
+  test('does not disclose admin localStorage keys to untrusted origins', () => {
+    const bridge = createBridgeHarness({
+      requestOrigin: 'https://evil.example',
+      storage: {
+        ns_admin_token: 'secret-admin-token',
+      },
+    });
+
+    bridge.sendMessage({ type: 'ns-sync', key: 'ns_admin_token' });
+
+    expect(bridge.postedMessages).toEqual([]);
+  });
+
+  test('does not relay disallowed keys even for trusted origins', () => {
+    const bridge = createBridgeHarness({
+      storage: {
+        ns_admin_token: 'secret-admin-token',
+      },
+    });
+
+    bridge.sendMessage({ type: 'ns-sync', key: 'ns_admin_token' });
+
+    expect(bridge.postedMessages).toEqual([]);
+  });
+
+  test('relays allowed content keys to trusted origins with a pinned target origin', () => {
+    const bridge = createBridgeHarness({
+      storage: {
+        ns_db_events: '[{"id":"event-1"}]',
+      },
+    });
+
+    bridge.sendMessage({ type: 'ns-sync', key: 'ns_db_events' });
+
+    expect(bridge.postedMessages).toEqual([
+      {
+        targetOrigin: 'https://nexasphere-glbajaj.vercel.app',
+        message: {
+          type: 'ns-content-updated',
+          key: 'ns_db_events',
+          value: '[{"id":"event-1"}]',
+        },
+      },
+    ]);
+  });
+
+  test('preserves same-origin admin sync requests for allowed content keys', () => {
+    const bridge = createBridgeHarness({
+      requestOrigin: 'https://admin.nexasphere.example',
+      storage: {
+        ns_db_announcements: '[{"id":"announcement-1"}]',
+      },
+    });
+
+    bridge.sendMessage({ type: 'ns-sync', key: 'ns_db_announcements' });
+
+    expect(bridge.postedMessages).toEqual([
+      {
+        targetOrigin: 'https://admin.nexasphere.example',
+        message: {
+          type: 'ns-content-updated',
+          key: 'ns_db_announcements',
+          value: '[{"id":"announcement-1"}]',
+        },
+      },
+    ]);
+  });
+
+  test('relays storage updates only after a trusted parent handshake', () => {
+    const bridge = createBridgeHarness({
+      storage: {
+        ns_db_events: '[]',
+      },
+    });
+
+    bridge.sendStorageEvent('ns_db_events', '[{"id":"before-handshake"}]');
+    expect(bridge.postedMessages).toEqual([]);
+
+    bridge.sendMessage({ type: 'ns-sync', key: 'ns_db_events' });
+    bridge.postedMessages.length = 0;
+    bridge.sendStorageEvent('ns_db_core_team', '[{"id":"member-1"}]');
+
+    expect(bridge.postedMessages).toEqual([
+      {
+        targetOrigin: 'https://nexasphere-glbajaj.vercel.app',
+        message: {
+          type: 'ns-content-updated',
+          key: 'ns_db_core_team',
+          value: '[{"id":"member-1"}]',
+        },
+      },
+    ]);
+  });
+});

--- a/admin-dashboard/src/services/api.js
+++ b/admin-dashboard/src/services/api.js
@@ -254,7 +254,7 @@ function notifyContentUpdated(key) {
   // Post to the sync-bridge iframe embedded by the website
   const bridge = document.querySelector('iframe[title="NexaSphere Sync Bridge"]');
   if (bridge?.contentWindow) {
-    bridge.contentWindow.postMessage({ type: 'ns-sync', key }, '*');
+    bridge.contentWindow.postMessage({ type: 'ns-sync', key }, window.location.origin);
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "admin-dashboard"
       ],
       "dependencies": {
-        "jwt-decode": "^4.0.0"
+        "jwt-decode": "^4.0.0",
         "lru-cache": "^11.5.1"
       },
       "devDependencies": {

--- a/website/src/__tests__/publicContentStore.bridge.test.js
+++ b/website/src/__tests__/publicContentStore.bridge.test.js
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('public content storage bridge receiver', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv('VITE_ADMIN_DASHBOARD_URL', 'https://admin.nexasphere.example');
+    document.documentElement.innerHTML = '<head></head><body></body>';
+    localStorage.clear();
+  });
+
+  test('accepts only allowed content keys from the configured admin bridge iframe', async () => {
+    const { initStorageSyncBridge } = await import('../utils/publicContentStore.js');
+
+    initStorageSyncBridge();
+
+    const bridge = document.querySelector('iframe[title="NexaSphere Sync Bridge"]');
+    const bridgeWindow = bridge.contentWindow;
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://evil.example',
+        source: bridgeWindow,
+        data: {
+          type: 'ns-content-updated',
+          key: 'ns_db_events',
+          value: '[{"id":"evil-origin"}]',
+        },
+      })
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://admin.nexasphere.example',
+        source: window,
+        data: {
+          type: 'ns-content-updated',
+          key: 'ns_db_events',
+          value: '[{"id":"wrong-source"}]',
+        },
+      })
+    );
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://admin.nexasphere.example',
+        source: bridgeWindow,
+        data: {
+          type: 'ns-content-updated',
+          key: 'ns_admin_token',
+          value: 'secret-admin-token',
+        },
+      })
+    );
+
+    expect(localStorage.getItem('ns_db_events')).toBeNull();
+    expect(localStorage.getItem('ns_admin_token')).toBeNull();
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        origin: 'https://admin.nexasphere.example',
+        source: bridgeWindow,
+        data: {
+          type: 'ns-content-updated',
+          key: 'ns_db_events',
+          value: '[{"id":"event-1"}]',
+        },
+      })
+    );
+
+    expect(localStorage.getItem('ns_db_events')).toBe('[{"id":"event-1"}]');
+  });
+});

--- a/website/src/utils/publicContentStore.js
+++ b/website/src/utils/publicContentStore.js
@@ -1,5 +1,15 @@
 const EVENTS_KEY = 'ns_db_events';
 const TEAM_KEY = 'ns_db_core_team';
+const ANNOUNCEMENTS_KEY = 'ns_db_announcements';
+const ALLOWED_BRIDGE_KEYS = new Set([EVENTS_KEY, TEAM_KEY, ANNOUNCEMENTS_KEY]);
+
+function normalizeOrigin(value) {
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
 
 function safeJsonParse(value, fallback) {
   if (!value) return fallback;
@@ -149,9 +159,10 @@ export function initStorageSyncBridge() {
   // Read admin origin from VITE_ADMIN_DASHBOARD_URL — already defined in
   // .env.example for both local dev and production deployments.
   // Falls back to http://localhost:5001 only when running locally.
-  const adminOrigin =
+  const configuredAdminOrigin =
     (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ADMIN_DASHBOARD_URL) ||
     'http://localhost:5001';
+  const adminOrigin = normalizeOrigin(configuredAdminOrigin) || 'http://localhost:5001';
   const bridgeUrl = `${adminOrigin}/sync-bridge.html`;
 
   // Check if we're in a cross-origin context (different port)
@@ -162,10 +173,14 @@ export function initStorageSyncBridge() {
   iframe.src = bridgeUrl;
   iframe.style.cssText = 'position:fixed;width:0;height:0;border:0;opacity:0;pointer-events:none;';
   iframe.setAttribute('aria-hidden', 'true');
+  iframe.setAttribute('title', 'NexaSphere Sync Bridge');
   iframe.tabIndex = -1;
 
   iframe.onload = () => {
     console.log('[StorageSync] Bridge iframe loaded from', adminOrigin);
+    ALLOWED_BRIDGE_KEYS.forEach((key) => {
+      iframe.contentWindow?.postMessage({ type: 'ns-sync', key }, adminOrigin);
+    });
   };
 
   iframe.onerror = () => {
@@ -176,7 +191,13 @@ export function initStorageSyncBridge() {
 
   // Listen for messages relayed through the bridge
   window.addEventListener('message', (event) => {
-    if (event.data && event.data.type === 'ns-content-updated' && event.data.key) {
+    if (event.origin !== adminOrigin || event.source !== iframe.contentWindow) return;
+
+    if (
+      event.data &&
+      event.data.type === 'ns-content-updated' &&
+      ALLOWED_BRIDGE_KEYS.has(event.data.key)
+    ) {
       // Update our own localStorage to match the admin's
       if (event.data.value !== null) {
         localStorage.setItem(event.data.key, event.data.value);


### PR DESCRIPTION
# Summary

Hardened the cross-origin content sync bridge so it no longer acts as an arbitrary localStorage read primitive.

@Ayushh-Sharmaa please review when convenient; this fixes the assigned security issue #1583.

## Related Issue
Fixes #1583

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] Infrastructure
- [x] Integration

## Changes Implemented

- Added an explicit bridge key allowlist for public content sync keys only:
  - `ns_db_events`
  - `ns_db_core_team`
  - `ns_db_announcements`
- Rejects untrusted `postMessage` senders and disallowed keys such as `ns_admin_token`.
- Pins bridge responses to the validated parent origin instead of using `*`.
- Requires storage-event relays to happen only after a trusted parent handshake.
- Hardened the website receiver to validate message origin, iframe source, and allowed key before writing localStorage.
- Added focused regression coverage for the bridge and website receiver.
- Fixed a one-character root `package-lock.json` JSON syntax issue so package tooling can parse the synced branch.

## Technical Details

### Frontend

- `admin-dashboard/public/sync-bridge.html` now enforces origin/source/key checks before reading localStorage.
- `website/src/utils/publicContentStore.js` now validates bridge messages before accepting synced data.
- `admin-dashboard/src/services/api.js` no longer sends sync messages with wildcard target origin.

### Backend

Not applicable.

### Database

Not applicable.

### API

No API contract changes.

### Infrastructure

No deployment config changes. The static bridge cannot read Vite env at runtime, so trusted parent origins are intentionally limited to the documented production website origin plus local development website origins.

## Screenshots

### Before

Not applicable; this is a security/message-handling fix.

### After

Not applicable; this is a security/message-handling fix.

## Testing

### Unit Tests
- [x] `cd admin-dashboard && npm run test -- syncBridge.test.js`
- [x] `cd admin-dashboard && npm run test`
- [x] `cd website && npm run test -- publicContentStore.bridge.test.js`

### Integration Tests
- [x] Bridge/receiver contract covered by focused cross-origin `postMessage` regression tests.

### E2E Tests
- [ ] Not run; this change is covered by focused bridge/receiver tests and package builds.

### Manual Testing
- [x] `cd admin-dashboard && npm run build`
- [x] `cd website && npm run build`
- [x] `grep -RIn "postMessage(.*['\"]\\*['\"]" admin-dashboard/public admin-dashboard/src website/src`
- [x] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); JSON.parse(require('fs').readFileSync('package-lock.json','utf8')); console.log('root package files parse')"`

## Security Review

- The original exploit path no longer succeeds: untrusted parents cannot request `ns_admin_token`, trusted parents cannot request disallowed keys, and bridge replies are no longer sent to `*`.
- Website-side writes now require the configured admin origin, the bridge iframe `contentWindow`, and an allowed public content key.
- Token storage itself is intentionally not changed here because it is tracked separately in #1476.

## Accessibility Review

No user-facing UI changes. The hidden iframe remains `aria-hidden`.

## Performance Impact

Negligible. The new checks are constant-time set/origin checks around existing bridge messages.

## Breaking Changes
- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

The trusted-origin list is deliberately narrow because `sync-bridge.html` is a static public file. If additional production website origins are introduced, they should be added explicitly rather than accepting arbitrary parent origins.

## Rollback Plan

Revert this PR to restore the previous bridge behavior if any unexpected sync regression appears.

## Checklist
- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review
