### PR TITLE
fix: throw config error for upstash http urls in ioredis

### DIFF
--- a/server/services/rateLimitService.js
+++ b/server/services/rateLimitService.js
@@ -47,6 +47,11 @@ class CappedMemoryStore {
 // Determine available Redis URL
 const redisUrl = process.env.REDIS_URL || process.env.UPSTASH_REDIS_REST_URL;
 
+if (process.env.UPSTASH_REDIS_REST_URL && !process.env.REDIS_URL) {
+  throw new Error(
+    'Configuration Error: ioredis does not support Upstash REST URLs. Please use a TCP connection string under REDIS_URL instead.'
+  );
+}
 if (redisUrl) {
   try {
     redisClient = new Redis(redisUrl, {


### PR DESCRIPTION
## Description
Added an explicit runtime configuration check to prevent `ioredis` from failing silently when an Upstash HTTP/REST URL is provided without a standard TCP connection string.

## Related Issue

Fixes #1163

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added validation logic in `rateLimitService.js`.
- The server now throws a descriptive configuration error immediately if `UPSTASH_REDIS_REST_URL` is set but `REDIS_URL` is missing.

## Technical Details

### Frontend
N/A

### Backend
Modified `server/services/rateLimitService.js` to evaluate `process.env.UPSTASH_REDIS_REST_URL` and `process.env.REDIS_URL` before initializing the Redis client. 

### Database
N/A

### API
N/A

### Infrastructure
N/A

## Screenshots

### Before
N/A (Backend console error)

### After
N/A (Backend console error)

## Testing

### Unit Tests

- [ ] 

### Integration Tests

- [ ] 

### E2E Tests

- [ ] 

### Manual Testing

- [x] Verified local server behavior when `.env` is configured with an Upstash REST URL and no standard Redis URL, confirming the custom error is thrown.

## Security Review
N/A

## Accessibility Review
N/A

## Performance Impact
Negligible. Adds a single environment variable check during service initialization.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes
N/A

## Rollback Plan
Revert commit if dynamic import of the rate limiter is negatively impacted.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [x] CI/CD passing
- [x] Ready for review