### PR TITLE
fix: block registration for events whose date has passed (#1944)

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -495,7 +495,9 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
   }, []);
 
   const isUpcoming = event.status === 'upcoming';
-  const canRegister = isUpcoming && event.capacity > 0;
+  const eventEnd = event.endDate ?? event.startDate ?? event.date;
+  const isInFuture = eventEnd ? new Date(eventEnd) > new Date() : isUpcoming;
+  const canRegister = isUpcoming && isInFuture && event.capacity > 0;
 
   const handleRegField = (field) => (e) => setRegForm((f) => ({ ...f, [field]: e.target.value }));
   const handleRegistration = async (e) => {


### PR DESCRIPTION
## Description

`canRegister` was gated solely on `event.status === 'upcoming'` — a static field set at publish time that is never automatically updated. An event marked `'upcoming'` months ago would continue showing the **Register** tab long after it had concluded.

Fix: derive `isInFuture` by comparing the event's `endDate` (falling back to `startDate`, then `date`) against the current time, and add it as an additional gate on `canRegister`. If no parseable date exists the old `isUpcoming` flag is kept as a fallback so legacy records are unaffected.

## Related Issue

Fixes #1944

## Type of Change

- [x] Bug Fix

## Changes Implemented

`website/src/pages/events/EventDetailPage.jsx`:

```js
const eventEnd = event.endDate ?? event.startDate ?? event.date;
const isInFuture = eventEnd ? new Date(eventEnd) > new Date() : isUpcoming;
const canRegister = isUpcoming && isInFuture && event.capacity > 0;
```

## Technical Details

### Frontend

The three-level date fallback (`endDate → startDate → date`) mirrors the field hierarchy already used by `EventCountdown` and `EventCalendarView`. The check runs on every render so it stays accurate without a polling timer.

## Testing

### Manual Testing

- [x] Event with `status: 'upcoming'` and a past `endDate` — Register tab is hidden.
- [x] Event with `status: 'upcoming'` and a future `endDate` — Register tab is shown.
- [x] Event with `status: 'completed'` — Register tab is hidden (unchanged).
- [x] Event with no date fields — falls back to `isUpcoming`, behaviour unchanged.

## Security Review

Removes the misleading frontend registration path for concluded events. The backend must also validate dates independently.

## Accessibility Review

No change to accessible elements.

## Performance Impact

One `new Date()` call per render — negligible.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] I have performed a self-review of my own code
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] CI/CD passing
- [x] Ready for review