### PR TITLE
fix: persist votes to backend API in handleVote with optimistic UI update

### DIFF
--- a/website/src/pages/resources/ResourcesPage.jsx
+++ b/website/src/pages/resources/ResourcesPage.jsx
@@ -58,11 +58,13 @@ export default function ResourcesPage({ onBack }) {
   }, [resources, searchQuery, selectedCategory, selectedDifficulty]);
 
   const handleVote = (id) => {
+    const hasVoted = votedIds.has(id);
+
+    // Optimistic UI update — reflect vote immediately before API response
     setResources((prev) =>
       prev.map((r) => {
         if (r.id !== id) return r;
         const votes = r.votes || [];
-        const hasVoted = votedIds.has(id);
         return {
           ...r,
           votes: hasVoted ? votes.slice(0, -1) : [...votes, 'current_user'],
@@ -75,6 +77,31 @@ export default function ResourcesPage({ onBack }) {
       else next.add(id);
       return next;
     });
+
+    // Persist vote to backend — consistent with handleDownload which
+    // also fires a POST to record the action server-side
+    const base = getApiBase();
+    if (base) {
+      apiClient(`${base}/api/resources/${id}/vote`, { method: 'POST' }).catch(() => {
+        // Revert optimistic update on failure
+        setResources((prev) =>
+          prev.map((r) => {
+            if (r.id !== id) return r;
+            const votes = r.votes || [];
+            return {
+              ...r,
+              votes: hasVoted ? [...votes, 'current_user'] : votes.slice(0, -1),
+            };
+          })
+        );
+        setVotedIds((prev) => {
+          const next = new Set(prev);
+          if (hasVoted) next.add(id);
+          else next.delete(id);
+          return next;
+        });
+      });
+    }
   };
 
   const handleDownload = (id) => {


### PR DESCRIPTION
## Description
`handleVote()` in `ResourcesPage.jsx` updated vote state client-side only with no API call — votes were lost on page refresh and not visible to other users:

```js
const handleVote = (id) => {
  setResources((prev) => /* optimistic update */);
  setVotedIds((prev) => /* update set */);
  // ← no API call — vote never persisted
};
```

This was inconsistent with `handleDownload()` which correctly calls `POST /api/resources/:id/download` to persist the action server-side.

Changes made:
- Added `POST /api/resources/:id/vote` API call after the optimistic UI update — consistent with the download endpoint pattern
- Optimistic update is applied immediately so the UI responds instantly
- On API failure, the vote state is rolled back to its pre-vote value so the UI accurately reflects the persisted server state
- `getApiBase()` was already imported from the previous fix on this file
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2078

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings