### PR TITLE
fix: add maxLength cap and try-catch to stream_chat_name localStorage writes

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -91,7 +91,13 @@ function HlsPlayer({ streamUrl, hlsUrl, status }) {
 
 function ChatPanel({ streamId, messages, onSendMessage }) {
   const [input, setInput] = useState('');
-  const [userName, setUserName] = useState(() => localStorage.getItem('stream_chat_name') || '');
+  const [userName, setUserName] = useState(() => {
+    try {
+      return (localStorage.getItem('stream_chat_name') || '').slice(0, 50);
+    } catch {
+      return '';
+    }
+  });
   const messagesEndRef = useRef(null);
 
   useEffect(() => {
@@ -115,9 +121,15 @@ function ChatPanel({ streamId, messages, onSendMessage }) {
         <input
           placeholder="Your name"
           value={userName}
+          maxLength={50}
           onChange={(e) => {
-            setUserName(e.target.value);
-            localStorage.setItem('stream_chat_name', e.target.value);
+            const trimmed = e.target.value.slice(0, 50);
+            setUserName(trimmed);
+            try {
+              localStorage.setItem('stream_chat_name', trimmed);
+            } catch {
+              // Ignore QuotaExceededError — name is still stored in state
+            }
           }}
           className="w-full px-2 py-1.5 bg-gray-700 border border-gray-600 rounded text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"
         />


### PR DESCRIPTION
## Description
`ChatPanel` in `LiveStreamPage.jsx` stored the chat username in `localStorage` on every keystroke with no length cap or error handling:

```js
onChange={(e) => {
  setUserName(e.target.value);
  localStorage.setItem('stream_chat_name', e.target.value); // no cap, no try-catch
}}
```

Typing an arbitrarily long string (e.g. 100,000 characters) could cause `localStorage.setItem` to throw `QuotaExceededError` — an unhandled exception that would crash the `onChange` handler silently, breaking the username input.

Changes made:
- Added `maxLength={50}` to the username input element to prevent excessively long values at the UI level
- Added `.slice(0, 50)` enforcement in `onChange` before storing — ensures the cap is respected even if `maxLength` is bypassed programmatically
- Wrapped `localStorage.setItem` in `try-catch` to handle `QuotaExceededError` gracefully — the name is still stored in React state so the user can continue chatting even if the `localStorage` write fails
- Wrapped the lazy `useState` initializer `localStorage.getItem` in `try-catch` and applied `.slice(0, 50)` to sanitize any previously stored oversized values on mount
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2077

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings