### PR TITLE
fix: guard against ERR_HTTP_HEADERS_SENT by checking res.writableEnded before setupSSEHeaders

### DIFF
--- a/server/routes/adminStream.js
+++ b/server/routes/adminStream.js
@@ -30,6 +30,9 @@ router.get('/stream', requireAdmin, (req, res) => {
   logger.info('Admin connected to SSE stream', { adminId });
   addSSEClient(res, req.adminSession);
 
+  // Guard against writing to an already-ended response (e.g. max capacity reached)
+  if (res.writableEnded) return;
+
   // Initialize headers and hand off the response to the SSE service
   setupSSEHeaders(req, res, () => {
     addSSEClient(res);


### PR DESCRIPTION
<!-- SSE server crash -->

# Summary
`addSSEClient` calls `res.end()` when `MAX_SSE_CLIENTS` is reached. Immediately after, `setupSSEHeaders` unconditionally called `res.setHeader()` and `res.write()` on the already-ended response, throwing `ERR_HTTP_HEADERS_SENT` and crashing the Node server. Added a `res.writableEnded` guard between the two calls to return early if the response is already closed.

## Related Issue
Closes #1903

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `if (res.writableEnded) return;` after `addSSEClient` and before `setupSSEHeaders` in `server/routes/adminStream.js`

## Technical Details
### Backend
- `server/routes/adminStream.js` — added `res.writableEnded` guard to prevent writing to an already-ended SSE response

## Checklist
- [x] Code follows project standards
- [x] Ready for review