### PR TITLE
fix: enforce 5 MB file size limit in ResumeUploader (#1942)

### DIFF
--- a/website/src/components/ResumeAnalyzer/ResumeUploader.jsx
+++ b/website/src/components/ResumeAnalyzer/ResumeUploader.jsx
@@ -6,6 +6,8 @@ export default function ResumeUploader({ onUpload }) {
   const [error, setError] = useState('');
   const inputRef = useRef();
 
+  const MAX_SIZE_BYTES = 5 * 1024 * 1024;
+
   const handleFile = (f) => {
     if (!f) return;
     const allowed = [
@@ -15,6 +17,10 @@ export default function ResumeUploader({ onUpload }) {
     ];
     if (!allowed.includes(f.type)) {
       setError('Please upload a PDF or DOC/DOCX file.');
+      return;
+    }
+    if (f.size > MAX_SIZE_BYTES) {
+      setError('File exceeds the 5 MB size limit. Please upload a smaller file.');
       return;
     }
     setError('');


### PR DESCRIPTION
## Description

The resume upload zone displayed **"Max 5MB"** in its label but `handleFile` never validated `file.size`, so arbitrarily large files were silently forwarded to `onUpload` and eventually the backend. This fix adds an explicit size check that rejects files over 5 MB and surfaces a descriptive error message to the user — mirroring the existing MIME-type validation pattern.

## Related Issue

Fixes #1942

## Type of Change

- [x] Bug Fix
- [x] Security Enhancement

## Changes Implemented

`website/src/components/ResumeAnalyzer/ResumeUploader.jsx` — added `MAX_SIZE_BYTES = 5 * 1024 * 1024` constant and an `f.size > MAX_SIZE_BYTES` guard in `handleFile` that sets an error and returns early before calling `onUpload`.

## Technical Details

### Frontend

The guard is placed after the MIME-type check so the error messages are evaluated in a logical order (wrong type → wrong size → accept). The error renders in the existing `role="alert"` element, so screen readers announce it automatically.

## Testing

### Manual Testing

- [x] Upload a file > 5 MB — error message appears, `onUpload` is never called.
- [x] Upload a valid PDF ≤ 5 MB — accepted as before.
- [x] Upload a file with wrong MIME type — existing error shown, size check not reached.

## Security Review

Prevents large payloads from reaching the backend through the resume analyzer flow.

## Accessibility Review

Error message uses the existing `role="alert"` element — no new a11y work needed.

## Performance Impact

Negligible (synchronous `size` property read before any network call).

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] I have performed a self-review of my own code
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] CI/CD passing
- [x] Ready for review