### PR TITLE
fix: capture total before slice to return accurate pagination count

### DIFF
--- a/server/controllers/searchController.js
+++ b/server/controllers/searchController.js
@@ -85,9 +85,10 @@ export const searchController = {
         results = [...results, ...matched];
       }
 
+      const trueTotal = results.length;
       results = results.slice(0, limit);
 
-      return res.json({ results, total: results.length, query: q });
+      return res.json({ results, total: trueTotal, query: q });
     } catch (err) {
       console.error('Search error:', err);
       return res.status(500).json({ error: 'Search failed', results: [], total: 0 });


### PR DESCRIPTION
# Summary
`total` in the search response was calculated after `results.slice(0, limit)`, making it always ≤ limit instead of the true match count. Captured `trueTotal` before slicing and returned that instead.

## Related Issue
Closes #1335

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `const trueTotal = results.length` before `results.slice(0, limit)` in `server/controllers/searchController.js`
- Changed `total: results.length` to `total: trueTotal` in the response

## Technical Details
### Backend
- `server/controllers/searchController.js` — fixed post-slice total calculation

## Checklist
- [x] Code follows project standards
- [x] Ready for review