### PR TITLE
fix: replace raw JSON slice in truncateData with recursive string truncation

### DIFF
--- a/server/services/errorTrackingService.js
+++ b/server/services/errorTrackingService.js
@@ -1,4 +1,3 @@
-
 import 'dotenv/config';
 import { validateEnvironment } from './utils/envValidator.js';
 
@@ -171,11 +170,20 @@ function truncateData(data, maxBytes) {
   if (!data) return null;
   const str = JSON.stringify(data);
   if (str.length <= maxBytes) return data;
-  try {
-    return JSON.parse(str.slice(0, maxBytes));
-  } catch {
-    return null;
+  function truncateStrings(obj, budget) {
+    if (typeof obj === 'string') return obj.slice(0, Math.floor(budget));
+    if (Array.isArray(obj)) return obj.map((item) => truncateStrings(item, budget / obj.length));
+    if (obj && typeof obj === 'object') {
+      const keys = Object.keys(obj);
+      const out = {};
+      for (const key of keys) {
+        out[key] = truncateStrings(obj[key], budget / keys.length);
+      }
+      return out;
+    }
+    return obj;
   }
+  return truncateStrings(data, maxBytes);
 }
 
 /**


### PR DESCRIPTION
<!-- payload truncation -->

# Summary
`truncateData` was stringifying the payload then slicing the raw JSON string at `maxBytes`. Slicing at an arbitrary byte offset almost always produces invalid JSON, causing `JSON.parse` to throw a `SyntaxError` and the catch block to return `null` — losing the entire payload from error logs. Replaced with a recursive approach that truncates string values within the object before stringifying, preserving valid structure.

## Related Issue
Closes #1901

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Replaced `JSON.parse(str.slice(0, maxBytes))` with a `truncateStrings` helper that recursively walks the object and shortens string values proportionally to fit within the byte budget
- Removed the now-unnecessary try/catch block

## Technical Details
### Backend
- `server/services/errorTrackingService.js` — fixed `truncateData` to use recursive string truncation instead of raw JSON slicing

## Checklist
- [x] Code follows project standards
- [x] Ready for review