### PR TITLE
[fix] Remove JWT token from OAuth callback redirect URL (fixes #2187)

### DIFF
--- a/server/controllers/studentAuthController.js
+++ b/server/controllers/studentAuthController.js
@@ -20,7 +20,7 @@ export const googleCallback = (req, res, next) => {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
-    return res.redirect(`${frontendUrl}/dashboard?token=${data.token}`);
+    return res.redirect(`${frontendUrl}/dashboard`);
   })(req, res, next);
 };
 
@@ -44,7 +44,7 @@ export const githubCallback = (req, res, next) => {
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
     const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
-    return res.redirect(`${frontendUrl}/dashboard?token=${data.token}`);
+    return res.redirect(`${frontendUrl}/dashboard`);
   })(req, res, next);
 };
 


### PR DESCRIPTION
## Description

Removes the JWT token from the OAuth callback redirect URL in studentAuthController.js. The httpOnly cookie (ns_student_token) is already set server-side before the redirect, making the token query parameter redundant while introducing security risks.

## Security Issue

Tokens in query strings are leaked via browser history, Referer headers, server access logs, and bookmarked URLs.

## Changes

- server/controllers/studentAuthController.js: Removed token from both Google and GitHub OAuth callback redirects

## Checklist

- [x] Removed token from Google callback redirect URL
- [x] Removed token from GitHub callback redirect URL
- [x] httpOnly cookie-based auth preserved

Fixes #2187
