### PR TITLE
fix: remove hardcoded secret from application-dev.properties

### DIFF
--- a/server-java/src/main/resources/application-dev.properties
+++ b/server-java/src/main/resources/application-dev.properties
@@ -1,6 +1,6 @@
 # ─── Dev profile: H2 in-memory, Flyway disabled (JPA handles schema) ───
 ADMIN_EMAIL=${ADMIN_EMAIL:nexasphere@glbajajgroup.org}
-ADMIN_PASSWORD=${ADMIN_PASSWORD:admin@123}
+ADMIN_PASSWORD=${ADMIN_PASSWORD:CHANGE_ME}
 CORS_ORIGIN=http://localhost:5173,http://localhost:5174,http://localhost:5175,http://localhost:5001
 
 spring.datasource.url=jdbc:h2:mem:nexaspheredb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;NON_KEYWORDS=VALUE


### PR DESCRIPTION
# Description
This PR addresses a security vulnerability (CWE-798) identified in the development configuration file where an administrative password was hardcoded as a default value.

## Related Issue
Closes #1891

## Type of Change
- [x] Security Enhancement

## Changes Implemented

1. Updated `server-java/src/main/resources/application-dev.properties` to replace the hardcoded `ADMIN_PASSWORD` default value with `CHANGE_ME`.
2. Ensured that sensitive credentials are no longer committed directly to the version control system.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [x] CI/CD passing
- [x] Ready for review