### PR TITLE
fix: replace raw fetch with apiClient in CertificateVerifyPage

### DIFF
--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -206,22 +206,14 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
 
     async function fetchVerification() {
       try {
-        const apiBase = getApiBase();
-        const res = await fetch(
-          `${apiBase}/api/public/certificates/verify/${encodeURIComponent(certificateId)}`,
-          {
-            signal: controller.signal,
-          }
+        const base = getApiBase();
+        // Use apiClient instead of raw fetch — provides Sentry error
+        // tracking, offline IndexedDB cache fallback, and standardised
+        // error handling via ApiError consistent with the rest of the codebase.
+        const json = await apiClient(
+          `${base}/api/public/certificates/verify/${encodeURIComponent(certificateId)}`,
+          { signal: controller.signal }
         );
-
-        if (!res.ok) {
-          const errData = await res.json().catch(() => ({}));
-          setMessage(errData.message || 'Server error during verification.');
-          setStatus('error');
-          return;
-        }
-
-        const json = await res.json();
         setData(json);
         setMessage(json.message);
         setStatus(json.valid ? 'valid' : 'invalid');


### PR DESCRIPTION
## Description
`CertificateVerifyPage.jsx` used raw `fetch()` for the certificate verification API call:

```js
const res = await fetch(`${apiBase}/api/public/certificates/verify/...`, { signal });
if (!res.ok) {
  const errData = await res.json().catch(() => ({}));
  setMessage(errData.message || 'Server error during verification.');
  setStatus('error');
  return;
}
const json = await res.json();
```

Using raw `fetch()` bypassed three features that `apiClient` provides:
1. **Sentry error tracking** — API errors not reported to Sentry
2. **Offline support** — no IndexedDB cache fallback when offline
3. **Standardised error handling** — manual `res.ok` + `res.json()` duplicates what `apiClient` does automatically with typed `ApiError` instances

Changes made:
- Added `import apiClient from '../../utils/apiClient'`
- Replaced raw `fetch()` + manual error handling with a single `apiClient()` call
- Added a comment explaining why `apiClient` is preferred over raw `fetch`
- `getApiBase()` import and usage unchanged
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2092

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings