### PR TITLE
security: protect dashboard profile and quest access

### DIFF
--- a/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
+++ b/server-java/src/main/java/org/nexasphere/config/SecurityConfig.java
@@ -74,6 +74,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/admin/login").permitAll()
                         .requestMatchers("/api/content/**").permitAll()
                         .requestMatchers("/api/public/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/dashboard/leaderboard").permitAll()
+                        .requestMatchers("/api/dashboard/**").authenticated()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html").permitAll()
                         .requestMatchers("/api/admin/**").authenticated()

--- a/server-java/src/main/java/org/nexasphere/controller/DashboardController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/DashboardController.java
@@ -5,10 +5,11 @@ import org.nexasphere.model.entity.UserProfileEntity;
 import org.nexasphere.repository.QuestRepository;
 import org.nexasphere.repository.UserProfileRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,6 +20,8 @@ import java.util.Optional;
 @RequestMapping("/api/dashboard")
 public class DashboardController {
 
+    private static final String DEDICATED_LEARNER_BADGE = "Dedicated Learner";
+
     @Autowired
     private UserProfileRepository userProfileRepository;
 
@@ -26,21 +29,26 @@ public class DashboardController {
     private QuestRepository questRepository;
 
     @GetMapping("/profile/{userId}")
-    public ResponseEntity<UserProfileEntity> getProfile(@PathVariable String userId) {
-        Optional<UserProfileEntity> profile = userProfileRepository.findByUserId(userId);
-        if (profile.isPresent()) {
-            return ResponseEntity.ok(profile.get());
-        } else {
-            // Create a default profile if not exists
-            UserProfileEntity newProfile = new UserProfileEntity();
-            newProfile.setUserId(userId);
-            newProfile.setUsername("User " + userId.substring(0, Math.min(4, userId.length())));
-            return ResponseEntity.ok(userProfileRepository.save(newProfile));
+    public ResponseEntity<?> getProfile(@PathVariable String userId, Authentication authentication) {
+        if (!isDashboardOwner(authentication, userId)) {
+            return forbidden();
         }
+
+        return userProfileRepository.findByUserId(userId)
+                .map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     @PostMapping("/profile/{userId}/interests")
-    public ResponseEntity<UserProfileEntity> updateInterests(@PathVariable String userId, @RequestBody List<String> interests) {
+    public ResponseEntity<?> updateInterests(
+            @PathVariable String userId,
+            @RequestBody List<String> interests,
+            Authentication authentication
+    ) {
+        if (!isDashboardOwner(authentication, userId)) {
+            return forbidden();
+        }
+
         Optional<UserProfileEntity> profileOpt = userProfileRepository.findByUserId(userId);
         if (profileOpt.isPresent()) {
             UserProfileEntity profile = profileOpt.get();
@@ -56,57 +64,32 @@ public class DashboardController {
     }
 
     @GetMapping("/quests/{userId}")
-    public ResponseEntity<List<QuestEntity>> getQuests(@PathVariable String userId) {
+    public ResponseEntity<?> getQuests(@PathVariable String userId, Authentication authentication) {
+        if (!isDashboardOwner(authentication, userId)) {
+            return forbidden();
+        }
+
         List<QuestEntity> quests = questRepository.findByUserId(userId);
         if (quests.isEmpty()) {
-            // Seed some initial quests for the user if none exist
-            QuestEntity q1 = new QuestEntity();
-            q1.setUserId(userId);
-            q1.setTitle("View Roadmap");
-            q1.setDescription("Check out our learning roadmaps.");
-            q1.setXpReward(50);
-            
-            QuestEntity q2 = new QuestEntity();
-            q2.setUserId(userId);
-            q2.setTitle("Join Hackathon");
-            q2.setDescription("Participate in an upcoming hackathon event.");
-            q2.setXpReward(200);
-
-            List<QuestEntity> seeds = new ArrayList<>();
-            seeds.add(q1);
-            seeds.add(q2);
-            questRepository.saveAll(seeds);
-            quests = questRepository.findByUserId(userId);
+            quests = seedInitialQuests(userId);
         }
         return ResponseEntity.ok(quests);
     }
 
     @PostMapping("/quests/{questId}/complete")
-    public ResponseEntity<Map<String, Object>> completeQuest(@PathVariable String questId) {
+    public ResponseEntity<?> completeQuest(@PathVariable String questId, Authentication authentication) {
         String safeQuestId = Objects.requireNonNull(questId, "questId must not be null");
         Optional<QuestEntity> questOpt = questRepository.findById(safeQuestId);
         if (questOpt.isPresent()) {
             QuestEntity quest = questOpt.get();
+            if (!isDashboardOwner(authentication, quest.getUserId())) {
+                return forbidden();
+            }
+
             if (!quest.isCompleted()) {
                 quest.setCompleted(true);
                 questRepository.save(quest);
-
-                // Add XP to user profile
-                Optional<UserProfileEntity> profileOpt = userProfileRepository.findByUserId(quest.getUserId());
-                if (profileOpt.isPresent()) {
-                    UserProfileEntity profile = profileOpt.get();
-                    profile.setXp(profile.getXp() + quest.getXpReward());
-                    
-                    // Simple level up logic
-                    if (profile.getXp() >= profile.getLevel() * 1000) {
-                        profile.setLevel(profile.getLevel() + 1);
-                        // Grant a badge potentially
-                        if (profile.getLevel() == 5 && !profile.getBadges().contains("Dedicated Learner")) {
-                            profile.getBadges().add("Dedicated Learner");
-                        }
-                    }
-                    userProfileRepository.save(profile);
-                }
+                awardQuestCompletion(quest);
             }
             Map<String, Object> response = new HashMap<>();
             response.put("success", true);
@@ -114,5 +97,56 @@ public class DashboardController {
             return ResponseEntity.ok(response);
         }
         return ResponseEntity.notFound().build();
+    }
+
+    private List<QuestEntity> seedInitialQuests(String userId) {
+        QuestEntity viewRoadmap = defaultQuest(
+                userId,
+                "View Roadmap",
+                "Check out our learning roadmaps.",
+                50
+        );
+        QuestEntity joinHackathon = defaultQuest(
+                userId,
+                "Join Hackathon",
+                "Participate in an upcoming hackathon event.",
+                200
+        );
+
+        return questRepository.saveAll(List.of(viewRoadmap, joinHackathon));
+    }
+
+    private QuestEntity defaultQuest(String userId, String title, String description, int xpReward) {
+        QuestEntity quest = new QuestEntity();
+        quest.setUserId(userId);
+        quest.setTitle(title);
+        quest.setDescription(description);
+        quest.setXpReward(xpReward);
+        return quest;
+    }
+
+    private void awardQuestCompletion(QuestEntity quest) {
+        userProfileRepository.findByUserId(quest.getUserId()).ifPresent(profile -> {
+            profile.setXp(profile.getXp() + quest.getXpReward());
+
+            if (profile.getXp() >= profile.getLevel() * 1000) {
+                profile.setLevel(profile.getLevel() + 1);
+                if (profile.getLevel() == 5 && !profile.getBadges().contains(DEDICATED_LEARNER_BADGE)) {
+                    profile.getBadges().add(DEDICATED_LEARNER_BADGE);
+                }
+            }
+            userProfileRepository.save(profile);
+        });
+    }
+
+    private boolean isDashboardOwner(Authentication authentication, String userId) {
+        return authentication != null
+                && authentication.isAuthenticated()
+                && userId != null
+                && userId.equals(authentication.getName());
+    }
+
+    private ResponseEntity<Void> forbidden() {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
     }
 }

--- a/server-java/src/test/java/org/nexasphere/controller/DashboardControllerSecurityTest.java
+++ b/server-java/src/test/java/org/nexasphere/controller/DashboardControllerSecurityTest.java
@@ -1,0 +1,172 @@
+package org.nexasphere.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.nexasphere.model.entity.QuestEntity;
+import org.nexasphere.model.entity.UserProfileEntity;
+import org.nexasphere.repository.QuestRepository;
+import org.nexasphere.repository.UserProfileRepository;
+import org.nexasphere.service.TokenService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DashboardControllerSecurityTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private TokenService tokenService;
+
+    @Autowired
+    private UserProfileRepository userProfileRepository;
+
+    @Autowired
+    private QuestRepository questRepository;
+
+    @BeforeEach
+    void cleanDatabase() {
+        questRepository.deleteAll();
+        userProfileRepository.deleteAll();
+    }
+
+    @Test
+    void profileAndQuestEndpointsRejectUnauthenticatedRequests() throws Exception {
+        mockMvc.perform(get("/api/dashboard/profile/victim-user"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/dashboard/profile/victim-user/interests")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of("security"))))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/dashboard/quests/victim-user"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/dashboard/quests/quest-1/complete"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void profileAndQuestEndpointsRejectCrossUserRequests() throws Exception {
+        mockMvc.perform(get("/api/dashboard/profile/victim-user")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/dashboard/profile/victim-user/interests")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of("tampered"))))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/dashboard/quests/victim-user")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isForbidden());
+
+        assertThat(userProfileRepository.findByUserId("victim-user")).isEmpty();
+        assertThat(questRepository.findByUserId("victim-user")).isEmpty();
+    }
+
+    @Test
+    void ownerProfileReadDoesNotCreateMissingProfiles() throws Exception {
+        mockMvc.perform(get("/api/dashboard/profile/owner-user")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isNotFound());
+
+        assertThat(userProfileRepository.findByUserId("owner-user")).isEmpty();
+    }
+
+    @Test
+    void ownerCanReadAndUpdateOnlyTheirDashboardData() throws Exception {
+        UserProfileEntity ownerProfile = new UserProfileEntity();
+        ownerProfile.setUserId("owner-user");
+        ownerProfile.setUsername("Owner");
+        userProfileRepository.save(ownerProfile);
+
+        mockMvc.perform(get("/api/dashboard/profile/owner-user")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userId").value("owner-user"));
+
+        mockMvc.perform(post("/api/dashboard/profile/owner-user/interests")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(List.of("java", "security"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.interests[0]").value("java"))
+                .andExpect(jsonPath("$.interests[1]").value("security"));
+
+        String questsResponse = mockMvc.perform(get("/api/dashboard/quests/owner-user")
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].userId").value("owner-user"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        JsonNode quests = objectMapper.readTree(questsResponse);
+        String questId = quests.get(0).get("id").asText();
+
+        mockMvc.perform(post("/api/dashboard/quests/{questId}/complete", questId)
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("owner-user")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.quest.completed").value(true));
+
+        UserProfileEntity profile = userProfileRepository.findByUserId("owner-user").orElseThrow();
+        assertThat(profile.getXp()).isGreaterThan(0);
+    }
+
+    @Test
+    void questCompletionRejectsTokensForOtherUsersWithoutMutatingProgress() throws Exception {
+        UserProfileEntity victimProfile = new UserProfileEntity();
+        victimProfile.setUserId("victim-user");
+        victimProfile.setUsername("Victim");
+        userProfileRepository.save(victimProfile);
+
+        QuestEntity victimQuest = new QuestEntity();
+        victimQuest.setUserId("victim-user");
+        victimQuest.setTitle("Protected quest");
+        victimQuest.setDescription("Must only be completed by the owner");
+        victimQuest.setXpReward(75);
+        victimQuest = questRepository.save(victimQuest);
+
+        mockMvc.perform(post("/api/dashboard/quests/{questId}/complete", victimQuest.getId())
+                        .header(HttpHeaders.AUTHORIZATION, bearerFor("attacker-user")))
+                .andExpect(status().isForbidden());
+
+        QuestEntity reloadedQuest = questRepository.findById(victimQuest.getId()).orElseThrow();
+        UserProfileEntity reloadedProfile = userProfileRepository.findByUserId("victim-user").orElseThrow();
+        assertThat(reloadedQuest.isCompleted()).isFalse();
+        assertThat(reloadedProfile.getXp()).isZero();
+    }
+
+    @Test
+    void leaderboardRemainsPublicReadOnlyDashboardData() throws Exception {
+        mockMvc.perform(get("/api/dashboard/leaderboard"))
+                .andExpect(status().isOk());
+    }
+
+    private String bearerFor(String subject) {
+        return "Bearer " + tokenService.createSession(subject).token();
+    }
+}


### PR DESCRIPTION
# Summary

Locks down the Java dashboard profile and quest APIs so user-specific dashboard data can only be read or mutated by the authenticated owner. The public leaderboard remains readable.

## Description

This refactor keeps PR #1686 focused on the two assigned security issues. It removes the earlier package/dependency/migration conflict surface and leaves the branch with only the Java dashboard authorization fix plus focused regression coverage.

Closes #1594
Closes #1604

## Related Issue
Closes #1594
Closes #1604

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Require authentication for `/api/dashboard/**` except `GET /api/dashboard/leaderboard`.
- Bind profile reads, interest updates, quest listing, and quest completion to `Authentication#getName()`.
- Verify quest ownership before marking a quest complete or awarding XP.
- Stop `GET /api/dashboard/profile/{userId}` from creating a missing profile as a side effect.
- Add dashboard authorization regression tests for unauthenticated requests, cross-user requests, owner success paths, no-mutation rejected paths, missing-profile reads, and public leaderboard access.

## Technical Details

### Frontend

No frontend changes.

### Backend

`SecurityConfig` now permits only the read-only leaderboard under `/api/dashboard/**`; every other dashboard route requires a bearer token.

`DashboardController` now uses a shared owner check before touching user-scoped profile or quest state. Quest completion checks the stored quest owner before any completion or XP mutation occurs.

### Database

No schema or migration changes.

### API

- `GET /api/dashboard/profile/{userId}` returns `401` without a token, `403` for another user's token, `404` for an authenticated owner without a profile, and `200` for an existing owner profile.
- `POST /api/dashboard/profile/{userId}/interests` requires the authenticated owner.
- `GET /api/dashboard/quests/{userId}` requires the authenticated owner.
- `POST /api/dashboard/quests/{questId}/complete` requires the authenticated quest owner.
- `GET /api/dashboard/leaderboard` remains public.

### Infrastructure

No package, lockfile, JSON, workflow, dependency, or deployment metadata changes.

## Screenshots

### Before

Not applicable; this is a backend API authorization fix.

### After

Not applicable; this is a backend API authorization fix.

## Testing

### Unit Tests
- [x] `JAVA_HOME=/tmp/codex-jdks/openjdk17-deb/usr/lib/jvm/java-17-openjdk-amd64 PATH="/tmp/codex-jdks/openjdk17-deb/usr/lib/jvm/java-17-openjdk-amd64/bin:$PATH" bash mvnw -ntp test -Dtest=DashboardControllerSecurityTest`
      Result: 6 tests, 0 failures, build success.

### Integration Tests
- [x] `DashboardControllerSecurityTest` exercises Spring Security and controller behavior together through MockMvc.

### E2E Tests
- [ ] Not run; this is covered by focused backend authorization regression tests.

### Manual Testing
- [x] `git diff HEAD --check`
- [x] Sub-agent spec review confirmed the diff is limited to the issue-scoped Java dashboard authorization files.
- [x] Sub-agent code-quality review found no critical or important issues in the net diff.

## Security Review

- Profile and quest APIs now reject unauthenticated calls before controller mutation paths run.
- Cross-user profile and quest calls return `403`.
- Quest completion checks the stored quest owner before setting `completed` or updating XP.
- Missing owner profile reads return `404` instead of creating profiles from `GET`.
- Leaderboard remains public because it returns read-only aggregate data.

## Accessibility Review

No user-facing UI changes.

## Performance Impact

Negligible. The new checks are constant-time authentication subject comparisons before existing repository work.

## Breaking Changes
- [ ] No Breaking Changes
- [x] Breaking Changes Documented

Dashboard profile and quest endpoints now require a bearer token whose subject matches the requested or stored dashboard owner. Missing profile reads now return `404` instead of creating profile records from `GET`.

## Deployment Notes

Deploy the Java service with the existing bearer-token filter enabled. No package install, database migration, or environment change is required.

## Rollback Plan

Revert this commit if an unexpected dashboard API regression appears. Rolling back would reopen #1594 and #1604, so a forward fix is preferred.

## Checklist
- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review
