### PR TITLE
fix: replace VITE_API_URL with getApiBase() in MentorsPage

### DIFF
--- a/website/src/pages/mentorship/MentorsPage.jsx
+++ b/website/src/pages/mentorship/MentorsPage.jsx
@@ -14,11 +14,11 @@ import {
 } from 'lucide-react';
 import { mentors as fallbackMentors, mentorDomains } from '../../data/mentorshipData.js';
 import './MentorsPage.css';
-
-const API_BASE = import.meta.env.VITE_API_URL || '';
+import { getApiBase } from '../../utils/runtimeConfig';
 
 async function apiFetch(path, options = {}) {
-  const res = await fetch(`${API_BASE}${path}`, {
+  const base = getApiBase();
+  const res = await fetch(`${base}${path}`, {
     headers: { 'Content-Type': 'application/json', ...options.headers },
     ...options,
   });


### PR DESCRIPTION
## Description
`MentorsPage.jsx` read `VITE_API_URL` instead of `VITE_API_BASE`:

```js
const API_BASE = import.meta.env.VITE_API_URL || '';
```

`VITE_API_URL` is not documented in `.env.example` and is never set in this project — `API_BASE` was always `''` regardless of any environment configuration. All mentors API calls silently used relative paths. The rest of the codebase uses `VITE_API_BASE` via `getApiBase()` from `runtimeConfig.js`.

Changes made:
- Removed module-level `API_BASE` constant
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Moved `const base = getApiBase()` inside `apiFetch()` — consistent with the same fix applied to `MentorshipDashboard.jsx` and `LiveStreamPage.jsx`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2074

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings