### PR TITLE
fix: wrap console.error calls in DEV guard in PromptHistorySidebar.jsx and PinnedChats.jsx

### DIFF
--- a/website/src/components/history/PinnedChats.jsx
+++ b/website/src/components/history/PinnedChats.jsx
@@ -12,7 +12,9 @@ const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
       const pinned = await getPinnedPrompts(workspace);
       setPinnedPrompts(pinned);
     } catch (error) {
-      console.error('Error loading pinned prompts:', error);
+      if (import.meta.env.DEV) {
+        console.error('[PinnedChats] Error loading pinned prompts:', error.message);
+      }
     } finally {
       setLoading(false);
     }

--- a/website/src/components/history/PromptHistorySidebar.jsx
+++ b/website/src/components/history/PromptHistorySidebar.jsx
@@ -19,7 +19,9 @@ const PromptHistorySidebar = ({ isOpen, onSelectPrompt, currentWorkspace = 'defa
       const promptList = await getAllPrompts(selectedWorkspace);
       setPrompts(promptList);
     } catch (error) {
-      console.error('Error loading history:', error);
+      if (import.meta.env.DEV) {
+        console.error('[PromptHistorySidebar] Error loading history:', error.message);
+      }
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Description
`PromptHistorySidebar.jsx` and `PinnedChats.jsx` logged history load errors with `console.error` and no DEV guard — firing in production for all users who encounter IndexedDB or storage errors, leaking internal error details to the browser console.

Changes made:
- Wrapped `console.error('Error loading history:', error)` in `if (import.meta.env.DEV)` with `[PromptHistorySidebar]` prefix and `error.message`
- Wrapped `console.error('Error loading pinned prompts:', error)` in `if (import.meta.env.DEV)` with `[PinnedChats]` prefix and `error.message`
- Zero TypeScript errors introduced

Fixes #2215

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings