### PR TITLE
fix: replace inline import.meta.env reads with getApiBase() in AdminPage

### DIFF
--- a/website/src/pages/admin/AdminPage.jsx
+++ b/website/src/pages/admin/AdminPage.jsx
@@ -5,6 +5,7 @@ import UserGrowthChart from '../../components/admin/analytics/UserGrowthChart';
 import EventAttendanceChart from '../../components/admin/analytics/EventAttendanceChart';
 import '../../components/admin/analytics/analytics.css';
 import socketClient from '../../utils/socketClient';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 export default function AdminPage({ onBack }) {
   const [loading, setLoading] = useState(false);
@@ -23,7 +24,7 @@ export default function AdminPage({ onBack }) {
   const fetchAnalytics = async () => {
     try {
       setLoading(true);
-      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const base = getApiBase();
       const authToken = token || localStorage.getItem('ns_admin_token');
       const headers = { Authorization: `Bearer ${authToken}` };
 
@@ -51,7 +52,7 @@ export default function AdminPage({ onBack }) {
   useEffect(() => {
     if (!isLoggedIn) return;
 
-    const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+    const base = getApiBase();
     const url = `${base}/api/admin/metrics/stream`;
 
     const listeners = {};
@@ -181,7 +182,7 @@ export default function AdminPage({ onBack }) {
     e.preventDefault();
     try {
       setLoading(true);
-      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const base = getApiBase();
       const result = await apiClient(`${base}/api/admin/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -205,7 +206,7 @@ export default function AdminPage({ onBack }) {
 
   const handleLogout = async () => {
     try {
-      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const base = getApiBase();
       await fetch(`${base}/api/admin/logout`, {
         method: 'POST',
         credentials: 'include',


### PR DESCRIPTION
## Description
`AdminPage.jsx` had 4 inline copies of the same URL resolution expression across different handlers:

```js
const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js` — the same utility used across all other pages in the codebase. Having 4 inline copies means if the resolution logic in `runtimeConfig.js` ever changes, admin API calls would silently diverge.

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Replaced all 4 inline `base` declarations with `const base = getApiBase()`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2018

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings