### PR TITLE
fix: remove static API_BASE export from config.js and replace usages with getApiBase()

### DIFF
--- a/website/src/data/config.js
+++ b/website/src/data/config.js
@@ -1,5 +1,3 @@
-export const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/+$/, '');
-
 export const THEME_STORAGE_KEY = 'ns-theme';
 export const DEFAULT_THEME = 'dark';
 

--- a/website/src/hooks/useDataHooks.js
+++ b/website/src/hooks/useDataHooks.js
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
-import { API_BASE, THEME_STORAGE_KEY, DEFAULT_THEME, EVENTS_API_ENDPOINT } from '../data/config';
+import { THEME_STORAGE_KEY, DEFAULT_THEME, EVENTS_API_ENDPOINT } from '../data/config';
+import { getApiBase } from '../utils/runtimeConfig';
 
 export function useThemeManagement() {
   const [theme, setTheme] = useState(
@@ -26,7 +27,8 @@ export function useDynamicEvents(fallbackEvents) {
 
   useEffect(() => {
     let isMounted = true;
-    const url = API_BASE ? `${API_BASE}${EVENTS_API_ENDPOINT}` : EVENTS_API_ENDPOINT;
+    const base = getApiBase();
+    const url = base ? `${base}${EVENTS_API_ENDPOINT}` : EVENTS_API_ENDPOINT;
 
     fetch(url)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error('Failed to load events'))))

--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react';
 import { DynamicIcon } from '../../shared/Icons';
-import { API_BASE } from '../../data/config';
+import { getApiBase } from '../../utils/runtimeConfig';
 import apiClient from '../../utils/apiClient';
 
 function hexToRgb(hex) {
@@ -513,7 +513,7 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
     setRegError('');
     setRegSubmitting(true);
     try {
-      const base = API_BASE || '';
+      const base = getApiBase();
       const url = `${base}/api/content/events/${event.id}/register`;
       const data = await apiClient(url, {
         method: 'POST',
@@ -536,7 +536,7 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
   };
 
   const handleCalendarDownload = () => {
-    const base = API_BASE || '';
+    const base = getApiBase();
     const url = `${base}/api/content/events/${event.id}/calendar`;
     window.open(url, '_blank');
   };


### PR DESCRIPTION
## Description
`website/src/data/config.js` exported `API_BASE` as a module-level constant computed once at import time:

```js
export const API_BASE = (import.meta.env.VITE_API_BASE || '').replace(/\/+$/, '');
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js`. Two files imported `API_BASE` from `config.js` instead of using the shared utility — `useDataHooks.js` and `EventDetailPage.jsx`. `EventDetailPage.jsx` additionally had two inline `const base = API_BASE || ''` usages, giving it three different access patterns for the same value.

Changes made:
- Removed `API_BASE` export from `config.js`
- Updated `useDataHooks.js` to `import { getApiBase } from '../utils/runtimeConfig'` and replaced `API_BASE` usage with `getApiBase()` inside `useDynamicEvents`
- Updated `EventDetailPage.jsx` to `import { getApiBase } from '../../utils/runtimeConfig'` and replaced all three `API_BASE` usages with `getApiBase()` calls
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2032

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings