### PR TITLE
fix: replace listener: any with SocketListener type in socket.ts DEV-mode monkey-patch

### DIFF
--- a/website/src/services/socket.ts
+++ b/website/src/services/socket.ts
@@ -1,4 +1,7 @@
 import { io, Socket } from 'socket.io-client';
+
+/** Type-safe listener signature matching Socket.IO's internal contract. */
+type SocketListener = (...args: unknown[]) => void;
 import { getSocketServerUrl } from '../utils/runtimeConfig';
 
 // Keep a singleton instance
@@ -57,7 +60,7 @@ export const initializeSocket = (
     // and to prevent event names leaking into production logs.
     if (import.meta.env.DEV) {
       const originalOn = socketInstance.on.bind(socketInstance);
-      socketInstance.on = (event: string, listener: any) => {
+      socketInstance.on = (event: string, listener: SocketListener) => {
         if (event !== 'connect' && event !== 'disconnect') {
           console.log(`[Socket.IO] Listener registered for event: ${event}`);
         }
@@ -65,7 +68,7 @@ export const initializeSocket = (
       };
 
       const originalOff = socketInstance.off.bind(socketInstance);
-      socketInstance.off = (event: string, listener?: any) => {
+      socketInstance.off = (event: string, listener?: SocketListener) => {
         if (event !== 'connect' && event !== 'disconnect') {
           console.log(`[Socket.IO] Listener removed for event: ${event}`);
         }


### PR DESCRIPTION
## Description
`socket.ts` DEV-mode monkey-patch for `on()` and `off()` used `listener: any` and `listener?: any` — bypassing TypeScript's type checking on Socket.IO event listener signatures. A mistyped listener would not be caught at compile time.

Changes made:
- Added `type SocketListener = (...args: unknown[]) => void` type alias matching Socket.IO's internal listener contract
- Replaced `listener: any` with `listener: SocketListener` in the `on()` override
- Replaced `listener?: any` with `listener?: SocketListener` in the `off()` override
- `unknown[]` preserves type safety while still allowing handlers to narrow argument types themselves
- Zero TypeScript errors introduced

Fixes #2123

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings