### PR TITLE
fix: register missing attendance routes to resolve 404 on all attendance endpoints

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -40,10 +40,35 @@ router.delete(
 );
 
 // Admin auth
+router.post(
+  '/api/attendance/mark',
+  adminAuthMiddleware.requireAdmin,
+  attendanceController.markAttendance
+);
+router.get(
+  '/api/attendance',
+  adminAuthMiddleware.requireAdmin,
+  attendanceController.getAttendanceList
+);
 router.get('/api/admin/users', adminAuthMiddleware.requireAdmin, usersController.getAdminUsers);
-router.post('/api/admin/users', adminAuthMiddleware.requireAdmin, adminAuditMiddleware, usersController.adminCreateUser);
-router.put('/api/admin/users/:id', adminAuthMiddleware.requireAdmin, adminAuditMiddleware, usersController.adminUpdateUser);
-router.delete('/api/admin/users/:id', adminAuthMiddleware.requireAdmin, adminAuditMiddleware, usersController.adminDeactivateUser);
+router.post(
+  '/api/admin/users',
+  adminAuthMiddleware.requireAdmin,
+  adminAuditMiddleware,
+  usersController.adminCreateUser
+);
+router.put(
+  '/api/admin/users/:id',
+  adminAuthMiddleware.requireAdmin,
+  adminAuditMiddleware,
+  usersController.adminUpdateUser
+);
+router.delete(
+  '/api/admin/users/:id',
+  adminAuthMiddleware.requireAdmin,
+  adminAuditMiddleware,
+  usersController.adminDeactivateUser
+);
 router.post('/api/admin/login', authRateLimiter, adminAuthMiddleware.login);
 router.post('/api/admin/logout', adminAuthMiddleware.requireAdmin, adminAuthMiddleware.logout);
 


### PR DESCRIPTION
<!-- attendance 404 -->

# Summary
`attendanceController` was imported in `server/routes/api.js` but none of its functions were mapped to any HTTP routes, making all attendance endpoints return 404. Added `POST /api/attendance/mark` and `GET /api/attendance` routes protected by `adminAuthMiddleware.requireAdmin`.

## Related Issue
Closes #1909

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `router.post('/api/attendance/mark', adminAuthMiddleware.requireAdmin, attendanceController.markAttendance)` in `server/routes/api.js`
- Added `router.get('/api/attendance', adminAuthMiddleware.requireAdmin, attendanceController.getAttendanceList)` in `server/routes/api.js`

## Technical Details
### Backend
- `server/routes/api.js` — registered two missing attendance routes under admin auth section

## Checklist
- [x] Code follows project standards
- [x] Ready for review