### PR TITLE
[fix] Implement sanitizeEventRecord and sanitizeCoreTeamMemberRecord with field allowlists (fixes #2202)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -635,8 +635,19 @@ async function listEventsStore({ page = 1, limit = 20 } = {}) {
   return { events: all.slice(start, start + limit), total };
 }
 
+const ALLOWED_EVENT_FIELDS = [
+  'id', 'name', 'description', 'date_text', 'time', 'location',
+  'type', 'mode', 'category', 'tags', 'image_url', 'registration_link',
+  'capacity', 'registered_count', 'price', 'created_at', 'updated_at',
+];
+
 function sanitizeEventRecord(event) {
-  return event;
+  if (!event || typeof event !== 'object') return event;
+  const sanitized = {};
+  for (const field of ALLOWED_EVENT_FIELDS) {
+    if (field in event) sanitized[field] = event[field];
+  }
+  return sanitized;
 }
 
 async function createEventStore(event) {
@@ -873,8 +884,18 @@ async function listCoreTeamStore() {
   return (content.coreTeam || []).map((member) => sanitizeCoreTeamMemberRecord(member));
 }
 
+const ALLOWED_TEAM_MEMBER_FIELDS = [
+  'id', 'name', 'role', 'position', 'bio', 'avatar_url',
+  'github_url', 'linkedin_url', 'email', 'joined_at', 'order',
+];
+
 function sanitizeCoreTeamMemberRecord(member) {
-  return member;
+  if (!member || typeof member !== 'object') return member;
+  const sanitized = {};
+  for (const field of ALLOWED_TEAM_MEMBER_FIELDS) {
+    if (field in member) sanitized[field] = member[field];
+  }
+  return sanitized;
 }
 
 async function createCoreTeamStore(member) {


### PR DESCRIPTION
## Description  In server/controllers/syncController.js and server/index.js, the `sanitizeEventRecord()` and `sanitizeCoreTeamMemberRecord()` functions are defined as no-op functions that return the input unchanged:  ```js function sanitizeEventRecord(event) { return event; } function sanitizeCoreTeamMemberRecord(member) { return member; } ```  These functions are supposed to strip sensitive fields before sending data to clients but they do absolutely nothing. Any sensitive data attached to event or team member objects (such as createdBy details, internal IDs, or contact info) will be exposed to all clients.  ## Location  - server/index.js - Lines ~638-640 (sanitizeEventRecord) - server/index.js - Lines ~876-878 (sanitizeCoreTeamMemberRecord)  ## Why 50+ lines needed  Proper fix requires: 1. Defining explicit field allowlists for events and team members 2. Implementing field stripping/filtering logic 3. Sanitizing nested/related objects 4. Ensuring no regression on existing API responses 5. Adding tests to verify sensitive fields are stripped  Estimated 50-100 lines across both functions.  

Fixes #2202