### PR TITLE
fix: replace inline import.meta.env reads with getApiBase() in team pages

### DIFF
--- a/website/src/pages/team/TeamPage.jsx
+++ b/website/src/pages/team/TeamPage.jsx
@@ -12,6 +12,7 @@ import TeamMemberModal from './TeamMemberModal';
 import { IconSpark } from '../../shared/Icons';
 import { BannerOrbs } from '../../shared/MotionLayer';
 import Footer from '../../shared/Footer';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 function MemberCard({ member, idx, onClick, triggerRef }) {
   const ref = useRef(null);
@@ -106,7 +107,7 @@ export default function TeamPage({ onBack, onApply }) {
 
   useEffect(() => {
     let alive = true;
-    const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+    const base = getApiBase();
     const applyLocalTeam = () => {
       if (alive) setMembers(getLocalTeamMembers(teamMembers));
     };

--- a/website/src/pages/team/TeamSection.jsx
+++ b/website/src/pages/team/TeamSection.jsx
@@ -4,6 +4,7 @@ import { on, off } from '../../utils/socketClient.js';
 import TeamMemberModal from './TeamMemberModal';
 import { IconSpark } from '../../shared/Icons';
 import { teamMembers as fallbackTeamMembers } from '../../data/teamData';
+import { getApiBase } from '../../utils/runtimeConfig';
 import {
   getLocalTeamMembers,
   mergeTeamMembers,
@@ -95,7 +96,7 @@ export default function TeamSection({ onApply }) {
 
   useEffect(() => {
     let alive = true;
-    const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+    const base = getApiBase();
     const applyLocalTeam = () => {
       if (alive) setMembers(getLocalTeamMembers(fallbackTeamMembers));
     };


### PR DESCRIPTION
## Description
`TeamPage.jsx` and `TeamSection.jsx` both inlined the same API base URL expression:

```js
const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js` — the same utility used across all other pages. If the resolution logic changes, team API calls would silently diverge from the rest of the codebase.

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'` to both `TeamPage.jsx` and `TeamSection.jsx`
- Replaced inline `base` declarations with `const base = getApiBase()`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2024

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings