### PR TITLE
fix: replace apiBase parameter with internal getApiBase() in useSearch

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -56,11 +56,9 @@ export default function SearchBar({ open, onClose, activities, events, onNavigat
   const inputRef = useRef(null);
   const listRef = useRef(null);
   const [focusIdx, setFocusIdx] = useState(-1);
-  const apiBase = import.meta?.env?.VITE_API_BASE || '';
   const { query, setQuery, filter, setFilter, results, loading, clearSearch } = useSearch(
     activities,
-    events,
-    apiBase
+    events
   );
 
   useEffect(() => {

--- a/website/src/hooks/useSearch.js
+++ b/website/src/hooks/useSearch.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { getApiBase } from '../utils/runtimeConfig';
 
 function useDebounce(value, delay = 300) {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -29,7 +30,8 @@ export function eventMatchesQuery(event, query) {
   );
 }
 
-export function useSearch(activities, events, apiBase = '') {
+export function useSearch(activities, events) {
+  const apiBase = getApiBase();
   const [query, setQuery] = useState('');
   const [filter, setFilter] = useState('all');
   const [results, setResults] = useState([]);
@@ -120,7 +122,7 @@ export function useSearch(activities, events, apiBase = '') {
       }
 
       if (filter === 'all' || filter === 'members') {
-        const base = apiBase || '';
+        const base = getApiBase();
         try {
           const res = await fetch(`${base}/api/content/team`);
           if (res.ok) {


### PR DESCRIPTION
## Description
`useSearch.js` accepted `apiBase` as an optional parameter defaulting to `''` — requiring every caller to resolve and pass the API base URL manually. `SearchBar.jsx` (the only consumer) declared its own `import.meta.env.VITE_API_BASE` expression to supply it, duplicating URL resolution logic already centralised in `getApiBase()` from `runtimeConfig.js`.

Changes made:
- Removed `apiBase` parameter from `useSearch()` signature
- Added `import { getApiBase } from '../utils/runtimeConfig'` to `useSearch.js`
- Added `const apiBase = getApiBase()` inside the hook so URL resolution is handled internally
- Replaced secondary `const base = apiBase || ''` at line 123 with `const base = getApiBase()` directly
- Removed `apiBase` declaration and argument from `SearchBar.jsx`
- All commits signed off with `--signoff` per DCO requirements
- Verified zero TypeScript errors introduced by this change

Fixes #2120

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings