### PR TITLE
fix: return 409 conflict when registering mentor with existing email to prevent profile hijack

### DIFF
--- a/server/repositories/mentorshipRepository.js
+++ b/server/repositories/mentorshipRepository.js
@@ -135,16 +135,9 @@ export const mentorshipRepository = {
     return withDb(async (client) => {
       const existing = await client.query('select id from mentors where email = $1', [input.email]);
       if (existing.rows.length > 0) {
-        const updateSql = `update mentors set name = $1, domains = $2, bio = $3, experience = $4, availability = $5, is_available = true, updated_at = now() where email = $6 returning *`;
-        const { rows } = await client.query(updateSql, [
-          input.name,
-          JSON.stringify(input.domains),
-          input.bio || '',
-          input.experience || '',
-          input.availability || '',
-          input.email,
-        ]);
-        return rows.length ? mapMentorRow(rows[0]) : null;
+        const error = new Error('Email already registered');
+        error.status = 409;
+        throw error;
       }
       const { rows } = await client.query(
         `insert into mentors (name, email, domains, bio, experience, availability) values ($1, $2, $3, $4, $5, $6) returning *`,


### PR DESCRIPTION
<!-- profile hijack -->

# Summary
`registerMentor` was silently executing an UPDATE query when a mentor with the provided email already existed, with no authentication or ownership check. Anyone could overwrite an existing mentor's profile by submitting a registration form with their email. Fixed by throwing a 409 Conflict error instead of updating.

## Related Issue
Closes #1906

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Replaced the silent UPDATE query with a 409 Conflict error when an existing mentor email is detected in `server/repositories/mentorshipRepository.js` line 134

## Technical Details
### Backend
- `server/repositories/mentorshipRepository.js` — replaced unauthenticated profile overwrite with a 409 Conflict error on duplicate email

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review