### PR TITLE
[fix] Remove hardcoded fallback JWT secret — throw if env var is unset (fixes #2189)

### DIFF
--- a/server/services/studentAuthService.js
+++ b/server/services/studentAuthService.js
@@ -1,7 +1,10 @@
 import jwt from 'jsonwebtoken';
 import { studentUsersRepository } from '../repositories/studentUsersRepository.js';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'nexasphere-jwt-dev-secret-change-in-production';
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable must be set');
+}
+const JWT_SECRET = process.env.JWT_SECRET;
 const JWT_EXPIRY = process.env.JWT_EXPIRY || '7d';
 
 const STUDENT_ROLES = {


### PR DESCRIPTION
## Description

Removes the hardcoded fallback JWT secret in studentAuthService.js. If JWT_SECRET is not set in the environment, the server now throws immediately at startup instead of silently using a well-known dev secret.

## Security Issue

The fallback secret is visible in public source code. If JWT_SECRET is accidentally unset in production, anyone can forge valid JWT tokens and impersonate any user.

## Changes

- server/services/studentAuthService.js: Replaced fallback with a guard that throws if the env var is missing

## Checklist

- [x] Removed hardcoded fallback secret
- [x] Added startup-time validation that JWT_SECRET is set
- [x] Existing token generation/verification behavior preserved

Fixes #2189
