### PR TITLE
fix: add needs array to notify-failure job to correctly detect deployment failures

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -123,6 +123,7 @@ jobs:
 
   notify-failure:
     name: Notify Slack Failure
+    needs: [deploy-backend, deploy-frontend, smoke-test]
     if: failure()
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
<!-- notify-failure always skipped -->

# Summary
The `notify-failure` job had no `needs` array, causing it to run immediately at workflow start before any jobs could fail. Since `if: failure()` evaluated to false at timestamp 0, the job was permanently skipped and Slack was never notified on deployment failures. Added `needs: [deploy-backend, deploy-frontend, smoke-test]` so the job waits for the right jobs and correctly detects failures.

## Related Issue
Closes #2118

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [x] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `needs: [deploy-backend, deploy-frontend, smoke-test]` to the `notify-failure` job in `.github/workflows/production-deployment.yml`

## Technical Details
### Infrastructure
- `.github/workflows/production-deployment.yml` — added `needs` dependency to `notify-failure` job so it correctly triggers on deployment failures

## Checklist
- [x] Code follows project standards
- [x] Ready for review