### PR TITLE
fix: persist accumulated tokens in rate limiter else block to prevent client starvation

### DIFF
--- a/server/middleware/tierRateLimiter.js
+++ b/server/middleware/tierRateLimiter.js
@@ -107,7 +107,7 @@ export function tierRateLimiter(options = {}) {
             redis.call('EXPIRE', key, 3600)
             return {1, math.floor(tokens)}
           else
-            redis.call('HMSET', key, 'last_updated', last_updated)
+            redis.call('HMSET', key, 'tokens', tokens, 'last_updated', last_updated)
             return {0, 0}
           end
         `;


### PR DESCRIPTION
<!-- client starvation -->

# Summary
In the Lua script's else block, only `last_updated` was being saved to Redis, discarding newly accumulated fractional tokens. This caused the bucket to never refill for clients polling faster than the refill rate, permanently returning 429. Added `tokens` to the `HMSET` call to fix the starvation.

## Related Issue
Closes #1898

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `tokens` field to `HMSET` call in the else block of the Lua rate limiter script in `server/middleware/tierRateLimiter.js` line 110

## Technical Details
### Backend
- `server/middleware/tierRateLimiter.js` — fixed Lua else block to persist accumulated tokens alongside `last_updated`

## Checklist
- [x] Code follows project standards
- [x] Ready for review