### PR TITLE
fix: replace as any cast with UseReactToPrintOptions type in useCertificateExport

### DIFF
--- a/website/src/hooks/useCertificateExport.ts
+++ b/website/src/hooks/useCertificateExport.ts
@@ -1,5 +1,5 @@
-import { useState, useCallback } from 'react';
-import { useReactToPrint } from 'react-to-print';
+import React, { useState, useCallback } from 'react';
+import { useReactToPrint, type UseReactToPrintOptions } from 'react-to-print';
 import { isIOS } from '../utils/deviceDetection';
 import { generatePDFBlob } from '../utils/certificateDownload';
 
@@ -16,10 +16,10 @@ export const useCertificateExport = (options: UseCertificateExportOptions) => {
   const isIOSDevice = isIOS();
 
   // Setup standard react-to-print hook for non-iOS devices
-  const handleReactToPrint = useReactToPrint({
-    content: options.content,
+  const printOptions: UseReactToPrintOptions = {
+    contentRef: { current: options.content() } as React.RefObject<HTMLElement>,
     documentTitle: options.documentTitle,
-    onBeforeGetContent: async () => {
+    onBeforePrint: async () => {
       setIsExporting(true);
       if (options.onBeforeGetContent) {
         await options.onBeforeGetContent();
@@ -31,15 +31,16 @@ export const useCertificateExport = (options: UseCertificateExportOptions) => {
         options.onAfterPrint();
       }
     },
-    removeAfterPrint: options.removeAfterPrint ?? true,
-    // Add print error handling to not get stuck in exporting state
-    onPrintError: () => {
+    preserveAfterPrint: !(options.removeAfterPrint ?? true),
+    // Reset exporting state on print error to prevent stuck loading state
+    onPrintError: (_errorLocation, _error) => {
       setIsExporting(false);
       if (options.onAfterPrint) {
         options.onAfterPrint();
       }
     },
-  } as any);
+  };
+  const handleReactToPrint = useReactToPrint(printOptions);
 
   const handlePrint = useCallback(async () => {
     if (!isIOSDevice) {


### PR DESCRIPTION
## Description
`useCertificateExport.ts` passed the `useReactToPrint` configuration as `as any`:

```ts
const handleReactToPrint = useReactToPrint({
  content: options.content,
  // ...
} as any);
```

Using `as any` bypassed TypeScript's checks on all print hook options. Additionally the installed version of `react-to-print` has a newer API that differs from what was being used — several options were renamed or restructured.

Changes made:
- Added `import { type UseReactToPrintOptions } from 'react-to-print'`
- Replaced `as any` with a typed `printOptions: UseReactToPrintOptions` constant
- Updated option names to match the current `react-to-print` API:
  - `content` → `contentRef` (now a `RefObject`)
  - `onBeforeGetContent` → `onBeforePrint`
  - `removeAfterPrint` → `preserveAfterPrint` (inverted boolean)
  - `onPrintError` signature updated to `(errorLocation, error) => void`
- TypeScript now enforces correct option names and types on the print hook configuration
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2075

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings