### PR TITLE
fix: use correct snake_case table names in recommendation_logic SQL q…

### DIFF
--- a/server-python/services/recommendation_logic.py
+++ b/server-python/services/recommendation_logic.py
@@ -55,11 +55,11 @@ def fetch_data_with_sqlalchemy(user_id):
         try:
             with engine.connect() as conn:
                 # 1. Fetch Events
-                events_result = conn.execute(text('SELECT id, name, tags FROM "Events" WHERE status != \'completed\''))
+                events_result = conn.execute(text("SELECT id, name, tags FROM events WHERE status != 'completed'"))
                 events = [{"id": row.id, "name": row.name, "tags": row.tags} for row in events_result]
                 
                 # 2. Fetch all User Profiles
-                users_result = conn.execute(text('SELECT id, interests FROM "Profile"'))
+                users_result = conn.execute(text("SELECT id, interests FROM profiles"))
                 for row in users_result:
                     user_interests = row.interests
                     if isinstance(user_interests, str):


### PR DESCRIPTION
## Description
Fixes incorrect mixed-case quoted table names in `server-python/services/recommendation_logic.py` that caused silent DB query failures. PostgreSQL is case-sensitive for quoted identifiers — `"Events"` and `"Profile"` were failing with `relation does not exist`, causing the recommendation engine to always fall back to mock data even when the database was available.

Fixes #1938

## Changes
- `"Events"` → `events` in SQL query
- `"Profile"` → `profiles` in SQL query
- `event_participants` was already correct snake_case

## Before / After
```py
# Before 
events_result = conn.execute(text('SELECT id, name, tags FROM "Events" WHERE status != \'completed\''))
users_result = conn.execute(text('SELECT id, interests FROM "Profile"'))

# After 
events_result = conn.execute(text("SELECT id, name, tags FROM events WHERE status != 'completed'"))
users_result = conn.execute(text("SELECT id, interests FROM profiles"))
```

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings