### PR TITLE
fix: replace React.FC<any> and entry:any with typed props in CustomTooltip

### DIFF
--- a/website/src/components/analytics/ChartComponents.tsx
+++ b/website/src/components/analytics/ChartComponents.tsx
@@ -98,7 +98,19 @@ export const ChartWrapper: React.FC<ChartWrapperProps> = ({
   );
 };
 
-export const CustomTooltip: React.FC<any> = ({ active, payload, label }) => {
+interface TooltipPayloadEntry {
+  color?: string;
+  name?: string;
+  value?: number | string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayloadEntry[];
+  label?: string;
+}
+
+export const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, label }) => {
   if (active && payload && payload.length) {
     return (
       <div
@@ -123,7 +135,7 @@ export const CustomTooltip: React.FC<any> = ({ active, payload, label }) => {
         >
           {label}
         </p>
-        {payload.map((entry: any, index: number) => (
+        {payload.map((entry, index: number) => (
           <div
             key={`item-${index}`}
             style={{


### PR DESCRIPTION
## Description
`ChartComponents.tsx` typed `CustomTooltip` as `React.FC<any>` and mapped payload entries as `(entry: any)`:

```ts
export const CustomTooltip: React.FC<any> = ({ active, payload, label }) => {
  // ...
  {payload.map((entry: any, index: number) => (
```

Using `any` bypassed TypeScript's checks on all tooltip fields — `entry.color`, `entry.name`, `entry.value` were all untyped. If any field was misread or the Recharts payload shape changed, errors would only surface at runtime.

Changes made:
- Defined `TooltipPayloadEntry` interface with `color`, `name`, and `value` fields matching what Recharts passes to custom tooltip components
- Defined `CustomTooltipProps` interface with `active`, `payload`, and `label` typed correctly
- Replaced `React.FC<any>` with `React.FC<CustomTooltipProps>`
- Removed `(entry: any)` annotation — `entry` is now inferred as `TooltipPayloadEntry` from the typed payload array
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2009

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings