### PR TITLE
fix: replace Math.random() width with stable values in PortfolioSkeleton.jsx

### DIFF
--- a/website/src/components/ui/skeleton/PortfolioSkeleton.jsx
+++ b/website/src/components/ui/skeleton/PortfolioSkeleton.jsx
@@ -50,13 +50,10 @@ export const PortfolioSkeleton = () => {
           <section className="portfolio-panel">
             <Skeleton width="200px" height="2rem" style={{ marginBottom: '20px' }} />
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '12px' }}>
-              {Array.from({ length: 6 }).map((_, i) => (
-                <Skeleton
-                  key={i}
-                  width={`${Math.floor(Math.random() * 60) + 80}px`}
-                  height="32px"
-                  style={{ borderRadius: '16px' }}
-                />
+              {/* Stable widths — avoid Math.random() in render which causes
+                  layout instability and breaks React hydration */}
+              {[96, 120, 88, 112, 100, 136].map((w, i) => (
+                <Skeleton key={i} width={`${w}px`} height="32px" style={{ borderRadius: '16px' }} />
               ))}
             </div>
           </section>


### PR DESCRIPTION
## Description
`PortfolioSkeleton.jsx` called `Math.floor(Math.random() * 60) + 80` during render to set skill tag skeleton widths. `Math.random()` produces different values on every render — causing visual layout instability on re-renders and breaking React hydration if SSR is ever added.

Changes made:
- Replaced `Math.random()` with a stable pre-defined width array `[96, 120, 88, 112, 100, 136]` covering the same 80-140px range
- Added a comment explaining why `Math.random()` must not be used in render
- Zero TypeScript errors introduced

Fixes #2211

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings