### PR TITLE
fix: add adminAuth middleware to mentorship PUT routes to prevent unauthorized tampering

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -82,8 +82,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const CONTENT_FILE = path.join(__dirname, 'data', 'content.json');
 
-
-
 validateEnvironment();
 
 const app = express();
@@ -1682,11 +1680,15 @@ app.get('/api/admin/forum/threads', adminAuth, forumController.adminListThreads)
 app.get('/api/mentorship/mentors', mentorshipController.listMentors);
 app.get('/api/mentorship/mentors/:id', mentorshipController.getMentor);
 app.post('/api/mentorship/mentors', mentorshipController.registerMentor);
-app.put('/api/mentorship/mentors/:id', mentorshipController.updateMentor);
+app.put('/api/mentorship/mentors/:id', adminAuth, mentorshipController.updateMentor);
 app.post('/api/mentorship/requests', mentorshipController.requestMentorship);
 app.get('/api/mentorship/requests', mentorshipController.listMentorships);
 app.get('/api/mentorship/requests/:id', mentorshipController.getMentorship);
-app.put('/api/mentorship/requests/:id/status', mentorshipController.updateMentorshipStatus);
+app.put(
+  '/api/mentorship/requests/:id/status',
+  adminAuth,
+  mentorshipController.updateMentorshipStatus
+);
 app.post('/api/mentorship/requests/:id/sessions', mentorshipController.logSession);
 app.get('/api/mentorship/requests/:id/sessions', mentorshipController.listSessions);
 app.post('/api/mentorship/buddy-pairs', mentorshipController.createBuddyPair);


### PR DESCRIPTION
<!-- unauthorized mentorship tampering -->

# Summary
`PUT /api/mentorship/mentors/:id` and `PUT /api/mentorship/requests/:id/status` had no authentication middleware, allowing any anonymous user to modify mentor profiles or change mentorship statuses. Added `adminAuth` to both routes.

## Related Issue
Closes #1905

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `adminAuth` to `PUT /api/mentorship/mentors/:id` in `server/index.js`
- Added `adminAuth` to `PUT /api/mentorship/requests/:id/status` in `server/index.js`

## Technical Details
### Backend
- `server/index.js` — added `adminAuth` middleware to both unprotected mentorship PUT routes

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review