### PR TITLE
fix: update cross-tab logout listener to watch admin_token instead of token

### DIFF
--- a/admin-dashboard/src/context/AuthContext.jsx
+++ b/admin-dashboard/src/context/AuthContext.jsx
@@ -55,7 +55,7 @@ export function AuthProvider({ children }) {
   // Cross-tab logout sync
   useEffect(() => {
     const handleStorageChange = (event) => {
-      if (event.key === LOGOUT_EVENT_KEY || (event.key === 'token' && !event.newValue)) {
+      if (event.key === LOGOUT_EVENT_KEY || (event.key === 'admin_token' && !event.newValue)) {
         clearAutoLogoutTimer();
         setIsAuthenticated(false);
 


### PR DESCRIPTION
<!-- wrong localStorage key -->

# Summary
The cross-tab logout listener was checking `event.key === 'token'` but the admin auth utility stores the token under `'admin_token'`. Other tabs never received the logout signal. Fixed by updating the key to `'admin_token'`.

## Related Issue
Closes #1907

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Changed `event.key === 'token'` to `event.key === 'admin_token'` in the storage event listener in `admin-dashboard/src/context/AuthContext.jsx` line 55

## Technical Details
### Frontend
- `admin-dashboard/src/context/AuthContext.jsx` — fixed wrong localStorage key in cross-tab logout sync listener

## Checklist
- [x] Code follows project standards
- [x] Ready for review