### PR TITLE
fix: replace inline import.meta.env reads with getApiBase() in PortfolioBuilder

### DIFF
--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import apiClient from '../../utils/apiClient.js';
+import { getApiBase } from '../../utils/runtimeConfig';
 import { projectsData } from '../../data/projectsData';
 import { roadmapData } from '../../data/roadmapData';
 import { RepoCardSkeleton } from '../ui/skeleton/RepoCardSkeleton';
@@ -81,7 +82,7 @@ export default function PortfolioBuilder() {
     setErrorMsg('');
     setSuccessMsg('');
     try {
-      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const base = getApiBase();
       const url = base ? `${base}/api/portfolio/${username}` : `/api/portfolio/${username}`;
       const data = await apiClient(url);
       if (data) {
@@ -143,7 +144,7 @@ export default function PortfolioBuilder() {
         customProjects,
       };
 
-      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const base = getApiBase();
       const url = base ? `${base}/api/portfolio` : `/api/portfolio`;
 
       const data = await apiClient(url, {


### PR DESCRIPTION
## Description
`PortfolioBuilder.jsx` inlined the same API base URL expression in two separate handlers:

```js
const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js` — the same utility used across all other pages. If the resolution logic changes, portfolio builder API calls would silently diverge from the rest of the codebase.

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Replaced both inline `base` declarations with `const base = getApiBase()`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2028

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings