### PR TITLE
fix: persist votedIds to localStorage so votes survive page refresh in ResourcesPage

### DIFF
--- a/website/src/pages/resources/ResourcesPage.jsx
+++ b/website/src/pages/resources/ResourcesPage.jsx
@@ -14,7 +14,20 @@ export default function ResourcesPage({ onBack }) {
   const [selectedCategory, setSelectedCategory] = useState('');
   const [selectedDifficulty, setSelectedDifficulty] = useState('');
   const [showUploadModal, setShowUploadModal] = useState(false);
-  const [votedIds, setVotedIds] = useState(new Set());
+  const [votedIds, setVotedIds] = useState(() => {
+    // Restore voted resource IDs from localStorage so votes survive
+    // page interactions and refreshes without requiring a backend read.
+    try {
+      const stored = localStorage.getItem('ns_resource_voted_ids');
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed)) return new Set(parsed);
+      }
+    } catch {
+      // Ignore malformed or unavailable localStorage
+    }
+    return new Set();
+  });
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -73,6 +86,12 @@ export default function ResourcesPage({ onBack }) {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
       else next.add(id);
+      // Persist to localStorage so voted state survives page refresh
+      try {
+        localStorage.setItem('ns_resource_voted_ids', JSON.stringify([...next]));
+      } catch {
+        // Ignore QuotaExceededError
+      }
       return next;
     });
   };


### PR DESCRIPTION
## Description
`ResourcesPage.jsx` initialised `votedIds` as `useState(new Set())` with no persistence:

```js
const [votedIds, setVotedIds] = useState(new Set());
```

Voted state was lost on every page refresh — users could vote the same resource repeatedly after refreshing, making the vote UI misleading. Additionally `new Set()` was evaluated eagerly rather than in a lazy initializer (minor performance issue).

Changes made:
- Replaced `useState(new Set())` with a lazy initializer that reads previously voted IDs from `localStorage` under `ns_resource_voted_ids` on mount — voted state now survives page refreshes
- Updated `setVotedIds` in `handleVote` to persist the new `Set` to `localStorage` after each vote/unvote
- Both `localStorage` reads and writes are wrapped in `try-catch` to handle `QuotaExceededError` and malformed stored values gracefully
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2080

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings