### PR TITLE
fix: replace typeof process guards with import.meta.env in logger.ts

### DIFF
--- a/website/src/lib/logger.ts
+++ b/website/src/lib/logger.ts
@@ -1,10 +1,13 @@
 import pino from 'pino';
 
-const isProduction = typeof process !== 'undefined' && process.env?.NODE_ENV === 'production';
+// In a Vite browser bundle, import.meta.env is the correct way to read
+// environment variables. typeof process guards are a Node.js/CJS pattern
+// and are unnecessary here — Vite replaces import.meta.env at build time.
+const isProduction = import.meta.env.MODE === 'production';
 const isNode = typeof window === 'undefined';
 
 export const logger = pino({
-  level: typeof process !== 'undefined' && process.env?.LOG_LEVEL ? process.env.LOG_LEVEL : 'info',
+  level: import.meta.env.VITE_LOG_LEVEL ?? 'info',
   ...(isProduction || !isNode
     ? {}
     : {


### PR DESCRIPTION
## Description
`logger.ts` used `typeof process !== 'undefined'` guards for reading `NODE_ENV` and `LOG_LEVEL` — a Node.js/CJS compatibility pattern that is unnecessary in a Vite browser bundle where `import.meta.env` is replaced at build time by Vite.

Changes made:
- Replaced `typeof process !== 'undefined' && process.env?.NODE_ENV === 'production'` with `import.meta.env.MODE === 'production'`
- Replaced `typeof process !== 'undefined' && process.env?.LOG_LEVEL ? process.env.LOG_LEVEL : 'info'` with `import.meta.env.VITE_LOG_LEVEL ?? 'info'`
- Added comment explaining why `typeof process` guards are unnecessary in a Vite-only browser environment
- Zero TypeScript errors introduced

Fixes #2129

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings