### PR TITLE
fix: remove debug console.log from handleSelect in Events.jsx

### DIFF
--- a/website/src/pages/Events.jsx
+++ b/website/src/pages/Events.jsx
@@ -45,7 +45,6 @@ const Events = () => {
   // Fix 2: useCallback — stable function reference, won't invalidate React.memo
   const handleSelect = useCallback((id) => {
     setSelectedEvent(id);
-    console.log('Selected event id:', id);
   }, []);
 
   return (


### PR DESCRIPTION
## Description
`Events.jsx` had a debug `console.log` left in the `handleSelect` callback:

```js
const handleSelect = useCallback((id) => {
  setSelectedEvent(id);
  console.log('Selected event id:', id); // ← debug log
}, []);
```

This fired every time a user clicked an event, logging internal event IDs to the browser console for all users. Anyone with DevTools open could see the internal IDs of every event the user selected.

Changes made:
- Removed `console.log('Selected event id:', id)` from `handleSelect`
- `setSelectedEvent(id)` is preserved — no functional change
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2029

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings