### PR TITLE
fix: wrap all localStorage access in try-catch in InstallPrompt.jsx

### DIFF
--- a/website/src/components/pwa/InstallPrompt.jsx
+++ b/website/src/components/pwa/InstallPrompt.jsx
@@ -24,12 +24,18 @@ export default function InstallPrompt() {
   useEffect(() => {
     // Don't show if already installed (standalone mode)
     if (window.matchMedia('(display-mode: standalone)').matches) return;
-    // Don't show if dismissed
-    if (localStorage.getItem(DISMISSED_KEY) === 'true') return;
 
-    // Track open count
-    const openCount = parseInt(localStorage.getItem(OPEN_COUNT_KEY) || '0', 10) + 1;
-    localStorage.setItem(OPEN_COUNT_KEY, String(openCount));
+    // Wrap all localStorage access in try-catch — throws SecurityError in
+    // Safari private browsing or QuotaExceededError when storage is full.
+    let openCount = 1;
+    try {
+      if (localStorage.getItem(DISMISSED_KEY) === 'true') return;
+      openCount = parseInt(localStorage.getItem(OPEN_COUNT_KEY) || '0', 10) + 1;
+      localStorage.setItem(OPEN_COUNT_KEY, String(openCount));
+    } catch {
+      // Storage unavailable — proceed without persisting state.
+      // Default openCount of 1 means the prompt will show after the delay.
+    }
 
     const handleBeforeInstallPrompt = (e) => {
       e.preventDefault(); // Don't show native prompt immediately
@@ -68,7 +74,11 @@ export default function InstallPrompt() {
       await deferredPrompt.prompt();
       const { outcome } = await deferredPrompt.userChoice;
       if (outcome === 'accepted') {
-        localStorage.setItem(DISMISSED_KEY, 'true');
+        try {
+          localStorage.setItem(DISMISSED_KEY, 'true');
+        } catch {
+          // Storage unavailable — dismissed state will not persist.
+        }
       }
     } catch (err) {
       console.warn('[InstallPrompt] Install failed:', err);
@@ -80,7 +90,11 @@ export default function InstallPrompt() {
 
   const handleDismiss = () => {
     setVisible(false);
-    localStorage.setItem(DISMISSED_KEY, 'true');
+    try {
+      localStorage.setItem(DISMISSED_KEY, 'true');
+    } catch {
+      // Storage unavailable — dismissed state will not persist.
+    }
     if (timerRef.current) clearTimeout(timerRef.current);
   };
 


### PR DESCRIPTION
## Description
`InstallPrompt.jsx` called `localStorage.getItem()` and `localStorage.setItem()` in three places without try-catch. In Safari private browsing mode, `localStorage` access throws `SecurityError`. When storage quota is exceeded, `localStorage.setItem()` throws `QuotaExceededError`. Either exception crashes the `useEffect` silently and can break the page.

Changes made:
- Wrapped `useEffect` localStorage access in try-catch — falls back to `openCount = 1` so the prompt still shows after the configured delay even when storage is unavailable
- Wrapped `handleInstall` `localStorage.setItem(DISMISSED_KEY)` in try-catch — silently skips persistence if storage is unavailable
- Wrapped `handleDismiss` `localStorage.setItem(DISMISSED_KEY)` in try-catch — silently skips persistence if storage is unavailable
- Prompt behaviour is fully preserved in all fallback cases
- Zero TypeScript errors introduced

Fixes #2125

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings