### PR TITLE
fix: replace inline import.meta.env reads with getApiBase() in ResourcesPage

### DIFF
--- a/website/src/pages/resources/ResourcesPage.jsx
+++ b/website/src/pages/resources/ResourcesPage.jsx
@@ -7,6 +7,7 @@ import {
   difficultyLevels,
 } from '../../data/resourcesData';
 import apiClient from '../../utils/apiClient';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 export default function ResourcesPage({ onBack }) {
   const [resources, setResources] = useState(fallbackResources);
@@ -18,7 +19,7 @@ export default function ResourcesPage({ onBack }) {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    const base = import.meta.env.VITE_API_BASE || '';
+    const base = getApiBase();
     if (!base) return;
 
     setLoading(true);
@@ -78,7 +79,7 @@ export default function ResourcesPage({ onBack }) {
   };
 
   const handleDownload = (id) => {
-    const base = import.meta.env.VITE_API_BASE || '';
+    const base = getApiBase();
     if (base) {
       apiClient(`${base}/api/resources/${id}/download`, { method: 'POST' }).catch(() => {});
     }


### PR DESCRIPTION
## Description
`ResourcesPage.jsx` had 2 inline copies of `import.meta.env.VITE_API_BASE` in two separate handlers:

```js
const base = import.meta.env.VITE_API_BASE || '';
```

This duplicated the logic already centralised in `getApiBase()` from `runtimeConfig.js` — the same utility used across all other pages. If the resolution logic changes, resources API calls would silently diverge.

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Replaced both inline `base` declarations with `const base = getApiBase()`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2071

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings