### PR TITLE
fix: add adminAuth to stream write/modify/delete/moderate routes to prevent anonymous access

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -82,8 +82,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const CONTENT_FILE = path.join(__dirname, 'data', 'content.json');
 
-
-
 validateEnvironment();
 
 const app = express();
@@ -1047,17 +1045,17 @@ app.delete('/api/admin/events/:id', adminAuth, eventsController.adminDeleteEvent
 app.get('/api/streams', streamController.listStreams);
 app.get('/api/streams/event/:eventId', streamController.getStreamByEvent);
 app.get('/api/streams/:id', streamController.getStream);
-app.post('/api/streams', streamController.createStream);
-app.put('/api/streams/:id', streamController.updateStream);
-app.patch('/api/streams/:id/status', streamController.setStreamStatus);
-app.delete('/api/streams/:id', streamController.deleteStream);
+app.post('/api/streams', adminAuth, streamController.createStream);
+app.put('/api/streams/:id', adminAuth, streamController.updateStream);
+app.patch('/api/streams/:id/status', adminAuth, streamController.setStreamStatus);
+app.delete('/api/streams/:id', adminAuth, streamController.deleteStream);
 app.post('/api/streams/:id/chat', streamController.addChatMessage);
 app.get('/api/streams/:id/chat', streamController.listChatMessages);
 app.post('/api/streams/:id/polls', streamController.createPoll);
 app.get('/api/streams/:id/polls', streamController.listPolls);
 app.post('/api/streams/polls/:pollId/vote', streamController.votePoll);
-app.patch('/api/streams/polls/:pollId/close', streamController.closePoll);
-app.patch('/api/streams/chat/:messageId/moderate', streamController.moderateChatMessage);
+app.patch('/api/streams/polls/:pollId/close', adminAuth, streamController.closePoll);
+app.patch('/api/streams/chat/:messageId/moderate', adminAuth, streamController.moderateChatMessage);
 app.get('/api/admin/streams', adminAuth, streamController.adminListAll);
 
 // Public listings


### PR DESCRIPTION
<!-- unauthenticated stream access -->

# Summary
`POST`, `PUT`, `DELETE`, `PATCH` stream routes had no authentication middleware, allowing any anonymous user to create, modify, delete, or moderate live streams. Added `adminAuth` to all 6 sensitive routes while keeping public GET routes unchanged.

## Related Issue
Closes #1904

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `adminAuth` to `POST /api/streams`
- Added `adminAuth` to `PUT /api/streams/:id`
- Added `adminAuth` to `PATCH /api/streams/:id/status`
- Added `adminAuth` to `DELETE /api/streams/:id`
- Added `adminAuth` to `PATCH /api/streams/polls/:pollId/close`
- Added `adminAuth` to `PATCH /api/streams/chat/:messageId/moderate`

## Technical Details
### Backend
- `server/index.js` — added `adminAuth` middleware to all stream write/modify/delete/moderate routes

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review