### PR TITLE
fix: wrap StorageSync bridge iframe console.log in DEV guard in publicContentStore.js

### DIFF
--- a/website/src/utils/publicContentStore.js
+++ b/website/src/utils/publicContentStore.js
@@ -176,7 +176,9 @@ export function initStorageSyncBridge() {
   iframe.tabIndex = -1;
 
   iframe.onload = () => {
-    console.log('[StorageSync] Bridge iframe loaded from', adminOrigin);
+    if (import.meta.env.DEV) {
+      console.log('[StorageSync] Bridge iframe loaded from', adminOrigin);
+    }
     ALLOWED_BRIDGE_KEYS.forEach((key) => {
       iframe.contentWindow?.postMessage({ type: 'ns-sync', key }, adminOrigin);
     });


### PR DESCRIPTION
## Description
`publicContentStore.js` used `console.log` for the StorageSync bridge iframe load event with no DEV guard — polluting the browser console for all users in production and bypassing log level control.

Changes made:
- Wrapped `console.log('[StorageSync] Bridge iframe loaded from', adminOrigin)` in `if (import.meta.env.DEV)` consistent with the pattern used elsewhere in the codebase for operational logs
- Zero TypeScript errors introduced

Fixes #2127

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings