### PR TITLE
fix: cancel mount setTimeout on unmount in EventDetailPage (#1943)

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -472,7 +472,7 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
   const [regSubmitting, setRegSubmitting] = useState(false);
   useEffect(() => {
     window.scrollTo({ top: 0 });
-    setTimeout(() => setMounted(true), 60);
+    const mountTimer = setTimeout(() => setMounted(true), 60);
 
     // Local scroll-reveal observer — sub-pages mount after the global observer ran
     const obs = new IntersectionObserver(
@@ -491,7 +491,10 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
         '#event-detail-page .pop-in, #event-detail-page .pop-left, #event-detail-page .pop-right, #event-detail-page .pop-scale'
       )
       .forEach((el) => obs.observe(el));
-    return () => obs.disconnect();
+    return () => {
+      clearTimeout(mountTimer);
+      obs.disconnect();
+    };
   }, []);
 
   const isUpcoming = event.status === 'upcoming';


### PR DESCRIPTION
## Description

`EventDetailPage`'s mount `useEffect` called `setTimeout(() => setMounted(true), 60)` without capturing the return value, making it impossible to cancel. If a user navigated away within those 60 ms the timer fired on an unmounted component, triggering a React state-update-on-unmounted-component warning and a potential memory leak.

Fix: store the timer id in `mountTimer` and call `clearTimeout(mountTimer)` in the existing cleanup function alongside `obs.disconnect()`.

## Related Issue

Fixes #1943

## Type of Change

- [x] Bug Fix

## Changes Implemented

`website/src/pages/events/EventDetailPage.jsx` — assigned `setTimeout` return to `const mountTimer` and added `clearTimeout(mountTimer)` to the `useEffect` cleanup function.

## Technical Details

### Frontend

The cleanup previously only called `obs.disconnect()`. Adding `clearTimeout` ahead of it ensures both the observer and the pending timer are torn down when the component unmounts, regardless of how quickly the user navigates away.

## Testing

### Manual Testing

- [x] Navigate to an event detail page and immediately press Back — no React warning in the console.

## Security Review

No security impact.

## Accessibility Review

No change to accessible elements.

## Performance Impact

Negligible.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] I have performed a self-review of my own code
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] CI/CD passing
- [x] Ready for review