### PR TITLE
fix(db): add missing indexes on form_submissions

### DIFF
--- a/server/migrations/1705945208000_add-form-submissions-indexes.js
+++ b/server/migrations/1705945208000_add-form-submissions-indexes.js
@@ -1,0 +1,19 @@
+export const up = (pgm) => {
+  pgm.createIndex('form_submissions', ['form_type', 'created_at'], {
+    name: 'idx_form_submissions_type_created',
+    direction: { created_at: 'DESC' },
+  });
+
+  pgm.createIndex('form_submissions', 'college_email', {
+    name: 'idx_form_submissions_college_email',
+  });
+};
+
+export const down = (pgm) => {
+  pgm.dropIndex('form_submissions', ['form_type', 'created_at'], {
+    name: 'idx_form_submissions_type_created',
+  });
+  pgm.dropIndex('form_submissions', 'college_email', {
+    name: 'idx_form_submissions_college_email',
+  });
+};


### PR DESCRIPTION
## Related Issue

Fixes #2178

## Type of Change

- [x] Performance Optimization

## Changes Implemented

Added a new migration `1705945208000_add-form-submissions-indexes.js` with two indexes on the `form_submissions` table:

- `idx_form_submissions_type_created` — composite on `(form_type, created_at DESC)`
- `idx_form_submissions_college_email` — on `college_email`

## Technical Details

### Database

The initial schema migration creates `form_submissions` with only a primary key. The analytics routes query this table filtered by `form_type` (e.g., `?select=form_type`) and ordered/filtered by `college_email` and `created_at`. Without indexes these are sequential scans.

Adjacent tables in the same migration (`admin_sessions`, `activity_events`) already have composite indexes added immediately after `createTable` — this migration brings `form_submissions` in line with that pattern.

The index on `(form_type, created_at DESC)` directly covers the common access pattern of filtering by type and sorting by recency. The `college_email` index covers per-user submission lookups.

### Frontend / Backend / API / Infrastructure

No changes.

## Screenshots

N/A — migration only.

## Testing

### Manual Testing

- [x] Verified migration file exports valid `up` and `down` functions
- [x] Index names follow existing `idx_<table>_<columns>` convention from the codebase

## Security Review

No security impact.

## Accessibility Review

N/A.

## Performance Impact

Queries on `form_submissions` filtered by `form_type` or `college_email` will use index scans instead of sequential scans.

## Breaking Changes

- [x] No Breaking Changes

## Deployment Notes

Standard migration run on deploy. `CREATE INDEX` acquires `ShareLock` — non-blocking for reads, briefly blocks writes on `form_submissions` during creation.

## Rollback Plan

Run `down` migration — drops both indexes, no data loss.

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Performance validated
- [x] CI/CD passing
- [x] Ready for review