### PR TITLE
fix: reset JoinRequestModal form state on reopen

### DIFF
--- a/website/src/components/collab/JoinRequestModal.jsx
+++ b/website/src/components/collab/JoinRequestModal.jsx
@@ -10,7 +10,16 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   const [github, setGithub] = useState('');
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
-
+  const resetForm = () => {
+    setPitch('');
+    setSkills('');
+    setGithub('');
+    setSuccess(false);
+  };
+  const handleClose = () => {
+    resetForm();
+    onClose();
+  };
   // Store the element that triggered the modal so focus can be
   // returned to it when the modal closes.
   const triggerRef = useRef(document.activeElement);
@@ -34,7 +43,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   useEffect(() => {
     const handleKeyDown = (e) => {
       if (e.key === 'Escape') {
-        onClose();
+        handleClose();
         return;
       }
 
@@ -67,20 +76,26 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   }, [onClose]);
 
   useEffect(() => {
-  if (modalRef.current) {
-    const firstFocusable = modalRef.current.querySelector(
-      'button, input, textarea, select, a[href]'
-    );
+    if (modalRef.current) {
+      const firstFocusable = modalRef.current.querySelector(
+        'button, input, textarea, select, a[href]'
+      );
 
-    firstFocusable?.focus();
-  }
-}, []);
+      firstFocusable?.focus();
+    }
+  }, []);
+  useEffect(() => {
+    resetForm();
+  }, [team?.id]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     setLoading(true);
     try {
       await onSubmit({ pitch, skills, github, teamId: team.id });
+      setPitch('');
+      setSkills('');
+      setGithub('');
       setSuccess(true);
     } catch (err) {
       console.error(err);
@@ -126,7 +141,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
               Join {team?.name}
             </h2>
             <button
-              onClick={onClose}
+              onClick={handleClose}
               style={{
                 background: 'transparent',
                 border: 'none',
@@ -140,11 +155,11 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
             </button>
           </div>
           <p
-  id="modal-description"
-  style={{ margin: '8px 0 0 0', color: 'var(--c1)', fontSize: '0.9rem' }}
->
-  Pitch yourself for the {team?.vacantRoles?.join(', ')} role(s)
-</p>
+            id="modal-description"
+            style={{ margin: '8px 0 0 0', color: 'var(--c1)', fontSize: '0.9rem' }}
+          >
+            Pitch yourself for the {team?.vacantRoles?.join(', ')} role(s)
+          </p>
         </div>
 
         <div style={{ padding: '24px' }}>
@@ -170,7 +185,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
                 The team leader will be notified.
               </p>
               <button
-                onClick={onClose}
+                onClick={handleClose}
                 autoFocus
                 style={{
                   marginTop: '20px',
@@ -286,7 +301,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
               <div style={{ display: 'flex', gap: '12px', marginTop: '16px' }}>
                 <button
                   type="button"
-                  onClick={onClose}
+                  onClick={handleClose}
                   style={{
                     flex: 1,
                     padding: '12px',


### PR DESCRIPTION
## Description

This PR fixes an issue where the JoinRequestModal retained previously entered form data after being closed and reopened.

The form state is now reset whenever the modal is closed or when a different team is selected, ensuring users always start with a fresh form and preventing accidental submission of outdated information.

Fixes #1466

## Type of Change

* [ ] Feature
* [x] Bug Fix
* [x] UI/UX Improvement
* [ ] Performance Optimization
* [ ] Security Enhancement
* [ ] Refactoring
* [ ] Documentation
* [ ] Testing
* [ ] Infrastructure
* [ ] Integration

## Changes Implemented

* Added a reusable form reset helper.
* Cleared form state when the modal is closed.
* Reset form values when opening the modal for a different team.
* Cleared submission success state on modal reopen.
* Prevented stale user input from persisting between modal sessions.

## Technical Details

### Frontend

* Updated `website/src/components/collab/JoinRequestModal.jsx`
* Added `resetForm()` utility function.
* Added `handleClose()` wrapper to reset state before closing.
* Added `useEffect()` to reset form when the selected team changes.

### Backend

* No backend changes required.

### Database

* No database changes required.

### API

* No API changes required.

### Infrastructure

* No infrastructure changes required.

## Screenshots

### Before

* Form fields retained previously entered values after closing and reopening the modal.
* Users could accidentally submit outdated information.

### After

* Form fields are reset whenever the modal is reopened.
* Users always start with a clean form state.

## Testing

### Unit Tests

* [ ] Not applicable

### Integration Tests

* [ ] Not applicable

### E2E Tests

* [ ] Not applicable

### Manual Testing

* [x] Opened modal and entered form data.
* [x] Closed modal without submitting.
* [x] Reopened modal and verified fields were cleared.
* [x] Opened modal for a different team and verified fresh form state.
* [x] Submitted form successfully and verified state resets correctly.

## Security Review

* No security impact.

## Accessibility Review

* Improves usability by ensuring predictable modal behavior.

## Performance Impact

* Negligible impact. Reset logic only runs when the modal closes or team selection changes.

## Breaking Changes

* [x] No Breaking Changes
* [ ] Breaking Changes Documented

## Deployment Notes

* No special deployment steps required.

## Rollback Plan

* Revert the form reset logic added to `JoinRequestModal.jsx`.

## Checklist

* [x] Code follows project standards
* [ ] Tests added or updated
* [ ] Documentation updated
* [x] Security reviewed
* [x] Accessibility reviewed
* [x] Performance validated
* [ ] CI/CD passing
* [x] Ready for review
