### PR TITLE
feat(observability): Monitoring, logging, and distributed tracing stack (#1817)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,8 +18,15 @@ services:
       NODE_ENV: development
       PORT: 8787
       REDIS_URL: redis://redis:6379
+      LOG_FORMAT: json
+      METRICS_ENABLED: 'true'
+      OTEL_SERVICE_NAME: nexasphere-api
+      OTEL_ENABLED: 'false'
       # Allow requests from the Vite dev servers
       CORS_ORIGIN: 'http://localhost:5175,http://localhost:5001'
+    networks:
+      - default
+      - observability
     volumes:
       # Mount source for hot-reload (override CMD in dev if needed)
       - ./server:/app
@@ -62,5 +69,31 @@ services:
       api:
         condition: service_healthy
     restart: unless-stopped
+
+  # ── Python AI API (optional, for observability scraping) ────────────────────
+  python-api:
+    profiles: ['python', 'observability']
+    build:
+      context: ./server-python
+      dockerfile: Dockerfile
+    expose:
+      - '8000'
+    environment:
+      REDIS_URL: redis://redis:6379/0
+      OTEL_SERVICE_NAME: nexasphere-python
+      OTEL_ENABLED: 'false'
+      LOG_FORMAT: json
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - default
+      - observability
+
+networks:
+  observability:
+    name: nexasphere-observability
+    driver: bridge
 
 # Redis is used for rate limiting and Socket.IO session sharing.

--- a/observability/README.md
+++ b/observability/README.md
@@ -1,0 +1,144 @@
+# NexaSphere Observability Stack (#1817)
+
+Three pillars: **metrics** (Prometheus), **logs** (ELK), **traces** (Jaeger via OpenTelemetry), with **Grafana** dashboards and **Alertmanager** routing.
+
+## Quick start
+
+```bash
+# From repo root — starts API, Redis, gateway, and full observability stack
+docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml up -d
+```
+
+Optional Python API for scraping:
+
+```bash
+docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml --profile python up -d
+```
+
+Validate the stack (PowerShell):
+
+```powershell
+.\observability\scripts\smoke-test.ps1
+```
+
+Run server tests:
+
+```bash
+cd server && npm test
+```
+
+Python dev environment (IDE type checking):
+
+```powershell
+cd server-python
+.\scripts\setup-venv.ps1
+```
+
+## URLs (local)
+
+| Service | URL | Credentials |
+|---------|-----|-------------|
+| Grafana | http://localhost:3000 | admin / `nexasphere` (or `GRAFANA_ADMIN_PASSWORD`) |
+| Prometheus | http://localhost:9090 | — |
+| Alertmanager | http://localhost:9093 | — |
+| Kibana | http://localhost:5601 | — |
+| Jaeger | http://localhost:16686 | — |
+| Elasticsearch | http://localhost:9200 | security disabled (dev only) |
+
+## Application configuration
+
+Copy variables from [`server/.env.example.monitoring`](../server/.env.example.monitoring):
+
+| Variable | Purpose |
+|----------|---------|
+| `LOG_FORMAT=json` | Structured logs for ELK parsing |
+| `METRICS_ENABLED=true` | Expose `/metrics` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Jaeger OTLP collector (e.g. `http://jaeger:4318`) |
+| `OTEL_SERVICE_NAME` | Service label in traces/logs |
+| `MONITORING_API_TOKEN` | Auth for `/api/monitoring/*` |
+| `SLACK_WEBHOOK_URL` | Warning alerts |
+| `PAGERDUTY_ROUTING_KEY` | Critical alerts |
+| `ERROR_RATE_THRESHOLD` | Slack alert threshold (default 1%) |
+| `SLOW_REQUEST_THRESHOLD` | Slow request log threshold (ms) |
+
+## Log retention
+
+- **Default logs** (`nexasphere-logs-*`): 30-day ILM policy
+- **Compliance logs** (`nexasphere-compliance-*`): 365-day ILM for `audit` / `admin` level entries
+
+ILM policies are applied by the `elasticsearch-setup` container on first boot.
+
+## Kibana searches
+
+```
+level:error AND service:nexasphere-api
+traceId:"<from Jaeger>"
+userId:"<user-id>"
+@timestamp:[now-1h TO now]
+```
+
+## Alert severity routing
+
+| Severity | Receiver |
+|----------|----------|
+| critical | PagerDuty (if `PAGERDUTY_ROUTING_KEY` set) + Slack |
+| warning | Slack |
+| info | suppressed (null receiver) |
+
+Configure `SLACK_WEBHOOK_URL` and `PAGERDUTY_ROUTING_KEY` in the environment before starting Alertmanager. For local dev, export them in your shell or use a `.env` file loaded by Docker Compose.
+
+## Production (Render / Vercel)
+
+- **Metrics**: Prometheus scrapes `/metrics` from internal network; use Grafana Cloud or self-hosted Prometheus with Render private networking.
+- **Logs**: Ship stdout JSON logs via Filebeat/Vector to managed Elasticsearch or forward Render log streams.
+- **Traces**: Point `OTEL_EXPORTER_OTLP_ENDPOINT` to Grafana Cloud Tempo or self-hosted Jaeger.
+- **CloudWatch**: Not used by default; migrate by replacing Prometheus/ELK exporters with CloudWatch agent if deploying to AWS.
+
+## On-call escalation (configure in your org)
+
+1. **L1** — Slack `#monitoring-alerts` (warning, 5 min ack)
+2. **L2** — PagerDuty/Opsgenie on-call rotation (critical, 5 min ack)
+3. **L3** — Engineering lead escalation after 15 min unresolved critical
+
+## Dashboards
+
+Provisioned automatically under Grafana folder **NexaSphere**:
+
+- System Overview
+- Application
+- Database
+- Infrastructure
+- Business Metrics
+
+## RUM endpoint
+
+`POST /api/monitoring/rum` (Bearer `MONITORING_API_TOKEN`):
+
+```json
+{ "durationSeconds": 1.23 }
+```
+
+Feeds `nexasphere_page_load_seconds` histogram.
+
+## Team onboarding (5-minute walkthrough)
+
+1. **Start stack** — `docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml up -d`
+2. **Grafana** — open http://localhost:3000 → folder **NexaSphere** → **System Overview**
+3. **Prometheus** — http://localhost:9090 → query `rate(http_requests_total[5m])`
+4. **Kibana** — http://localhost:5601 → Discover → index `nexasphere-logs-*` → filter `level:error`
+5. **Jaeger** — http://localhost:16686 → search service `nexasphere-api` → find slow traces
+6. **Alerts** — http://localhost:9090/alerts and http://localhost:9093 (Alertmanager UI)
+
+For production alerting, copy `alertmanager/alertmanager.prod.yml.example` → `alertmanager.local.yml`, fill in Slack/PagerDuty keys, and mount it in compose.
+
+## Acceptance criteria checklist (#1817)
+
+| Criterion | How to verify |
+|-----------|---------------|
+| Metrics for all services | Prometheus targets UP at :9090/targets |
+| Alerts configured | Prometheus → Alerts tab shows rules |
+| Logs centralized | Kibana Discover shows `nexasphere-logs-*` |
+| Traces available | Jaeger UI shows `nexasphere-api` spans |
+| Dashboards | Grafana NexaSphere folder (5 dashboards) |
+| Log retention | `curl localhost:9200/_ilm/policy/nexasphere-logs-30d` |
+| Error tracking wired | `cd server && npm test` (62 tests pass) |

--- a/observability/alertmanager/alertmanager.prod.yml.example
+++ b/observability/alertmanager/alertmanager.prod.yml.example
@@ -1,0 +1,56 @@
+# Production Alertmanager config — copy to alertmanager.local.yml and set env vars,
+# then mount alertmanager.local.yml in docker-compose.observability.yml.
+#
+# Required env: SLACK_WEBHOOK_URL
+# Optional: PAGERDUTY_ROUTING_KEY, OPSGENIE_API_KEY
+
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: slack-warnings
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - match:
+        severity: critical
+      receiver: pagerduty-critical
+      continue: true
+    - match:
+        severity: critical
+      receiver: slack-warnings
+    - match:
+        severity: warning
+      receiver: slack-warnings
+    - match:
+        severity: info
+      receiver: null-receiver
+
+receivers:
+  - name: null-receiver
+
+  - name: slack-warnings
+    webhook_configs:
+      - url: 'https://hooks.slack.com/services/YOUR/WEBHOOK/URL'
+        send_resolved: true
+
+  - name: pagerduty-critical
+    pagerduty_configs:
+      - routing_key: 'YOUR_PAGERDUTY_ROUTING_KEY'
+        severity: critical
+        send_resolved: true
+
+  - name: opsgenie-critical
+    opsgenie_configs:
+      - api_key: 'YOUR_OPSGENIE_API_KEY'
+        priority: P1
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ['alertname']

--- a/observability/alertmanager/alertmanager.yml
+++ b/observability/alertmanager/alertmanager.yml
@@ -1,0 +1,38 @@
+global:
+  resolve_timeout: 5m
+
+route:
+  receiver: null-receiver
+  group_by: ['alertname', 'severity']
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+  routes:
+    - match:
+        severity: critical
+      receiver: critical-receiver
+      continue: true
+    - match:
+        severity: warning
+      receiver: warning-receiver
+    - match:
+        severity: info
+      receiver: null-receiver
+
+receivers:
+  - name: null-receiver
+
+  # Local dev: alerts are routed here until SLACK_WEBHOOK_URL is configured.
+  # Copy alertmanager.prod.yml.example → alertmanager.local.yml and mount it for production.
+  - name: warning-receiver
+    webhook_configs: []
+
+  - name: critical-receiver
+    webhook_configs: []
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ['alertname']

--- a/observability/docker-compose.observability.yml
+++ b/observability/docker-compose.observability.yml
@@ -1,0 +1,204 @@
+# Observability stack overlay for NexaSphere (#1817)
+# Usage: docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml up -d
+
+services:
+  api:
+    environment:
+      OTEL_ENABLED: 'true'
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318/v1/traces
+
+  python-api:
+    environment:
+      OTEL_ENABLED: 'true'
+      OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4318/v1/traces
+
+  prometheus:
+    image: prom/prometheus:v2.51.2
+    container_name: nexasphere-prometheus
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.enable-lifecycle'
+    restart: unless-stopped
+    networks:
+      - observability
+      - default
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    container_name: nexasphere-alertmanager
+    ports:
+      - '9093:9093'
+    volumes:
+      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    command:
+      - '--config.file=/etc/alertmanager/alertmanager.yml'
+    restart: unless-stopped
+    networks:
+      - observability
+
+  grafana:
+    image: grafana/grafana:10.4.2
+    container_name: nexasphere-grafana
+    ports:
+      - '3000:3000'
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-nexasphere}
+      GF_USERS_ALLOW_SIGN_UP: 'false'
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+      - elasticsearch
+      - jaeger
+    restart: unless-stopped
+    networks:
+      - observability
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
+    container_name: nexasphere-elasticsearch
+    ports:
+      - '9200:9200'
+    environment:
+      discovery.type: single-node
+      xpack.security.enabled: 'false'
+      ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+    volumes:
+      - elasticsearch_data:/usr/share/elasticsearch/data
+      - ./elasticsearch/index-templates:/usr/share/elasticsearch/index-templates:ro
+      - ./elasticsearch/setup-ilm.sh:/usr/share/elasticsearch/setup-ilm.sh:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sf http://localhost:9200/_cluster/health || exit 1']
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    restart: unless-stopped
+    networks:
+      - observability
+
+  elasticsearch-setup:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.13.2
+    container_name: nexasphere-elasticsearch-setup
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    volumes:
+      - ./elasticsearch/index-templates:/templates:ro
+      - ./elasticsearch/setup-ilm.sh:/setup-ilm.sh:ro
+    entrypoint: ['/bin/bash', '/setup-ilm.sh']
+    networks:
+      - observability
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:8.13.2
+    container_name: nexasphere-logstash
+    ports:
+      - '5044:5044'
+      - '9600:9600'
+    volumes:
+      - ./logstash/pipeline/logstash.conf:/usr/share/logstash/pipeline/logstash.conf:ro
+    environment:
+      LS_JAVA_OPTS: '-Xms256m -Xmx256m'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - observability
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.13.2
+    container_name: nexasphere-kibana
+    ports:
+      - '5601:5601'
+    environment:
+      ELASTICSEARCH_HOSTS: 'http://elasticsearch:9200'
+    depends_on:
+      elasticsearch:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - observability
+
+  kibana-setup:
+    image: curlimages/curl:8.7.1
+    container_name: nexasphere-kibana-setup
+    depends_on:
+      - kibana
+    volumes:
+      - ./kibana/setup-saved-objects.sh:/setup.sh:ro
+    entrypoint: ['/bin/sh', '/setup.sh']
+    networks:
+      - observability
+
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.13.2
+    container_name: nexasphere-filebeat
+    user: root
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - /var/lib/docker/containers:/var/lib/docker/containers:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ../server/logs:/var/log/nexasphere:ro
+    depends_on:
+      - logstash
+    restart: unless-stopped
+    networks:
+      - observability
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.56
+    container_name: nexasphere-jaeger
+    ports:
+      - '16686:16686'
+      - '4317:4317'
+      - '4318:4318'
+    environment:
+      COLLECTOR_OTLP_ENABLED: 'true'
+    restart: unless-stopped
+    networks:
+      - observability
+
+  node-exporter:
+    image: prom/node-exporter:v1.8.0
+    container_name: nexasphere-node-exporter
+    ports:
+      - '9100:9100'
+    restart: unless-stopped
+    networks:
+      - observability
+
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.58.0
+    container_name: nexasphere-redis-exporter
+    ports:
+      - '9121:9121'
+    environment:
+      REDIS_ADDR: 'redis://redis:6379'
+    depends_on:
+      redis:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - observability
+      - default
+
+volumes:
+  prometheus_data:
+  grafana_data:
+  elasticsearch_data:
+
+networks:
+  observability:
+    name: nexasphere-observability
+    driver: bridge

--- a/observability/elasticsearch/index-templates/logs-30d-policy.json
+++ b/observability/elasticsearch/index-templates/logs-30d-policy.json
@@ -1,0 +1,20 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "1d",
+            "max_primary_shard_size": "10gb"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "30d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/observability/elasticsearch/index-templates/logs-30d.json
+++ b/observability/elasticsearch/index-templates/logs-30d.json
@@ -1,0 +1,23 @@
+{
+  "index_patterns": ["nexasphere-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.lifecycle.name": "nexasphere-logs-30d",
+      "index.lifecycle.rollover_alias": "nexasphere-logs"
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": { "type": "date" },
+        "level": { "type": "keyword" },
+        "message": { "type": "text" },
+        "service": { "type": "keyword" },
+        "reqId": { "type": "keyword" },
+        "traceId": { "type": "keyword" },
+        "userId": { "type": "keyword" }
+      }
+    }
+  },
+  "priority": 100
+}

--- a/observability/elasticsearch/index-templates/logs-compliance-365d-policy.json
+++ b/observability/elasticsearch/index-templates/logs-compliance-365d-policy.json
@@ -1,0 +1,20 @@
+{
+  "policy": {
+    "phases": {
+      "hot": {
+        "actions": {
+          "rollover": {
+            "max_age": "7d",
+            "max_primary_shard_size": "10gb"
+          }
+        }
+      },
+      "delete": {
+        "min_age": "365d",
+        "actions": {
+          "delete": {}
+        }
+      }
+    }
+  }
+}

--- a/observability/elasticsearch/index-templates/logs-compliance-365d.json
+++ b/observability/elasticsearch/index-templates/logs-compliance-365d.json
@@ -1,0 +1,23 @@
+{
+  "index_patterns": ["nexasphere-compliance-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.lifecycle.name": "nexasphere-compliance-365d",
+      "index.lifecycle.rollover_alias": "nexasphere-compliance"
+    },
+    "mappings": {
+      "properties": {
+        "@timestamp": { "type": "date" },
+        "level": { "type": "keyword" },
+        "message": { "type": "text" },
+        "service": { "type": "keyword" },
+        "reqId": { "type": "keyword" },
+        "traceId": { "type": "keyword" },
+        "userId": { "type": "keyword" }
+      }
+    }
+  },
+  "priority": 200
+}

--- a/observability/elasticsearch/setup-ilm.sh
+++ b/observability/elasticsearch/setup-ilm.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -euo pipefail
+
+ES_URL="${ES_URL:-http://elasticsearch:9200}"
+
+echo "Waiting for Elasticsearch at ${ES_URL}..."
+until curl -sf "${ES_URL}/_cluster/health" > /dev/null; do
+  sleep 5
+done
+
+echo "Applying ILM policies..."
+
+curl -sf -X PUT "${ES_URL}/_ilm/policy/nexasphere-logs-30d" \
+  -H 'Content-Type: application/json' \
+  -d @/templates/logs-30d-policy.json
+
+curl -sf -X PUT "${ES_URL}/_ilm/policy/nexasphere-compliance-365d" \
+  -H 'Content-Type: application/json' \
+  -d @/templates/logs-compliance-365d-policy.json
+
+curl -sf -X PUT "${ES_URL}/_index_template/nexasphere-logs" \
+  -H 'Content-Type: application/json' \
+  -d @/templates/logs-30d.json
+
+curl -sf -X PUT "${ES_URL}/_index_template/nexasphere-compliance" \
+  -H 'Content-Type: application/json' \
+  -d @/templates/logs-compliance-365d.json
+
+echo "ILM policies and index templates applied."

--- a/observability/filebeat/filebeat.yml
+++ b/observability/filebeat/filebeat.yml
@@ -1,0 +1,23 @@
+filebeat.inputs:
+  - type: container
+    paths:
+      - '/var/lib/docker/containers/*/*.log'
+    processors:
+      - add_docker_metadata: ~
+
+  - type: log
+    enabled: true
+    paths:
+      - '/var/log/nexasphere/*.log'
+    fields:
+      service: nexasphere-api
+    fields_under_root: false
+    json.keys_under_root: true
+    json.add_error_key: true
+    json.message_key: message
+
+output.logstash:
+  hosts: ['logstash:5044']
+
+logging.level: info
+logging.to_files: false

--- a/observability/grafana/dashboards/application.json
+++ b/observability/grafana/dashboards/application.json
@@ -1,0 +1,55 @@
+{
+  "uid": "nexa-application",
+  "title": "Application",
+  "tags": ["nexasphere", "application"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Requests by Status",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [{
+        "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (status)",
+        "legendFormat": "{{status}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 2,
+      "title": "Requests by Method",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [{
+        "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (method)",
+        "legendFormat": "{{method}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 3,
+      "title": "Latency by Route (p95)",
+      "type": "timeseries",
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le, route))",
+        "legendFormat": "{{route}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4,
+      "title": "5xx Errors by Route",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "targets": [{
+        "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m])) by (route)",
+        "legendFormat": "{{route}}",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/observability/grafana/dashboards/business-metrics.json
+++ b/observability/grafana/dashboards/business-metrics.json
@@ -1,0 +1,51 @@
+{
+  "uid": "nexa-business",
+  "title": "Business Metrics",
+  "tags": ["nexasphere", "business"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Active Users Online",
+      "type": "stat",
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "targets": [{ "expr": "nexasphere_active_users_online", "refId": "A" }]
+    },
+    {
+      "id": 2,
+      "title": "Events Registered (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 },
+      "targets": [{
+        "expr": "rate(nexasphere_events_registered_total[5m]) * 60",
+        "legendFormat": "registrations/min",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 3,
+      "title": "Events Created (rate/min)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [{
+        "expr": "rate(nexasphere_events_created_total[5m]) * 60",
+        "legendFormat": "created/min",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4,
+      "title": "Page Load p95",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum(rate(nexasphere_page_load_seconds_bucket[5m])) by (le))",
+        "legendFormat": "p95",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/observability/grafana/dashboards/database.json
+++ b/observability/grafana/dashboards/database.json
@@ -1,0 +1,51 @@
+{
+  "uid": "nexa-database",
+  "title": "Database",
+  "tags": ["nexasphere", "database"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Database Up",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "nexasphere_database_up", "refId": "A" }],
+      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }] } }
+    },
+    {
+      "id": 2,
+      "title": "Pool Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [{
+        "expr": "pg_pool_connections",
+        "legendFormat": "{{state}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 3,
+      "title": "Waiting Connections",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [{
+        "expr": "pg_pool_connections{state=\"waiting\"}",
+        "legendFormat": "waiting",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4,
+      "title": "Cache Hit/Miss Rate",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "targets": [
+        { "expr": "rate(redis_cache_hits_total[5m])", "legendFormat": "hits/s", "refId": "A" },
+        { "expr": "rate(redis_cache_misses_total[5m])", "legendFormat": "misses/s", "refId": "B" }
+      ]
+    }
+  ]
+}

--- a/observability/grafana/dashboards/infrastructure.json
+++ b/observability/grafana/dashboards/infrastructure.json
@@ -1,0 +1,65 @@
+{
+  "uid": "nexa-infrastructure",
+  "title": "Infrastructure",
+  "tags": ["nexasphere", "infrastructure"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "CPU Usage %",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [{
+        "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
+        "legendFormat": "CPU",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 2,
+      "title": "Memory Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [{
+        "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
+        "legendFormat": "memory used ratio",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 3,
+      "title": "Disk Usage",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [{
+        "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})",
+        "legendFormat": "{{mountpoint}}",
+        "refId": "A"
+      }]
+    },
+    {
+      "id": 4,
+      "title": "Network I/O",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        { "expr": "rate(node_network_receive_bytes_total[5m])", "legendFormat": "rx {{device}}", "refId": "A" },
+        { "expr": "rate(node_network_transmit_bytes_total[5m])", "legendFormat": "tx {{device}}", "refId": "B" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Redis Memory",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "targets": [{
+        "expr": "redis_memory_used_bytes",
+        "legendFormat": "used",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/observability/grafana/dashboards/system-overview.json
+++ b/observability/grafana/dashboards/system-overview.json
@@ -1,0 +1,51 @@
+{
+  "uid": "nexa-system-overview",
+  "title": "System Overview",
+  "tags": ["nexasphere", "overview"],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Service Up",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "targets": [{ "expr": "up{job=\"nexasphere-api\"}", "refId": "A" }],
+      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }] } }
+    },
+    {
+      "id": 2,
+      "title": "Firing Alerts",
+      "type": "stat",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "targets": [{ "expr": "count(ALERTS{alertstate=\"firing\"})", "refId": "A" }]
+    },
+    {
+      "id": 3,
+      "title": "Request Rate (req/s)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "targets": [{ "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m]))", "legendFormat": "RPS", "refId": "A" }]
+    },
+    {
+      "id": 4,
+      "title": "Error Rate (5xx)",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "targets": [{ "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m]))", "legendFormat": "5xx/s", "refId": "A" }]
+    },
+    {
+      "id": 5,
+      "title": "p95 Latency",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "targets": [{
+        "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le))",
+        "legendFormat": "p95",
+        "refId": "A"
+      }]
+    }
+  ]
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: NexaSphere
+    orgId: 1
+    folder: NexaSphere
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /var/lib/grafana/dashboards

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,27 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+
+  - name: Elasticsearch
+    type: elasticsearch
+    access: proxy
+    url: http://elasticsearch:9200
+    database: 'nexasphere-logs-*'
+    jsonData:
+      timeField: '@timestamp'
+      esVersion: '8.0.0'
+      logMessageField: message
+      logLevelField: level
+    editable: false
+
+  - name: Jaeger
+    type: jaeger
+    access: proxy
+    url: http://jaeger:16686
+    editable: false

--- a/observability/kibana/setup-saved-objects.sh
+++ b/observability/kibana/setup-saved-objects.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Creates Kibana index pattern and saved searches for NexaSphere logs.
+set -euo pipefail
+
+KIBANA_URL="${KIBANA_URL:-http://kibana:5601}"
+ES_URL="${ES_URL:-http://elasticsearch:9200}"
+
+echo "Waiting for Kibana at ${KIBANA_URL}..."
+until curl -sf "${KIBANA_URL}/api/status" > /dev/null 2>&1; do
+  sleep 5
+done
+
+echo "Creating index pattern nexasphere-logs-*..."
+curl -sf -X POST "${KIBANA_URL}/api/index_patterns/index_pattern" \
+  -H 'kbn-xsrf: true' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "index_pattern": {
+      "title": "nexasphere-logs-*",
+      "timeFieldName": "@timestamp"
+    }
+  }' || echo "Index pattern may already exist."
+
+echo "Creating saved search: errors by service..."
+curl -sf -X POST "${KIBANA_URL}/api/saved_objects/search/nexasphere-errors" \
+  -H 'kbn-xsrf: true' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "attributes": {
+      "title": "NexaSphere Errors",
+      "columns": ["@timestamp", "level", "service", "message", "traceId", "userId"],
+      "sort": [["@timestamp", "desc"]],
+      "kibanaSavedObjectMeta": {
+        "searchSourceJSON": "{\"index\":\"nexasphere-logs-*\",\"query\":{\"language\":\"kuery\",\"query\":\"level:error\"},\"filter\":[]}"
+      }
+    }
+  }' || echo "Saved search may already exist."
+
+echo "Kibana setup complete."

--- a/observability/logstash/pipeline/logstash.conf
+++ b/observability/logstash/pipeline/logstash.conf
@@ -1,0 +1,49 @@
+input {
+  beats {
+    port => 5044
+  }
+}
+
+filter {
+  if [message] =~ /^\{.*\}$/ {
+    json {
+      source => "message"
+      target => "nexa"
+    }
+    mutate {
+      rename => {
+        "[nexa][timestamp]" => "@timestamp"
+        "[nexa][level]" => "level"
+        "[nexa][message]" => "log_message"
+        "[nexa][service]" => "service"
+        "[nexa][reqId]" => "reqId"
+        "[nexa][traceId]" => "traceId"
+        "[nexa][userId]" => "userId"
+      }
+    }
+  }
+
+  if [log_message] {
+    mutate {
+      replace => { "message" => "%{log_message}" }
+    }
+  }
+
+  if ![service] {
+    mutate { add_field => { "service" => "unknown" } }
+  }
+}
+
+output {
+  if [level] == "audit" or [level] == "admin" {
+    elasticsearch {
+      hosts => ["http://elasticsearch:9200"]
+      index => "nexasphere-compliance-%{+YYYY.MM.dd}"
+    }
+  } else {
+    elasticsearch {
+      hosts => ["http://elasticsearch:9200"]
+      index => "nexasphere-logs-%{+YYYY.MM.dd}"
+    }
+  }
+}

--- a/observability/prometheus/alerts.yml
+++ b/observability/prometheus/alerts.yml
@@ -1,0 +1,86 @@
+groups:
+  - name: nexasphere-application
+    rules:
+      - alert: HighResponseTime
+        expr: |
+          histogram_quantile(0.95,
+            sum(rate(http_request_duration_seconds_bucket{job="nexasphere-api"}[5m])) by (le)
+          ) > 0.5
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'API p95 response time exceeds 500ms'
+          description: 'p95 latency is {{ $value | humanizeDuration }} over the last 5 minutes.'
+
+      - alert: HighErrorRate
+        expr: |
+          (
+            sum(rate(http_requests_total{job="nexasphere-api",status=~"5.."}[5m]))
+            /
+            sum(rate(http_requests_total{job="nexasphere-api"}[5m]))
+          ) > 0.01
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'API error rate exceeds 1%'
+          description: '5xx error rate is {{ $value | humanizePercentage }}.'
+
+      - alert: DatabaseDown
+        expr: nexasphere_database_up == 0
+        for: 1m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Database is unreachable'
+          description: 'PostgreSQL health probe reports database down.'
+
+      - alert: PoolExhaustion
+        expr: |
+          (
+            pg_pool_connections{state="waiting"}
+            /
+            (pg_pool_connections{state="total"} > 0)
+          ) > 0.8
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Database connection pool near exhaustion'
+          description: 'More than 80% of pool connections are waiting.'
+
+  - name: nexasphere-infrastructure
+    rules:
+      - alert: HighCPU
+        expr: |
+          100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: 'CPU usage exceeds 80%'
+          description: 'CPU usage is {{ $value | printf "%.1f" }}% on {{ $labels.instance }}.'
+
+      - alert: HighDisk
+        expr: |
+          (
+            node_filesystem_avail_bytes{fstype!~"tmpfs|overlay"}
+            /
+            node_filesystem_size_bytes{fstype!~"tmpfs|overlay"}
+          ) < 0.1
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: 'Disk usage exceeds 90%'
+          description: 'Less than 10% disk space available on {{ $labels.mountpoint }}.'
+
+      - alert: TargetDown
+        expr: up{job=~"nexasphere-.*"} == 0
+        for: 2m
+        labels:
+          severity: info
+        annotations:
+          summary: 'Scrape target {{ $labels.job }} is down'
+          description: 'Prometheus cannot scrape {{ $labels.instance }}.'

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,45 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ['alertmanager:9093']
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: nexasphere-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['api:8787']
+        labels:
+          service: nexasphere-api
+
+  - job_name: nexasphere-python
+    metrics_path: /metrics
+    static_configs:
+      - targets: ['python-api:8000']
+        labels:
+          service: nexasphere-python
+
+  - job_name: nexasphere-java
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ['host.docker.internal:8080']
+        labels:
+          service: nexasphere-java
+
+  - job_name: node-exporter
+    static_configs:
+      - targets: ['node-exporter:9100']
+
+  - job_name: redis-exporter
+    static_configs:
+      - targets: ['redis-exporter:9121']

--- a/observability/scripts/smoke-test.ps1
+++ b/observability/scripts/smoke-test.ps1
@@ -1,0 +1,55 @@
+# Quick smoke test for observability stack (run after compose up)
+param(
+    [string]$ApiUrl = "http://localhost/health",
+    [string]$PrometheusUrl = "http://localhost:9090",
+    [string]$GrafanaUrl = "http://localhost:3000",
+    [string]$JaegerUrl = "http://localhost:16686",
+    [string]$KibanaUrl = "http://localhost:5601"
+)
+
+$ErrorActionPreference = "Stop"
+$passed = 0
+$failed = 0
+
+function Test-Endpoint {
+    param([string]$Name, [string]$Url)
+    try {
+        $r = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 10
+        if ($r.StatusCode -ge 200 -and $r.StatusCode -lt 400) {
+            Write-Host "[PASS] $Name ($Url)"
+            $script:passed++
+        } else {
+            Write-Host "[FAIL] $Name — status $($r.StatusCode)"
+            $script:failed++
+        }
+    } catch {
+        Write-Host "[FAIL] $Name — $($_.Exception.Message)"
+        $script:failed++
+    }
+}
+
+Write-Host "NexaSphere observability smoke test"
+Write-Host "====================================="
+
+Test-Endpoint "API health (via gateway)" $ApiUrl
+Test-Endpoint "Prometheus" "$PrometheusUrl/-/healthy"
+Test-Endpoint "Grafana" "$GrafanaUrl/api/health"
+Test-Endpoint "Jaeger" "$JaegerUrl"
+Test-Endpoint "Kibana" "$KibanaUrl/api/status"
+
+try {
+    $metrics = Invoke-WebRequest -Uri "http://localhost:8787/metrics" -UseBasicParsing -TimeoutSec 5
+    if ($metrics.Content -match "http_requests_total") {
+        Write-Host "[PASS] Prometheus metrics endpoint"
+        $passed++
+    } else {
+        Write-Host "[FAIL] Metrics endpoint missing http_requests_total"
+        $failed++
+    }
+} catch {
+    Write-Host "[SKIP] Direct /metrics (only reachable inside Docker network)"
+}
+
+Write-Host ""
+Write-Host "Results: $passed passed, $failed failed"
+if ($failed -gt 0) { exit 1 }

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,14 @@
+{
+  "include": ["server-python"],
+  "venvPath": "server-python",
+  "venv": ".venv",
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "reportPrivateImportUsage": "none",
+  "executionEnvironments": [
+    {
+      "root": "server-python",
+      "pythonVersion": "3.10"
+    }
+  ]
+}

--- a/server-java/src/main/resources/application.properties
+++ b/server-java/src/main/resources/application.properties
@@ -20,4 +20,6 @@ server.port=8080
 
 management.endpoints.web.exposure.include=health,info,metrics,prometheus
 management.endpoint.health.probes.enabled=true
+management.tracing.enabled=true
+management.otlp.tracing.endpoint=${OTEL_EXPORTER_OTLP_ENDPOINT:http://localhost:4318/v1/traces}
 logging.pattern.level=%5p [${spring.application.name:server-java},%X{traceId:-},%X{spanId:-}]

--- a/server-python/Dockerfile
+++ b/server-python/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/server-python/main.py
+++ b/server-python/main.py
@@ -1,38 +1,74 @@
+import json
 import logging
 import os
 import uuid
 import contextvars
+
 import google.generativeai as genai
+from dotenv import load_dotenv
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
-from dotenv import load_dotenv
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+
+from observability.metrics import collect_celery_queue_depth
+from observability.tracing import init_tracing
+from prompts.system_prompt import SYSTEM_PROMPT
+from routers import certificates, forms, health, notifications, portfolio, recommend
+from utils.security import limiter
 
 load_dotenv()
 
 # --- Logging Standardization with Trace ID ---
 request_id_context = contextvars.ContextVar("request_id", default="system")
+SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "nexasphere-python")
+LOG_FORMAT = os.getenv("LOG_FORMAT", "text").lower()
+
 
 class TraceIdFilter(logging.Filter):
     def filter(self, record):
         record.trace_id = request_id_context.get()
+        record.service = SERVICE_NAME
         return True
 
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] [%(trace_id)s] %(name)s: %(message)s"
-)
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record):
+        payload = {
+            "timestamp": self.formatTime(record, self.datefmt),
+            "level": record.levelname.lower(),
+            "message": record.getMessage(),
+            "service": getattr(record, "service", SERVICE_NAME),
+            "traceId": getattr(record, "trace_id", None),
+            "reqId": getattr(record, "trace_id", None),
+            "logger": record.name,
+        }
+        if record.exc_info:
+            payload["stack"] = self.formatException(record.exc_info)
+        return json.dumps(payload)
+
+
+def _configure_logging():
+    root = logging.getLogger()
+    root.handlers.clear()
+    handler = logging.StreamHandler()
+    handler.addFilter(TraceIdFilter())
+    if LOG_FORMAT == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s [%(levelname)s] [%(trace_id)s] %(name)s: %(message)s")
+        )
+    root.addHandler(handler)
+    root.setLevel(logging.INFO)
+
+
+_configure_logging()
 logger = logging.getLogger(__name__)
-logger.addFilter(TraceIdFilter())
 
-for logger_name in ["uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"]:
-    l = logging.getLogger(logger_name)
-    l.addFilter(TraceIdFilter())
-
-# 1. Configuration & Persona
-from prompts.system_prompt import SYSTEM_PROMPT
-
-# 2. Initialize Gemini
+# Initialize Gemini
 API_KEY = os.getenv("GEMINI_API_KEY")
 
 if not API_KEY:
@@ -40,18 +76,38 @@ if not API_KEY:
     model = None
 else:
     genai.configure(api_key=API_KEY)
-    model = genai.GenerativeModel(
-        model_name='gemini-3.1-flash-lite-preview'
-    )
-
-from slowapi.errors import RateLimitExceeded
-from slowapi import _rate_limit_exceeded_handler
-from utils.security import limiter
+    model = genai.GenerativeModel(model_name="gemini-3.1-flash-lite-preview")
 
 app = FastAPI(title="NexaSphere AI Core")
 
+init_tracing(app)
+
+if os.getenv("METRICS_ENABLED", "true").lower() != "false":
+    instrumentator = Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+    )
+    instrumentator.add(lambda info: collect_celery_queue_depth())
+    instrumentator.instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
+
 app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # pyright: ignore[reportArgumentType]
+
+origins = os.getenv(
+    "CORS_ORIGIN",
+    "http://localhost:5173,http://localhost:5174,https://nexasphere-glbajaj.vercel.app,"
+    "https://admin-nexasphere.vercel.app,https://nexa-sphere-sigma.vercel.app,"
+    "https://admin-dashboard-navy-pi-22.vercel.app",
+).split(",")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 
 @app.middleware("http")
 async def request_id_middleware(request: Request, call_next):
@@ -62,46 +118,41 @@ async def request_id_middleware(request: Request, call_next):
     request_id_context.reset(token)
     return response
 
+
 @app.get("/")
 async def root():
-    return {"message": "NexaSphere AI Core API is running. Visit /docs for Swagger API documentation."}
+    return {
+        "message": "NexaSphere AI Core API is running. Visit /docs for Swagger API documentation."
+    }
 
-from routers import forms, recommend, certificates, notifications, portfolio, health
+
 app.include_router(forms.router)
 app.include_router(recommend.router)
 app.include_router(certificates.router)
 app.include_router(notifications.router)
 app.include_router(health.router)
 app.include_router(portfolio.router)
-# 3. CORS Configuration
-origins = os.getenv("CORS_ORIGIN", "http://localhost:5173,http://localhost:5174,https://nexasphere-glbajaj.vercel.app,https://admin-nexasphere.vercel.app,https://nexa-sphere-sigma.vercel.app,https://admin-dashboard-navy-pi-22.vercel.app").split(",")
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
 
 class ChatRequest(BaseModel):
     message: str
 
-# 4. Chat Endpoint
+
 @app.post("/ai/chat")
 @limiter.limit("20/minute")
 async def chat_with_ai(http_request: Request, chat_req: ChatRequest):
     try:
         if not model:
             return {"reply": "Nexa-AI Core is offline. (GEMINI_API_KEY missing)"}
-            
-        # We send the user message to the model along with system instructions manually
-        full_prompt = f"System Instruction:\n{SYSTEM_PROMPT}\n\nUser Message:\n{chat_req.message}"
+
+        full_prompt = (
+            f"System Instruction:\n{SYSTEM_PROMPT}\n\nUser Message:\n{chat_req.message}"
+        )
         response = model.generate_content(full_prompt)
-        
+
         if not response.text:
             return {"reply": "Nexa-AI is processing, but returned an empty signal. Try rephrasing."}
-            
+
         return {"reply": response.text}
 
     except Exception as e:
@@ -110,13 +161,16 @@ async def chat_with_ai(http_request: Request, chat_req: ChatRequest):
             "Gemini request failed",
             extra={"error_type": type(e).__name__, "status_code": error_code},
         )
-        
-        # Friendly error handling for Quota limits
+
         if error_code == 429 or getattr(getattr(e, "response", None), "status_code", None) == 429:
-            return {"reply": "Nexa-AI is currently at peak capacity (Quota Limit). Please wait 60 seconds."}
-        
+            return {
+                "reply": "Nexa-AI is currently at peak capacity (Quota Limit). Please wait 60 seconds."
+            }
+
         return {"reply": "Nexa-AI Core Offline. Connection recalibrating..."}
+
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/server-python/observability/__init__.py
+++ b/server-python/observability/__init__.py
@@ -1,0 +1,1 @@
+"""Observability helpers for NexaSphere Python API."""

--- a/server-python/observability/metrics.py
+++ b/server-python/observability/metrics.py
@@ -1,0 +1,20 @@
+import os
+
+import redis
+from prometheus_client import Gauge
+
+CELERY_QUEUE_DEPTH = Gauge(
+    "celery_queue_depth",
+    "Approximate Celery task queue depth (Redis list length)",
+    ["queue"],
+)
+
+
+def collect_celery_queue_depth() -> None:
+    redis_url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    try:
+        client = redis.from_url(redis_url)
+        depth = client.llen("celery")
+        CELERY_QUEUE_DEPTH.labels(queue="celery").set(depth)
+    except Exception:
+        CELERY_QUEUE_DEPTH.labels(queue="celery").set(-1)

--- a/server-python/observability/tracing.py
+++ b/server-python/observability/tracing.py
@@ -1,0 +1,35 @@
+import os
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+SERVICE_NAME = os.getenv("OTEL_SERVICE_NAME", "nexasphere-python")
+OTLP_ENDPOINT = os.getenv(
+    "OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318/v1/traces"
+)
+
+
+def init_tracing(app):
+    if os.getenv("OTEL_ENABLED", "true").lower() == "false":
+        return
+
+    resource = Resource.create({"service.name": SERVICE_NAME})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=OTLP_ENDPOINT)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    FastAPIInstrumentor.instrument_app(app)
+
+
+def get_active_trace_id() -> str | None:
+    span = trace.get_current_span()
+    ctx = span.get_span_context()
+    if ctx and ctx.trace_id:
+        trace_id = format(ctx.trace_id, "032x")
+        if trace_id != "0" * 32:
+            return trace_id
+    return None

--- a/server-python/pyproject.toml
+++ b/server-python/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "nexasphere-python"
+version = "0.0.0"
+requires-python = ">=3.10"
+
+[tool.pyright]
+include = ["."]
+exclude = ["**/__pycache__", ".venv"]
+venvPath = "."
+venv = ".venv"
+pythonVersion = "3.10"
+typeCheckingMode = "basic"
+reportPrivateImportUsage = "none"

--- a/server-python/pyrightconfig.json
+++ b/server-python/pyrightconfig.json
@@ -1,0 +1,9 @@
+{
+  "include": ["."],
+  "exclude": ["**/__pycache__", ".venv"],
+  "venvPath": ".",
+  "venv": ".venv",
+  "pythonVersion": "3.10",
+  "typeCheckingMode": "basic",
+  "reportPrivateImportUsage": "none"
+}

--- a/server-python/requirements.txt
+++ b/server-python/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.109.0
+slowapi==0.1.9
 uvicorn[standard]==0.27.0
 pydantic==2.5.3
 pydantic[email]==2.5.3
@@ -16,4 +17,10 @@ SQLAlchemy==2.0.25
 Pillow==10.3.0
 qrcode[pil]==7.4.2
 celery==5.4.0
+prometheus-fastapi-instrumentator==7.0.0
+prometheus-client==0.20.0
+opentelemetry-api==1.24.0
+opentelemetry-sdk==1.24.0
+opentelemetry-instrumentation-fastapi==0.45b0
+opentelemetry-exporter-otlp-proto-http==1.24.0
 

--- a/server-python/scripts/setup-venv.ps1
+++ b/server-python/scripts/setup-venv.ps1
@@ -1,0 +1,14 @@
+# One-time Python dev environment setup for server-python
+$ErrorActionPreference = "Stop"
+$root = Split-Path -Parent $PSScriptRoot
+
+Set-Location $root
+
+if (-not (Test-Path .venv)) {
+    python -m venv .venv
+}
+
+.\.venv\Scripts\pip install --upgrade pip
+.\.venv\Scripts\pip install -r requirements.txt
+
+Write-Host "Done. Select interpreter: $root\.venv\Scripts\python.exe"

--- a/server/observability/businessMetrics.js
+++ b/server/observability/businessMetrics.js
@@ -1,0 +1,74 @@
+/**
+ * Periodic business and infrastructure metric collectors.
+ */
+
+import { getConnectedUsersCount } from '../config/socket.js';
+import { getMetrics as getLegacyMetrics } from '../middleware/performanceMonitor.js';
+import { sendErrorRateAlert } from '../utils/slack.js';
+import { activeUsersOnline, updatePoolMetrics } from './metrics.js';
+
+const COLLECT_INTERVAL_MS = 15_000;
+const ALERT_INTERVAL_MS = 60_000;
+
+let collectTimer = null;
+let alertTimer = null;
+
+function isPerformanceMonitoringEnabled() {
+  return process.env.ENABLE_PERFORMANCE_MONITORING !== 'false';
+}
+
+function collectBusinessMetrics() {
+  if (!isPerformanceMonitoringEnabled()) return;
+
+  try {
+    activeUsersOnline.set(getConnectedUsersCount());
+    updatePoolMetrics();
+  } catch {
+    // Socket.IO may not be initialized in all environments
+  }
+}
+
+function checkErrorRateAndAlert() {
+  if (!isPerformanceMonitoringEnabled()) return;
+
+  const threshold = parseFloat(process.env.ERROR_RATE_THRESHOLD || '1');
+  const legacy = getLegacyMetrics();
+  let totalRequests = 0;
+  let totalErrors = 0;
+
+  Object.values(legacy.endpoints || {}).forEach((windows) => {
+    const fiveMin = windows['5min'] || {};
+    totalRequests += fiveMin.count || 0;
+    totalErrors += fiveMin.errorCount || 0;
+  });
+
+  if (totalRequests === 0) return;
+
+  const errorRate = (totalErrors / totalRequests) * 100;
+  if (errorRate > threshold) {
+    sendErrorRateAlert(errorRate, threshold);
+  }
+}
+
+export function startBusinessMetricsCollectors() {
+  if (collectTimer) return;
+
+  collectTimer = setInterval(collectBusinessMetrics, COLLECT_INTERVAL_MS);
+  collectTimer.unref?.();
+
+  alertTimer = setInterval(checkErrorRateAndAlert, ALERT_INTERVAL_MS);
+  alertTimer.unref?.();
+
+  collectBusinessMetrics();
+}
+
+export function stopBusinessMetricsCollectors() {
+  if (collectTimer) {
+    clearInterval(collectTimer);
+    collectTimer = null;
+  }
+  if (alertTimer) {
+    clearInterval(alertTimer);
+    alertTimer = null;
+  }
+}

--- a/server/observability/httpMetrics.js
+++ b/server/observability/httpMetrics.js
@@ -1,0 +1,68 @@
+/**
+ * Express middleware for Prometheus HTTP metrics.
+ */
+
+import logger from '../utils/logger.js';
+import {
+  httpRequestsTotal,
+  httpRequestDuration,
+  httpErrorsTotal,
+} from './metrics.js';
+
+const SLOW_REQUEST_THRESHOLD = parseInt(process.env.SLOW_REQUEST_THRESHOLD || '1000', 10);
+const PERFORMANCE_ENABLED = process.env.ENABLE_PERFORMANCE_MONITORING !== 'false';
+
+function normalizeRoute(req) {
+  if (req.route?.path) {
+    const base = req.baseUrl || '';
+    const path = typeof req.route.path === 'string' ? req.route.path : req.route.path.join('|');
+    return `${base}${path}`;
+  }
+  return req.path || 'unknown';
+}
+
+export function httpMetricsMiddleware(req, res, next) {
+  if (!PERFORMANCE_ENABLED) {
+    return next();
+  }
+
+  const start = process.hrtime.bigint();
+
+  res.on('finish', () => {
+    const durationSec = Number(process.hrtime.bigint() - start) / 1e9;
+    const durationMs = durationSec * 1000;
+    const method = req.method;
+    const route = normalizeRoute(req);
+    const status = String(res.statusCode);
+    const labels = { method, route, status };
+
+    httpRequestsTotal.inc(labels);
+    httpRequestDuration.observe(labels, durationSec);
+
+    if (res.statusCode >= 500) {
+      httpErrorsTotal.inc(labels);
+    }
+
+    if (durationMs > SLOW_REQUEST_THRESHOLD) {
+      logger.warn('Slow request detected', {
+        method,
+        route,
+        status: res.statusCode,
+        durationMs: Math.round(durationMs),
+        threshold: SLOW_REQUEST_THRESHOLD,
+      });
+    }
+
+    if ((process.env.LOG_FORMAT || '').toLowerCase() === 'json') {
+      logger.http('HTTP request', {
+        method,
+        route,
+        status: res.statusCode,
+        durationMs: Math.round(durationMs),
+        userId: req.user?.id || req.adminSession?.username || null,
+      });
+    }
+  });
+
+  next();
+}

--- a/server/observability/index.js
+++ b/server/observability/index.js
@@ -1,0 +1,47 @@
+/**
+ * Observability bootstrap: tracing, metrics, and /metrics endpoint.
+ */
+
+import { initTracing } from './tracing.js';
+import { httpMetricsMiddleware } from './httpMetrics.js';
+import { getMetricsText, getMetricsContentType } from './metrics.js';
+import { startBusinessMetricsCollectors } from './businessMetrics.js';
+
+export function initObservability(app) {
+  if (process.env.OTEL_ENABLED !== 'false') {
+    initTracing();
+  }
+
+  const metricsEnabled = process.env.METRICS_ENABLED !== 'false';
+
+  if (metricsEnabled) {
+    app.use(httpMetricsMiddleware);
+
+    app.get('/metrics', async (req, res) => {
+      const authToken = process.env.METRICS_AUTH_TOKEN;
+      if (authToken) {
+        const provided = req.headers.authorization?.replace(/^Bearer\s+/i, '');
+        if (provided !== authToken) {
+          return res.status(403).json({ error: 'Forbidden' });
+        }
+      }
+
+      try {
+        res.set('Content-Type', getMetricsContentType());
+        res.end(await getMetricsText());
+      } catch (err) {
+        res.status(500).end(`# metrics error: ${err.message}`);
+      }
+    });
+
+    if (process.env.NODE_ENV !== 'test') {
+      startBusinessMetricsCollectors();
+    }
+  }
+
+  return app;
+}
+
+export { recordCacheHit, recordCacheMiss } from './metrics.js';
+export { recordEventRegistration, recordEventCreated, recordPageLoad } from './metrics.js';
+export { getActiveTraceId, injectTraceHeaders } from './tracing.js';

--- a/server/observability/metrics.js
+++ b/server/observability/metrics.js
@@ -1,0 +1,128 @@
+/**
+ * Prometheus metrics registry and custom collectors for NexaSphere API.
+ */
+
+import client from 'prom-client';
+import { getPoolStats } from '../repositories/db.js';
+
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'nexasphere-api';
+
+export const register = new client.Registry();
+
+register.setDefaultLabels({ service: SERVICE_NAME });
+client.collectDefaultMetrics({ register, prefix: 'nexasphere_' });
+
+export const httpRequestsTotal = new client.Counter({
+  name: 'http_requests_total',
+  help: 'Total HTTP requests',
+  labelNames: ['method', 'route', 'status'],
+  registers: [register],
+});
+
+export const httpRequestDuration = new client.Histogram({
+  name: 'http_request_duration_seconds',
+  help: 'HTTP request duration in seconds',
+  labelNames: ['method', 'route', 'status'],
+  buckets: [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10],
+  registers: [register],
+});
+
+export const httpErrorsTotal = new client.Counter({
+  name: 'http_errors_total',
+  help: 'Total HTTP 5xx errors',
+  labelNames: ['method', 'route', 'status'],
+  registers: [register],
+});
+
+export const pgPoolConnections = new client.Gauge({
+  name: 'pg_pool_connections',
+  help: 'PostgreSQL connection pool stats',
+  labelNames: ['state'],
+  registers: [register],
+});
+
+export const redisCacheHits = new client.Counter({
+  name: 'redis_cache_hits_total',
+  help: 'Redis cache hits',
+  registers: [register],
+});
+
+export const redisCacheMisses = new client.Counter({
+  name: 'redis_cache_misses_total',
+  help: 'Redis cache misses',
+  registers: [register],
+});
+
+export const eventsRegisteredTotal = new client.Counter({
+  name: 'nexasphere_events_registered_total',
+  help: 'Total event registrations',
+  registers: [register],
+});
+
+export const eventsCreatedTotal = new client.Counter({
+  name: 'nexasphere_events_created_total',
+  help: 'Total events created',
+  registers: [register],
+});
+
+export const activeUsersOnline = new client.Gauge({
+  name: 'nexasphere_active_users_online',
+  help: 'Currently connected users via Socket.IO',
+  registers: [register],
+});
+
+export const pageLoadSeconds = new client.Histogram({
+  name: 'nexasphere_page_load_seconds',
+  help: 'Client-reported page load duration',
+  buckets: [0.1, 0.25, 0.5, 1, 2, 3, 5, 10],
+  registers: [register],
+});
+
+export const databaseUp = new client.Gauge({
+  name: 'nexasphere_database_up',
+  help: 'Database connectivity (1=up, 0=down)',
+  registers: [register],
+});
+
+export function recordCacheHit() {
+  redisCacheHits.inc();
+}
+
+export function recordCacheMiss() {
+  redisCacheMisses.inc();
+}
+
+export function recordEventRegistration() {
+  eventsRegisteredTotal.inc();
+}
+
+export function recordEventCreated() {
+  eventsCreatedTotal.inc();
+}
+
+export function recordPageLoad(durationSeconds) {
+  if (typeof durationSeconds === 'number' && durationSeconds >= 0) {
+    pageLoadSeconds.observe(durationSeconds);
+  }
+}
+
+export function updatePoolMetrics() {
+  const stats = getPoolStats();
+  if (!stats) {
+    databaseUp.set(0);
+    return;
+  }
+  databaseUp.set(1);
+  pgPoolConnections.set({ state: 'total' }, stats.total);
+  pgPoolConnections.set({ state: 'idle' }, stats.idle);
+  pgPoolConnections.set({ state: 'waiting' }, stats.waiting);
+}
+
+export async function getMetricsText() {
+  updatePoolMetrics();
+  return register.metrics();
+}
+
+export function getMetricsContentType() {
+  return register.contentType;
+}

--- a/server/observability/tracing.js
+++ b/server/observability/tracing.js
@@ -1,0 +1,61 @@
+/**
+ * OpenTelemetry tracing initialization and helpers.
+ */
+
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { SEMRESATTRS_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { trace, context, propagation } from '@opentelemetry/api';
+
+const SERVICE_NAME = process.env.OTEL_SERVICE_NAME || 'nexasphere-api';
+const OTLP_ENDPOINT =
+  process.env.OTEL_EXPORTER_OTLP_ENDPOINT || 'http://localhost:4318/v1/traces';
+
+let sdk = null;
+
+export function initTracing() {
+  if (process.env.OTEL_ENABLED === 'false') {
+    return null;
+  }
+
+  const exporter = new OTLPTraceExporter({ url: OTLP_ENDPOINT });
+
+  sdk = new NodeSDK({
+    resource: new Resource({
+      [SEMRESATTRS_SERVICE_NAME]: SERVICE_NAME,
+    }),
+    traceExporter: exporter,
+    instrumentations: [
+      getNodeAutoInstrumentations({
+        '@opentelemetry/instrumentation-fs': { enabled: false },
+      }),
+    ],
+  });
+
+  sdk.start();
+
+  process.on('SIGTERM', () => {
+    sdk?.shutdown().catch(() => {});
+  });
+
+  return sdk;
+}
+
+export function getActiveTraceId() {
+  const span = trace.getSpan(context.active());
+  if (!span) return null;
+  const ctx = span.spanContext();
+  return ctx.traceId && ctx.traceId !== '00000000000000000000000000000000'
+    ? ctx.traceId
+    : null;
+}
+
+export function injectTraceHeaders(headers = {}) {
+  const carrier = { ...headers };
+  propagation.inject(context.active(), carrier);
+  return carrier;
+}
+
+export { trace, context, propagation };

--- a/server/test/logger.test.js
+++ b/server/test/logger.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { appContext } from '../config/appContext.js';
+import { setTraceIdResolver } from '../utils/logContext.js';
+import { getLogContext } from '../utils/logContext.js';
+
+test('getLogContext includes reqId from appContext', () => {
+  setTraceIdResolver(() => 'trace-abc');
+
+  appContext.run({ reqId: 'req-123' }, () => {
+    const ctx = getLogContext();
+    assert.equal(ctx.reqId, 'req-123');
+    assert.equal(ctx.traceId, 'trace-abc');
+    assert.ok(ctx.service);
+  });
+});
+
+test('getLogContext falls back when no store', () => {
+  setTraceIdResolver(() => null);
+  const ctx = getLogContext();
+  assert.equal(ctx.reqId, null);
+  assert.equal(ctx.traceId, null);
+});

--- a/server/test/metrics.test.js
+++ b/server/test/metrics.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import express from 'express';
+import { initObservability } from '../observability/index.js';
+import {
+  httpRequestsTotal,
+  recordEventRegistration,
+  register,
+} from '../observability/metrics.js';
+
+test('GET /metrics returns Prometheus text format', async () => {
+  const prev = process.env.METRICS_ENABLED;
+  process.env.METRICS_ENABLED = 'true';
+  process.env.OTEL_ENABLED = 'false';
+
+  const app = express();
+  initObservability(app);
+  app.get('/ping', (_req, res) => res.status(200).send('ok'));
+
+  const server = app.listen(0);
+  const { port } = server.address();
+
+  try {
+    await fetch(`http://127.0.0.1:${port}/ping`);
+    const res = await fetch(`http://127.0.0.1:${port}/metrics`);
+    const body = await res.text();
+
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get('content-type') || '', /text\/plain/);
+    assert.match(body, /http_requests_total/);
+    assert.match(body, /nexasphere_/);
+  } finally {
+    server.close();
+    process.env.METRICS_ENABLED = prev;
+  }
+});
+
+test('custom counters increment', async () => {
+  const metric = register.getSingleMetric('nexasphere_events_registered_total');
+  const before = (await metric.get()).values.reduce((sum, v) => sum + v.value, 0);
+  recordEventRegistration();
+  const after = (await metric.get()).values.reduce((sum, v) => sum + v.value, 0);
+  assert.ok(after > before);
+});

--- a/server/test/observabilityInit.test.js
+++ b/server/test/observabilityInit.test.js
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import express from 'express';
+import { initObservability } from '../observability/index.js';
+
+test('initObservability registers /metrics without throwing', () => {
+  process.env.OTEL_ENABLED = 'false';
+  process.env.METRICS_ENABLED = 'true';
+
+  const app = express();
+  const result = initObservability(app);
+
+  assert.equal(result, app);
+  assert.equal(typeof app.get, 'function');
+});
+
+test('initObservability can be called once per app', () => {
+  process.env.OTEL_ENABLED = 'false';
+  const app = express();
+  initObservability(app);
+  assert.doesNotThrow(() => initObservability(app));
+});

--- a/server/utils/logContext.js
+++ b/server/utils/logContext.js
@@ -1,0 +1,23 @@
+/**
+ * Resolves correlation fields for structured log entries.
+ */
+
+import { appContext } from '../config/appContext.js';
+
+let getActiveTraceIdFn = () => null;
+
+export function setTraceIdResolver(fn) {
+  getActiveTraceIdFn = fn;
+}
+
+export function getLogContext(extra = {}) {
+  const store = appContext.getStore() || {};
+  const traceId = getActiveTraceIdFn() || store.traceId || null;
+
+  return {
+    service: process.env.OTEL_SERVICE_NAME || 'nexasphere-api',
+    reqId: store.reqId || null,
+    traceId,
+    ...extra,
+  };
+}


### PR DESCRIPTION
# Summary

Implements the full observability stack for NexaSphere (issue #1817): Prometheus metrics, ELK log aggregation, Jaeger distributed tracing, Grafana dashboards, and Alertmanager alert rules. Instruments the Node API and Python service, wires existing error-tracking scaffolding, and adds operational runbooks and smoke tests.

## Related Issue
Fixes #1817

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [x] Documentation
- [x] Testing
- [x] Infrastructure
- [x] Integration

## Changes Implemented

- Added `observability/` directory with Docker Compose overlay (Prometheus, Alertmanager, Grafana, Elasticsearch, Logstash, Kibana, Filebeat, Jaeger, node/redis exporters)
- Node API: `server/observability/` module — prom-client metrics, OpenTelemetry tracing, JSON logging with `traceId`/`reqId`, `GET /metrics`
- Wired `errorTrackingService.logError`, env-gated performance alerts, Slack error-rate alerts, cache/event/business metrics
- Python API: Prometheus instrumentator, OTel tracing, JSON logging, Celery queue depth gauge, `Dockerfile`
- Java: OTLP tracing endpoint config for Actuator/Prometheus scrape
- 5 provisioned Grafana dashboards, Prometheus alert rules, ELK ILM retention (30d default / 365d compliance)
- Kibana saved-search setup script, smoke-test script, team onboarding guide
- Fixed missing `compression` (Node) and `slowapi` (Python) dependencies; pyright config for IDE

## Technical Details

### Frontend
No frontend changes. Existing website Sentry integration unchanged.

### Backend
- **Node** (`server/observability/`): `metrics.js`, `httpMetrics.js`, `tracing.js`, `businessMetrics.js`, `initObservability()` in `server/index.js`
- **Logger** (`server/utils/logger.js`): `LOG_FORMAT=json` structured output with correlation IDs
- **Tracing** (`server/middleware/tracingMiddleware.js`): OTel spans + `X-Request-ID`; trace propagation in `server/config/appContext.js`
- **Python** (`server-python/main.py`): prometheus-fastapi-instrumentator, OTel, reorganized imports
- **Monitoring API** (`server/routes/monitoring.js`): `POST /api/monitoring/rum`, removed fake backup-status data

### Database
No schema changes. Exposes existing PostgreSQL pool stats via `pg_pool_connections` Prometheus gauge from `server/repositories/db.js`.

### API
- New: `GET /metrics` (Prometheus scrape)
- New: `POST /api/monitoring/rum` (page-load histogram, auth required)
- Existing `/api/monitoring/*` JSON API retained for backward compatibility

### Infrastructure
- `observability/docker-compose.observability.yml` overlays root `docker-compose.yml`
- OTEL disabled in base compose; enabled in observability overlay when Jaeger is present
- Alertmanager local config uses null receivers; `observability/alertmanager/alertmanager.prod.yml.example` for prod Slack/PagerDuty

## Screenshots

### Before
No centralized metrics, logs, or traces. In-memory metrics only; Winston files on disk; `X-Request-ID` without Jaeger.

### After
N/A — infrastructure PR. Verify via:
- Grafana http://localhost:3000 (NexaSphere folder)
- Prometheus http://localhost:9090/targets
- Kibana http://localhost:5601
- Jaeger http://localhost:16686

## Testing

### Unit Tests
- [x] `cd server && npm test` — **86 tests pass** (includes `metrics.test.js`, `logger.test.js`, `observabilityInit.test.js`, `tracing.test.js`, `performanceMonitor.test.js`, `errorTracking.test.js`)

### Integration Tests
- [ ] Not added (observability stack validated via compose smoke test)

### E2E Tests
- [ ] Not applicable

### Manual Testing
- [ ] `docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml up -d`
- [ ] `.\observability\scripts\smoke-test.ps1`
- [ ] Prometheus targets UP for `nexasphere-api`
- [ ] Kibana Discover → `nexasphere-logs-*` → `level:error`
- [ ] Jaeger → service `nexasphere-api`

## Security Review
- `/metrics` optionally protected via `METRICS_AUTH_TOKEN`
- `/api/monitoring/*` requires `MONITORING_API_TOKEN` (unchanged)
- Public `/api/monitoring/health` remains minimal (no env leakage)
- Alertmanager prod config example documents webhook keys — not committed

## Accessibility Review
Not applicable (no UI changes).

## Performance Impact
- Low overhead: prom-client histograms/counters per request; OTel spans when `OTEL_ENABLED=true`
- JSON logging consolidates HTTP logs when `LOG_FORMAT=json` (disables redundant morgan/console request logger)
- Observability stack is opt-in via compose overlay — no impact on default `docker compose up`

## Breaking Changes
- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes
- **Local/dev**: `docker compose -f docker-compose.yml -f observability/docker-compose.observability.yml up -d`
- **Render/Vercel prod**: See `observability/README.md` — ship stdout JSON logs to ELK/CloudWatch; point `OTEL_EXPORTER_OTLP_ENDPOINT` to managed Jaeger/Tempo
- Set env vars from `server/.env.example.monitoring`
- Python IDE setup: `server-python/scripts/setup-venv.ps1`

## Rollback Plan
1. Revert this PR
2. Remove observability compose overlay from deployment
3. Set `METRICS_ENABLED=false` and `OTEL_ENABLED=false` on API
4. Existing Sentry + Winston logging continues to work independently

## Checklist
- [x] Code follows project standards
- [x] Tests added or updated
- [x] Documentation updated (`observability/README.md`, `.env.example.monitoring`)
- [x] Security reviewed
- [x] Accessibility reviewed (N/A)
- [x] Performance validated (metrics middleware is lightweight; full stack optional)
- [ ] CI/CD passing
- [ ] Ready for review (pending assignment + manual docker smoke test)
