### PR TITLE
fix: replace inline import.meta.env read with getApiBase() in ActivityDetailPage

### DIFF
--- a/website/src/pages/activities/ActivityDetailPage.jsx
+++ b/website/src/pages/activities/ActivityDetailPage.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { DynamicIcon } from '../../shared/Icons';
 import apiClient from '../../utils/apiClient.js';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 /* ── Animated counter ── */
 function Counter({ value, suffix = '' }) {
@@ -351,7 +352,7 @@ export default function ActivityDetailPage({ activity, onBack, onSelectEvent }) 
   const [mounted, setMounted] = useState(false);
   const [manualEvents, setManualEvents] = useState([]);
   const [fetchState, setFetchState] = useState('idle'); // 'idle' | 'loading' | 'done' | 'error'
-  const apiBase = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+  const apiBase = getApiBase();
   const activityKey = encodeURIComponent(activity.title);
 
   /* ── Fetch API-managed events with loading state ── */


### PR DESCRIPTION
## Description
`ActivityDetailPage.jsx` inlined the API base URL expression:

```js
const apiBase = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js` — the same utility used across all other pages. If the resolution logic changes, activity detail API calls would silently diverge from the rest of the codebase.

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Replaced inline `apiBase` declaration with `const apiBase = getApiBase()`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2025

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings