### PR TITLE
fix: replace local getApiBase with runtimeConfig import in useAnalyticsData

### DIFF
--- a/website/src/hooks/analytics/useAnalyticsData.ts
+++ b/website/src/hooks/analytics/useAnalyticsData.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { getApiBase } from '../../utils/runtimeConfig';
 import { useAnalyticsFilters } from '../../context/AnalyticsFilterContext';
 import {
   generateTrendData,
@@ -8,8 +9,6 @@ import {
   DistributionDataPoint,
   ComparisonDataPoint,
 } from '../../utils/chartDataFormatters';
-
-const getApiBase = () => (import.meta as any).env?.VITE_API_BASE?.replace(/\/+$/, '') || '';
 
 /**
  * Returns true when the API base URL is configured for this deployment.


### PR DESCRIPTION
## Description
`useAnalyticsData.ts` defined its own local `getApiBase` function using an `as any` cast:

```ts
const getApiBase = () => (import.meta as any).env?.VITE_API_BASE?.replace(/\/+$/, '') || '';
```

Two problems:
1. **`as any` cast**: `(import.meta as any).env` bypasses TypeScript's `import.meta` typing — the correct Vite pattern is `import.meta.env.VITE_API_BASE` which is fully typed
2. **Duplicate logic**: `getApiBase()` is already centralised in `runtimeConfig.js` and used across the codebase — a local copy means if the resolution logic changes, analytics API calls silently diverge

Changes made:
- Added `import { getApiBase } from '../../utils/runtimeConfig'`
- Removed local `getApiBase` definition — `isApiConfigured()` and all `getApiBase()` call sites now use the shared import
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2091

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings