### PR TITLE
fix: prevent Redis crash on startup when REDIS_URL is not configured

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -50,20 +50,24 @@ export function initializeSocketIO(httpServer) {
     reconnectionAttempts: 5,
   });
 
-  if (process.env.REDIS_URL) {
+  const pubClient = getRedisClient();
+  if (pubClient) {
     try {
-      const pubClient = getRedisClient();
       const subClient = pubClient.duplicate();
       io.adapter(createAdapter(pubClient, subClient));
-      logger.info('Socket.IO configured with Redis Adapter for horizontal scaling.');
+      logger.info('Socket.IO using Redis adapter for horizontal scaling.');
     } catch (err) {
       logger.error('Failed to configure Socket.IO Redis adapter:', err);
+      logger.info('Socket.IO falling back to in-memory adapter.');
     }
+  } else {
+    logger.info('Socket.IO using in-memory adapter (REDIS_URL not set).');
   }
 
   // Connection auth middleware — checks handshake auth token
   io.use(async (socket, next) => {
-    const token = socket.handshake.auth?.token || parseBearer(socket.handshake.headers?.authorization);
+    const token =
+      socket.handshake.auth?.token || parseBearer(socket.handshake.headers?.authorization);
     if (token) {
       try {
         const session = await getAdminSession(token);
@@ -109,7 +113,9 @@ export function _onConnection(socket) {
     // 1. Enforce Per-Socket Identification Rate Limiting
     identifyCount++;
     if (identifyCount > 3) {
-      logger.warn('Socket identification flood detected, forcing disconnect', { socketId: socket.id });
+      logger.warn('Socket identification flood detected, forcing disconnect', {
+        socketId: socket.id,
+      });
       socket.disconnect(true);
       return;
     }
@@ -124,7 +130,9 @@ export function _onConnection(socket) {
 
     // Validate fields exist and are strictly primitive strings
     if (typeof userId !== 'string' || typeof email !== 'string') {
-      logger.warn('User identification payload fields must be primitive strings', { socketId: socket.id });
+      logger.warn('User identification payload fields must be primitive strings', {
+        socketId: socket.id,
+      });
       return;
     }
 
@@ -141,7 +149,7 @@ export function _onConnection(socket) {
       socketId: String(socket.id),
       connectedAt: new Date(),
     });
-        
+
     logger.info('User identified successfully', { userId: String(userId), socketId: socket.id });
   });
 
@@ -170,7 +178,7 @@ export function _onConnection(socket) {
     }
 
     // 4. Per-Socket Bounded Active Rooms Cap (Set size check)
-    const joinedCount = socket.rooms ? (socket.rooms.size - 1) : 0;
+    const joinedCount = socket.rooms ? socket.rooms.size - 1 : 0;
     if (joinedCount >= MAX_ROOMS_PER_SOCKET) {
       logger.warn('Socket joined rooms limit exceeded', { socketId: socket.id });
       return socket.emit('room:join:error', { error: 'Maximum room subscription limit reached' });
@@ -191,12 +199,15 @@ export function _onConnection(socket) {
   socket.on('join_room', (roomId, user) => {
     // 1. Primitive Type & Structure Regex Validation (UUID/ObjectId/Workspace Name)
     if (typeof roomId !== 'string' || !/^[a-zA-Z0-9\-_]{1,100}$/.test(roomId)) {
-      logger.warn('Malformed workspace roomId join attempt rejected', { socketId: socket.id, roomId });
+      logger.warn('Malformed workspace roomId join attempt rejected', {
+        socketId: socket.id,
+        roomId,
+      });
       return;
     }
 
     // 2. Per-Socket Bounded Active Rooms Cap
-    const joinedCount = socket.rooms ? (socket.rooms.size - 1) : 0;
+    const joinedCount = socket.rooms ? socket.rooms.size - 1 : 0;
     if (joinedCount >= MAX_ROOMS_PER_SOCKET) {
       logger.warn('Socket workspace joined rooms limit exceeded', { socketId: socket.id });
       return;
@@ -225,15 +236,20 @@ export function _onConnection(socket) {
     logger.info('User joined workspace room', { socketId: socket.id, roomId });
 
     // Sanitize user details to prevent reference leaks / massive nested objects
-    const sanitizedUser = user && typeof user === 'object' ? {
-      id: typeof user.id === 'string' ? user.id.slice(0, 100) : undefined,
-      name: typeof user.name === 'string' ? user.name.slice(0, 100) : 'Anonymous',
-      email: typeof user.email === 'string' ? user.email.slice(0, 150) : '',
-      color: typeof user.color === 'string' ? user.color.slice(0, 50) : '#888',
-      initials: typeof user.initials === 'string' ? user.initials.slice(0, 2) : 'U',
-    } : { name: 'Anonymous', color: '#888', initials: 'U' };
+    const sanitizedUser =
+      user && typeof user === 'object'
+        ? {
+            id: typeof user.id === 'string' ? user.id.slice(0, 100) : undefined,
+            name: typeof user.name === 'string' ? user.name.slice(0, 100) : 'Anonymous',
+            email: typeof user.email === 'string' ? user.email.slice(0, 150) : '',
+            color: typeof user.color === 'string' ? user.color.slice(0, 50) : '#888',
+            initials: typeof user.initials === 'string' ? user.initials.slice(0, 2) : 'U',
+          }
+        : { name: 'Anonymous', color: '#888', initials: 'U' };
 
-    socket.to(roomId).emit('user_joined', { socketId: socket.id, user: sanitizedUser, timestamp: Date.now() });
+    socket
+      .to(roomId)
+      .emit('user_joined', { socketId: socket.id, user: sanitizedUser, timestamp: Date.now() });
   });
 
   // Leave workspace room
@@ -289,7 +305,10 @@ export function _onConnection(socket) {
     try {
       const session = await getAdminSession(token);
       if (!session) {
-        return socket.emit('admin:authenticated', { success: false, error: 'Invalid or expired token' });
+        return socket.emit('admin:authenticated', {
+          success: false,
+          error: 'Invalid or expired token',
+        });
       }
       socket.adminSession = session;
       socket.adminAuthenticated = true;
@@ -298,7 +317,10 @@ export function _onConnection(socket) {
       if (role && typeof role === 'string') {
         socket.join(`admin-room:${role}`);
       }
-      logger.info('Admin authenticated via socket event', { socketId: socket.id, username: session.username });
+      logger.info('Admin authenticated via socket event', {
+        socketId: socket.id,
+        username: session.username,
+      });
       socket.emit('admin:authenticated', { success: true });
     } catch (e) {
       logger.error('Admin authentication error', { error: e.message, socketId: socket.id });
@@ -353,7 +375,7 @@ export function emitToRoom(roomName, eventName, data) {
  */
 export function emitToUser(userId, eventName, data) {
   if (!io) return;
-  const user = Array.from(connectedUsers.values()).find(u => u.id === userId);
+  const user = Array.from(connectedUsers.values()).find((u) => u.id === userId);
   if (user) {
     io.to(user.socketId).emit(eventName, data);
     logger.debug('Emit to user', { userId, event: eventName });
@@ -442,4 +464,15 @@ export function emitToRole(roles, eventName, data) {
   logger.debug('Emit to role rooms', { rooms: [...targets], event: eventName });
 }
 
-export default { initializeSocketIO, getIO, broadcastEvent, emitToRoom, emitToUser, emitToRole, _clearConnectedUsers, _clearWorkspaceRoomMembers, _clearJoinRoomAttempts, _onConnection };
+export default {
+  initializeSocketIO,
+  getIO,
+  broadcastEvent,
+  emitToRoom,
+  emitToUser,
+  emitToRole,
+  _clearConnectedUsers,
+  _clearWorkspaceRoomMembers,
+  _clearJoinRoomAttempts,
+  _onConnection,
+};

--- a/server/utils/redis.js
+++ b/server/utils/redis.js
@@ -5,13 +5,16 @@ let redisClient = null;
 
 export function getRedisClient() {
   if (!redisClient) {
-    const redisUrl = process.env.REDIS_URL || 'redis://localhost:6379';
+    if (!process.env.REDIS_URL) {
+      return null;
+    }
+    const redisUrl = process.env.REDIS_URL;
     redisClient = new Redis(redisUrl);
-    
+
     redisClient.on('error', (err) => {
       logger.error('Redis connection error:', err);
     });
-    
+
     redisClient.on('connect', () => {
       logger.info('Connected to Redis');
     });
@@ -21,7 +24,11 @@ export function getRedisClient() {
 
 export async function getCachedQuery(key, queryFn, ttlSeconds = 300) {
   const client = getRedisClient();
-  
+
+  if (!client) {
+    return queryFn();
+  }
+
   // Try to read from cache first
   let cached = null;
   try {
@@ -32,44 +39,53 @@ export async function getCachedQuery(key, queryFn, ttlSeconds = 300) {
   } catch (err) {
     logger.warn('Redis cache read error, falling back to database query:', err);
   }
-  
+
   // Cache miss or Redis error — run queryFn exactly once
   const result = await queryFn();
-  
+
   // Best-effort cache write
   try {
-    client.set(key, JSON.stringify(result), 'EX', ttlSeconds).catch(err => {
+    client.set(key, JSON.stringify(result), 'EX', ttlSeconds).catch((err) => {
       logger.error('Error setting Redis cache:', err);
     });
   } catch (err) {
     logger.warn('Redis cache write error:', err);
   }
-  
+
   return result;
 }
 
 export function clearCache(keyPattern) {
   const client = getRedisClient();
-  
+
+  if (!client) {
+    return Promise.resolve(0);
+  }
+
   return new Promise((resolve, reject) => {
     const stream = client.scanStream({
       match: keyPattern,
-      count: 100
+      count: 100,
     });
-    
+
     let deletedCount = 0;
     const deletePromises = [];
-    
+
     stream.on('data', (resultKeys) => {
       if (resultKeys.length > 0) {
         // Delete in batches as they arrive to avoid unbounded memory usage
-        const promise = client.del(...resultKeys)
-          .then(count => { deletedCount += count; })
-          .catch(err => { logger.error('Error deleting cache keys batch:', err); });
+        const promise = client
+          .del(...resultKeys)
+          .then((count) => {
+            deletedCount += count;
+          })
+          .catch((err) => {
+            logger.error('Error deleting cache keys batch:', err);
+          });
         deletePromises.push(promise);
       }
     });
-    
+
     stream.on('end', async () => {
       try {
         await Promise.all(deletePromises);
@@ -78,7 +94,7 @@ export function clearCache(keyPattern) {
         reject(err);
       }
     });
-    
+
     stream.on('error', (err) => {
       reject(err);
     });


### PR DESCRIPTION
This PR resolves issue #1359 by ensuring the application gracefully falls back to in-memory mode when Redis is not available.

- `getRedisClient()` now returns `null` instead of attempting to connect to a default `localhost` instance if `REDIS_URL` is unset.
- Cache utilities (`getCachedQuery`, `clearCache`) safely handle a `null` client.
- Socket.IO correctly checks for a valid Redis client before duplicating it and configuring the `redis-adapter`.
- Startup logs clearly indicate whether the `in-memory` or `redis` adapter is active.

Fixes #1359
