### PR TITLE
fix: show real API error message in certificate verify page instead of hardcoded fallback

### DIFF
--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -219,7 +219,9 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
         setStatus(json.valid ? 'valid' : 'invalid');
       } catch (err) {
         if (err.name === 'AbortError') return;
-        setMessage('Unable to reach the verification server. Please try again later.');
+        setMessage(
+          err.message || 'Unable to reach the verification server. Please try again later.'
+        );
         setStatus('error');
       }
     }


### PR DESCRIPTION
<!-- hardcoded error message -->

# Summary
The catch block in `CertificateVerifyPage.jsx` was ignoring `err.message` and always showing a generic "Unable to reach the verification server" message. Users entering an invalid certificate ID would see a misleading "server down" message instead of the actual error (e.g. "Certificate not found"). Fixed by using `err.message` with a fallback to the generic text for genuine network errors.

## Related Issue
Closes #2117

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Changed `setMessage('Unable to reach...')` to `setMessage(err.message || 'Unable to reach...')` in the catch block in `website/src/pages/certificates/CertificateVerifyPage.jsx` line 222

## Technical Details
### Frontend
- `website/src/pages/certificates/CertificateVerifyPage.jsx` — fixed catch block to surface real API error messages

## Checklist
- [x] Code follows project standards
- [x] Ready for review