### PR TITLE
fix: remove typeof import.meta guard in publicContentStore.js

### DIFF
--- a/website/src/utils/publicContentStore.js
+++ b/website/src/utils/publicContentStore.js
@@ -160,8 +160,7 @@ export function initStorageSyncBridge() {
   // .env.example for both local dev and production deployments.
   // Falls back to http://localhost:5001 only when running locally.
   const configuredAdminOrigin =
-    (typeof import.meta !== 'undefined' && import.meta.env?.VITE_ADMIN_DASHBOARD_URL) ||
-    'http://localhost:5001';
+    import.meta.env?.VITE_ADMIN_DASHBOARD_URL || 'http://localhost:5001';
   const adminOrigin = normalizeOrigin(configuredAdminOrigin) || 'http://localhost:5001';
   const bridgeUrl = `${adminOrigin}/sync-bridge.html`;
 


### PR DESCRIPTION
## Description
`publicContentStore.js` used an unnecessary `typeof import.meta` guard when reading `VITE_ADMIN_DASHBOARD_URL`:

```js
(typeof import.meta !== 'undefined' && import.meta.env?.VITE_ADMIN_DASHBOARD_URL) ||
'http://localhost:5001'
```

`typeof import.meta !== 'undefined'` is a CommonJS/Node.js compatibility guard that is **never needed in a Vite ESM project** — `import.meta` is always defined in Vite's ESM environment. This is the same dead guard pattern previously fixed in `gamificationService.js`.

Changes made:
- Replaced `(typeof import.meta !== 'undefined' && import.meta.env?.VITE_ADMIN_DASHBOARD_URL)` with `import.meta.env?.VITE_ADMIN_DASHBOARD_URL` directly
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2093

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings