### PR TITLE
fix: revert localStorage cache on failed vote API call to prevent UI desync on reload

### DIFF
--- a/website/src/pages/resources/ResourcesPage.jsx
+++ b/website/src/pages/resources/ResourcesPage.jsx
@@ -118,6 +118,11 @@ export default function ResourcesPage({ onBack }) {
           const next = new Set(prev);
           if (hasVoted) next.add(id);
           else next.delete(id);
+          try {
+            localStorage.setItem('ns_resource_voted_ids', JSON.stringify([...next]));
+          } catch {
+            // Ignore QuotaExceededError
+          }
           return next;
         });
       });


### PR DESCRIPTION
<!-- localStorage desync on vote failure -->

# Summary
When a resource vote API call failed, the `.catch()` block correctly reverted `votedIds` React state but forgot to update localStorage. On page reload, the stale localStorage entry caused the vote button to incorrectly appear as already voted. Added the same `localStorage.setItem` call inside the revert block to keep state in sync.

## Related Issue
Closes #2119

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `localStorage.setItem('ns_resource_voted_ids', JSON.stringify([...next]))` inside the `setVotedIds` revert callback in the `.catch()` block in `website/src/pages/resources/ResourcesPage.jsx`

## Technical Details
### Frontend
- `website/src/pages/resources/ResourcesPage.jsx` — synced localStorage revert with React state revert on vote API failure

## Checklist
- [x] Code follows project standards
- [x] Ready for review