### PR TITLE
fix: emit admin:waitlist-added instead of admin:waitlist-promotion on waitlist addition

### DIFF
--- a/server/controllers/eventRegistrationController.js
+++ b/server/controllers/eventRegistrationController.js
@@ -121,7 +121,7 @@ export const registerForEvent = wrapAsync(async (req, res) => {
         waitlist: true,
       });
       try {
-        emitToRole('events_admin', 'admin:waitlist-promotion', {
+        emitToRole('events_admin', 'admin:waitlist-added', {
           eventId,
           userName: sanitizedFullName,
           timestamp: new Date(),


### PR DESCRIPTION


# Summary
Wrong socket event `admin:waitlist-promotion` was being emitted when a user is added to the waitlist. Replaced with the correct event `admin:waitlist-added`.

## Related Issue
Closes #1350

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Changed `admin:waitlist-promotion` to `admin:waitlist-added` in `emitToRole` call at `server/controllers/eventRegistrationController.js` line 124

## Technical Details
### Backend
- `server/controllers/eventRegistrationController.js` — fixed incorrect socket event name emitted on waitlist addition

## Checklist
- [x] Code follows project standards
- [x] Ready for review