### PR TITLE
Prevent trace header leakage and fix pg query patching

### DIFF
--- a/server/config/appContext.js
+++ b/server/config/appContext.js
@@ -4,40 +4,109 @@ import { propagation, context as otelContext } from '@opentelemetry/api';
 
 export const appContext = new AsyncLocalStorage();
 
-// Global patch for pg module to automatically append the Correlation ID to all queries
-const originalClientQuery = pg.Client.prototype.query;
-pg.Client.prototype.query = function (config, values, callback) {
-  const store = appContext.getStore();
-  if (store?.reqId) {
-    if (typeof config === 'string') {
-      config = `/* reqId: ${store.reqId} */ ${config}`;
-    } else if (config && typeof config.text === 'string') {
-      config.text = `/* reqId: ${store.reqId} */ ${config.text}`;
+// Idempotency guards — prevent double-patching if this module is re-imported
+const PG_PATCH_APPLIED = Symbol.for('appContext.pg.patched');
+const FETCH_PATCH_APPLIED = Symbol.for('appContext.fetch.patched');
+
+// Strip */ and newlines from reqId before embedding in a SQL comment
+// to prevent comment-injection attacks
+function sanitizeReqId(reqId) {
+  return String(reqId)
+    .replace(/\*\//g, '')
+    .replace(/[\r\n]/g, '');
+}
+
+function isInternalUrl(url)
+  { try { 
+    const { hostname } = new URL(url, 'http://localhost'); 
+  if (['localhost', '127.0.0.1', '::1'].includes(hostname)) return true; 
+    const dev_domain = process.env.DEV_DOMAIN; 
+    const prod = process.env.PROD_DOMAINS?.split(',').map((d) => d.trim()) ?? []; if (dev_domain && hostname.endsWith(dev_domain)) return true; 
+    if (prod.some((d) => hostname === d || hostname.endsWith('.' + d))) return  true; return false; } 
+  catch { return true; // treat unparseable / relative URLs as internal 
+        } 
+          
+  }
+
+function getUrlString(input) {
+  if (typeof input === 'string') {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  if (typeof Request !== 'undefined' && input instanceof Request) {
+    return input.url;
+  }
+
+  return String(input);
+}
+
+// Patch pg.Client.prototype.query to prepend /* reqId */ to every SQL query.
+// Uses ...args so all pg call signatures work correctly (query(sql, callback),
+// query(sql, values), query(sql, values, callback), query(config), etc.)
+
+  if (!pg.Client.prototype.query[PG_PATCH_APPLIED]) {
+  const originalClientQuery = pg.Client.prototype.query;
+
+    // TODO:
+    // Replace pg.Client.prototype patching with a
+    // client wrapper/factory (e.g. instrumentClient())
+    // to avoid global prototype mutation.
+    // Prototype patching is retained for compatibility.
+  pg.Client.prototype.query = function (...args) {
+    const store = appContext.getStore();
+
+    if (store?.reqId) {
+      const safeId = sanitizeReqId(store.reqId);
+      const firstArg = args[0];
+
+      if (typeof firstArg === 'string') {
+        args[0] = `/* reqId: ${safeId} */ ${firstArg}`;
+      } else if (firstArg?.text) {
+        args[0] = { ...firstArg, text: `/* reqId: ${safeId} */ ${firstArg.text}` };
+      }
     }
-  }
-  return originalClientQuery.call(this, config, values, callback);
-};
 
-// Global patch for fetch to automatically append the Correlation ID header to downstream requests
-const originalFetch = global.fetch;
-global.fetch = function (url, options) {
-  const store = appContext.getStore();
-  options = options || {};
+    return originalClientQuery.apply(this, args);
+  };
 
-  const headers = {};
-  if (options.headers instanceof Headers) {
-    options.headers.forEach((value, key) => {
-      headers[key] = value;
-    });
-  } else if (options.headers) {
-    Object.assign(headers, options.headers);
-  }
+  pg.Client.prototype.query[PG_PATCH_APPLIED] = true;
+}
 
-  if (store?.reqId) {
-    headers['X-Request-ID'] = store.reqId;
-  }
+// Patch global.fetch to forward X-Request-ID on all outgoing calls.
+// OTel trace headers are only injected for internal URLs — never for
+// external APIs (Stripe, GitHub, OpenAI, etc.)
+if (!global.fetch?.[FETCH_PATCH_APPLIED]) {
+  const originalFetch = global.fetch;
 
-  propagation.inject(otelContext.active(), headers);
+  // TODO:
+  // Replace global fetch monkey-patching with an explicit
+  // internalFetch() wrapper in a future refactor.
+  // Global patching is kept for backward compatibility
+  // with existing fetch() call sites.
+  global.fetch = function (url, options = {}) {
+    const store = appContext.getStore();
 
-  return originalFetch.call(this, url, { ...options, headers });
-};
+    const headers = {};
+    if (options.headers instanceof Headers) {
+      options.headers.forEach((v, k) => {
+        headers[k] = v;
+      });
+    } else if (options.headers) {
+      Object.assign(headers, options.headers);
+    }
+
+    if (store?.reqId) headers['X-Request-ID'] = store.reqId;
+
+   const urlstring =getUrlString(url);
+    if (isInternalUrl(urlstring)) {
+      propagation.inject(otelContext.active(), headers);
+    }
+    return originalFetch.call(this, url, { ...options, headers });
+  };
+
+  global.fetch[FETCH_PATCH_APPLIED] = true;
+}


### PR DESCRIPTION
## Summary

This PR hardens `server/config/appContext.js` by addressing security and compatibility issues in PostgreSQL query instrumentation and OpenTelemetry propagation.

### Changes Made

#### PostgreSQL Query Instrumentation

* Preserved all supported `pg.Client.query()` signatures by switching to `...args` and forwarding calls via `apply()`.
* Fixed handling of signatures such as:

  * `query(sql)`
  * `query(sql, callback)`
  * `query(sql, values)`
  * `query(sql, values, callback)`
  * `query(config)`
  * `query(config, callback)`

#### SQL Comment Injection Mitigation

* Added `sanitizeReqId()` to strip `*/` and newline characters before embedding `reqId` into SQL comments.
* Prevents malicious input from prematurely terminating SQL comments.

#### OpenTelemetry Header Propagation

* Restricted OpenTelemetry header injection (`traceparent`, `tracestate`, etc.) to internal service calls only.
* Prevents leaking tracing metadata to third-party APIs such as Stripe, GitHub, or OpenAI.

#### URL Handling Improvements

* Added `getUrlString()` to correctly support:

  * string URLs
  * `URL` instances
  * `Request` objects
* Prevents accidental propagation of trace headers when `fetch()` is invoked with a `Request` object.

#### Idempotent Patching

* Added `Symbol.for(...)` guards to prevent duplicate patching during hot reloads or repeated imports.

## Future Work

The current implementation retains global monkey-patching for backward compatibility with existing code paths.

Future refactors may include:

* Replacing `global.fetch` patching with an explicit `internalFetch()` wrapper.
* Replacing `pg.Client.prototype.query` patching with a client wrapper/factory (for example, `instrumentClient()`).
* Gradually migrating call sites to wrapper-based instrumentation to avoid global side effects and improve compatibility with third-party libraries and observability tools.

These changes are intentionally deferred to avoid breaking existing integrations and to minimize repository-wide refactoring.
