### PR TITLE
fix: wrap console.error calls in DEV guard in bookmarkStorage.ts

### DIFF
--- a/website/src/utils/bookmarkStorage.ts
+++ b/website/src/utils/bookmarkStorage.ts
@@ -15,7 +15,12 @@ export const getBookmarks = (): BookmarkItem[] => {
     const data = localStorage.getItem(STORAGE_KEY);
     return data ? JSON.parse(data) : [];
   } catch (error) {
-    console.error('Failed to parse bookmarks from localStorage', error);
+    if (import.meta.env.DEV) {
+      console.error(
+        '[bookmarkStorage] Failed to parse bookmarks from localStorage:',
+        (error as Error).message
+      );
+    }
     return [];
   }
 };
@@ -24,6 +29,11 @@ export const saveBookmarks = (bookmarks: BookmarkItem[]): void => {
   try {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(bookmarks));
   } catch (error) {
-    console.error('Failed to save bookmarks to localStorage', error);
+    if (import.meta.env.DEV) {
+      console.error(
+        '[bookmarkStorage] Failed to save bookmarks to localStorage:',
+        (error as Error).message
+      );
+    }
   }
 };


### PR DESCRIPTION
## Description
`bookmarkStorage.ts` logged `localStorage` parse and save errors with `console.error` and no DEV guard — firing in production for all users who encounter storage errors (private browsing, quota exceeded), leaking internal error details to the browser console.

Changes made:
- Wrapped both `console.error` calls in `if (import.meta.env.DEV)`
- Added descriptive `[bookmarkStorage]` prefix and `(error as Error).message` cast for traceability in development
- Zero TypeScript errors introduced

Fixes #2214

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings