### PR TITLE
fix: clear Typewriter setInterval on unmount (#1941)

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -13,18 +13,19 @@ function Typewriter({ text, speed = 10 }) {
   const [done, setDone] = useState(false);
   const ref = useRef(null);
   const started = useRef(false);
+  const intervalRef = useRef(null);
   useEffect(() => {
     const obs = new IntersectionObserver(
       ([e]) => {
         if (e.isIntersecting && !started.current) {
           started.current = true;
           let i = 0;
-          const t = setInterval(() => {
+          intervalRef.current = setInterval(() => {
             setDisplayed(text.slice(0, i + 1));
             i++;
             if (i >= text.length) {
               setDone(true);
-              clearInterval(t);
+              clearInterval(intervalRef.current);
             }
           }, speed);
         }
@@ -32,7 +33,10 @@ function Typewriter({ text, speed = 10 }) {
       { threshold: 0.3 }
     );
     if (ref.current) obs.observe(ref.current);
-    return () => obs.disconnect();
+    return () => {
+      obs.disconnect();
+      clearInterval(intervalRef.current);
+    };
   }, [text, speed]);
   return (
     <span ref={ref}>


### PR DESCRIPTION
## Description

The `Typewriter` component in `EventDetailPage` starts a `setInterval` inside an `IntersectionObserver` callback but only called `obs.disconnect()` on cleanup — the interval itself was never cancelled. If the component unmounted before the animation finished the interval kept firing, attempting `setState` on an unmounted component (memory leak + React warning).

Fix: store the interval handle in a `useRef` and call `clearInterval` in the `useEffect` cleanup alongside `obs.disconnect()`.

## Related Issue

Fixes #1941

## Type of Change

- [x] Bug Fix

## Changes Implemented

`website/src/pages/events/EventDetailPage.jsx` — `Typewriter` component: added `intervalRef = useRef(null)`, assigned `setInterval` return to `intervalRef.current`, and added `clearInterval(intervalRef.current)` to the cleanup function.

## Technical Details

### Frontend

The IntersectionObserver fires when the element enters the viewport and immediately starts the interval. Because the interval handle was only a local `const t`, the cleanup closure had no reference to it. The fix uses a ref so the cleanup always has access regardless of when unmount happens.

## Testing

### Manual Testing

- [x] Navigate to an event detail page and switch routes before the typewriter finishes — no React unmounted-component warning in console.

## Security Review

No security impact.

## Accessibility Review

No change to accessible elements.

## Performance Impact

Prevents a minor memory/timer leak on navigation.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] I have performed a self-review of my own code
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] CI/CD passing
- [x] Ready for review