### PR TITLE
fix: replace as any casts with StaticRoadmap type in RoadmapBuilder

### DIFF
--- a/website/src/components/roadmaps/RoadmapBuilder.tsx
+++ b/website/src/components/roadmaps/RoadmapBuilder.tsx
@@ -3,7 +3,7 @@ import { RoadmapBuilderProvider } from '../../context/RoadmapBuilderContext';
 import { useRoadmapBuilder } from '../../hooks/useRoadmapBuilder';
 import { NodeCanvas } from './NodeCanvas';
 import { NodeModal } from './NodeModal';
-import { parseStaticRoadmap } from '../../utils/roadmapParser';
+import { parseStaticRoadmap, type StaticRoadmap } from '../../utils/roadmapParser';
 import {
   exportToJSON,
   validateRoadmapJSON,
@@ -11,6 +11,10 @@ import {
   downloadPNG,
 } from '../../utils/exportRoadmap';
 import { roadmapData } from '../../data/roadmapData';
+
+// Use StaticRoadmap from roadmapParser — eliminates as any casts
+// when accessing domain keys and title fields in the builder.
+type RoadmapDataMap = Record<string, StaticRoadmap>;
 import {
   ArrowLeft,
   Plus,
@@ -83,7 +87,7 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
   // Import static NexaSphere Roadmaps
   const handleImportStatic = (domainKey: string) => {
     if (!domainKey) return;
-    const staticData = (roadmapData as any)[domainKey];
+    const staticData = (roadmapData as RoadmapDataMap)[domainKey];
     if (!staticData) return;
 
     if (
@@ -242,7 +246,7 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
               </option>
               {Object.keys(roadmapData).map((key) => (
                 <option key={key} value={key}>
-                  {(roadmapData as any)[key].title}
+                  {(roadmapData as RoadmapDataMap)[key].title}
                 </option>
               ))}
             </select>

--- a/website/src/utils/roadmapParser.ts
+++ b/website/src/utils/roadmapParser.ts
@@ -15,7 +15,7 @@ interface StaticNode {
   practice?: StaticResource[];
 }
 
-interface StaticRoadmap {
+export interface StaticRoadmap {
   title: string;
   description: string;
   nodes: StaticNode[];


### PR DESCRIPTION
## Description
`RoadmapBuilder.tsx` used `(roadmapData as any)` twice to access roadmap entries by dynamic key:

```ts
const staticData = (roadmapData as any)[domainKey];
// ...
{(roadmapData as any)[key].title}
```

Using `as any` bypassed TypeScript's type checking — if `roadmapData` keys or the shape of each entry (e.g. the `title` field) changed, TypeScript would not catch the mismatch and the builder would silently render `undefined` values or crash at runtime.

Changes made:
- Exported `StaticRoadmap` interface from `roadmapParser.ts` (it was already defined there but unexported)
- Imported `type StaticRoadmap` alongside the existing `parseStaticRoadmap` import in `RoadmapBuilder.tsx`
- Defined `type RoadmapDataMap = Record<string, StaticRoadmap>`
- Replaced both `(roadmapData as any)` casts with `(roadmapData as RoadmapDataMap)` — TypeScript now enforces the correct shape on all roadmap data access
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2007

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings