### PR TITLE
fix: respect prefers-reduced-motion in NotificationBell (WCAG 2.3.3) (#1945)

### DIFF
--- a/website/src/components/NotificationBell.jsx
+++ b/website/src/components/NotificationBell.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion, AnimatePresence, useReducedMotion } from 'framer-motion';
 import { MessageCircle, Users, AtSign, Settings, X, CheckCheck, Trash2 } from 'lucide-react';
 import { useNotifications } from '../hooks/useNotifications';
 import { formatRelativeTime } from '../utils/formatRelativeTime';
@@ -22,6 +22,7 @@ export default function NotificationBell() {
     clearAll,
   } = useNotifications();
 
+  const shouldReduceMotion = useReducedMotion();
   const panelRef = useRef(null);
 
   // Close on outside click
@@ -71,7 +72,7 @@ export default function NotificationBell() {
         }}
       >
         <motion.div
-          animate={unreadCount > 0 ? { rotate: [0, -15, 15, -10, 10, 0] } : {}}
+          animate={unreadCount > 0 && !shouldReduceMotion ? { rotate: [0, -15, 15, -10, 10, 0] } : {}}
           transition={{ duration: 0.5, repeat: Infinity, repeatDelay: 4 }}
           style={{
             display: 'flex',
@@ -120,10 +121,10 @@ export default function NotificationBell() {
         {isOpen && (
           <motion.div
             id="notification-panel"
-            initial={{ opacity: 0, y: -10, scale: 0.96 }}
+            initial={{ opacity: 0, y: shouldReduceMotion ? 0 : -10, scale: shouldReduceMotion ? 1 : 0.96 }}
             animate={{ opacity: 1, y: 0, scale: 1 }}
-            exit={{ opacity: 0, y: -8, scale: 0.96 }}
-            transition={{ duration: 0.2, ease: [0.22, 1, 0.36, 1] }}
+            exit={{ opacity: 0, y: shouldReduceMotion ? 0 : -8, scale: shouldReduceMotion ? 1 : 0.96 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.2, ease: [0.22, 1, 0.36, 1] }}
             style={{
               position: 'absolute',
               top: 'calc(100% + 10px)',


### PR DESCRIPTION
## Description

The notification bell in `NotificationBell.jsx` played an infinite rotation shake (`rotate: [0,-15,15,-10,10,0]`, `repeat: Infinity`) whenever unread notifications were present, with no regard for the user's `prefers-reduced-motion` OS setting. This violates WCAG 2.3.3 (Animation from Interactions) and can cause discomfort or harm for users with vestibular disorders.

Additionally the notification panel's enter/exit transitions included `y` translation and `scale` changes — also motion that should be suppressed under reduced-motion.

Fix: import `useReducedMotion` from `framer-motion` (already a project dependency) and use it to:
1. Skip the infinite bell shake entirely.
2. Collapse panel transitions to an instant opacity-only fade (duration `0`, no translate/scale).

## Related Issue

Fixes #1945

## Type of Change

- [x] Bug Fix
- [x] Accessibility

## Changes Implemented

`website/src/components/NotificationBell.jsx`:
- Added `useReducedMotion` to the framer-motion import.
- Called `const shouldReduceMotion = useReducedMotion()` at the top of the component.
- Bell `animate` prop: `unreadCount > 0 && !shouldReduceMotion ? { rotate: [...] } : {}`.
- Panel `initial`/`exit`: `y` and `scale` values set to neutral (`0` / `1`) when reduced motion is preferred.
- Panel `transition.duration`: set to `0` when reduced motion is preferred.

## Technical Details

### Frontend

`useReducedMotion()` reads `(prefers-reduced-motion: reduce)` reactively via the browser Media Query API — no manual `matchMedia` wiring. The hook is part of `framer-motion` which is already listed in the project's dependencies.

## Testing

### Manual Testing

- [x] Enable **Reduce Motion** in macOS/Windows accessibility settings → bell is static, panel appears/disappears instantly with no slide or scale.
- [x] Disable **Reduce Motion** → full shake + slide + scale animations play as before.

## Security Review

No security impact.

## Accessibility Review

Directly addresses **WCAG 2.3.3 — Animation from Interactions (AAA)**: decorative and repeated motion is suppressed when the user has expressed a preference for reduced motion via their OS accessibility settings.

## Performance Impact

Removes an `Infinity`-repeat CSS animation loop for affected users — minor CPU saving.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] I have performed a self-review of my own code
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] CI/CD passing
- [x] Ready for review