### PR TITLE
fix: add bounds check on optionIndex in votePoll to reject phantom keys

### DIFF
--- a/server/repositories/streamRepository.js
+++ b/server/repositories/streamRepository.js
@@ -238,6 +238,7 @@ export const streamRepository = {
       if (!rows.length) return null;
 
       const poll = rows[0];
+      if (Number(optionIndex) < 0 || Number(optionIndex) >= poll.options.length) return null;
       const votes = typeof poll.votes === 'string' ? JSON.parse(poll.votes) : poll.votes || {};
       const key = String(optionIndex);
       votes[key] = (votes[key] || 0) + 1;


### PR DESCRIPTION
<!-- phantom keys -->

# Summary
`votePoll` was incrementing `votes[optionIndex]` without validating whether `optionIndex` falls within the valid range of poll options. Users could vote on non-existent indices (e.g. 999), creating phantom keys in the database. Added a bounds check before incrementing to reject invalid indices.

## Related Issue
Closes #1900

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `if (Number(optionIndex) < 0 || Number(optionIndex) >= poll.options.length) return null` guard before vote increment in `server/repositories/streamRepository.js` line 239

## Technical Details
### Backend
- `server/repositories/streamRepository.js` — added optionIndex bounds validation in `votePoll`

## Checklist
- [x] Code follows project standards
- [x] Ready for review