### PR TITLE
fix: validate lastKnownTimestamp before conflict check to prevent silent bypass

### DIFF
--- a/server/controllers/syncController.js
+++ b/server/controllers/syncController.js
@@ -78,6 +78,16 @@ export const syncController = {
               const serverUpdated = new Date(current.updated_at);
               const clientKnown = new Date(lastKnownTimestamp);
 
+              if (!lastKnownTimestamp || isNaN(clientKnown.getTime())) {
+                results.push({
+                  id,
+                  type,
+                  status: 'error',
+                  message: 'Invalid or missing lastKnownTimestamp.',
+                });
+                continue;
+              }
+
               if (serverUpdated > clientKnown) {
                 results.push({
                   id,


### PR DESCRIPTION
<!-- silent conflict bypass -->

# Summary
`new Date(undefined)` produces `Invalid Date` with a `NaN` timestamp. Any comparison with `NaN` evaluates to `false`, silently bypassing conflict detection and allowing stale client data to overwrite newer server data. Added an explicit guard to reject payloads with missing or invalid `lastKnownTimestamp` before the comparison.

## Related Issue
Closes #1899

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `!lastKnownTimestamp || isNaN(clientKnown.getTime())` guard before the `serverUpdated > clientKnown` comparison in `server/controllers/syncController.js`
- Returns an `error` status entry for that change and continues to next instead of silently bypassing

## Technical Details
### Backend
- `server/controllers/syncController.js` — added timestamp validation before conflict detection logic

## Checklist
- [x] Code follows project standards
- [x] Ready for review