### PR TITLE
fix: remove debug console.log from Events.jsx

### DIFF
--- a/website/src/pages/Events.jsx
+++ b/website/src/pages/Events.jsx
@@ -45,7 +45,6 @@ const Events = () => {
   // Fix 2: useCallback — stable function reference, won't invalidate React.memo
   const handleSelect = useCallback((id) => {
     setSelectedEvent(id);
-    console.log('Selected event id:', id);
   }, []);
 
   return (


### PR DESCRIPTION
**Fixes:** #2029

### What this changes

Removes a leftover debug statement from `Events.jsx` that was logging selected event IDs to the browser console in production.

```js
// Removed:
console.log('Selected event id:', id);
```

This line leaks internal event selection data to any user who opens browser DevTools and was likely left in accidentally during development.

### Why it matters

- No functional change — purely a cleanup
- Prevents data leakage visible to end users in the browser console
- Aligns with the project's other production-clean components

### How to test

1. Open the Events page in a browser
2. Open DevTools → Console
3. Select any event
4. Confirm no `"Selected event id:"` log appears