### PR TITLE
fix: wrap console.error in DEV guard in dashboardRepository.js

### DIFF
--- a/website/src/services/dashboardRepository.js
+++ b/website/src/services/dashboardRepository.js
@@ -50,7 +50,9 @@ export const dashboardRepository = {
         profileCompletion: this.getProfileCompletion(),
       };
     } catch (error) {
-      console.error('Failed to load dashboard data:', error);
+      if (import.meta.env.DEV) {
+        console.error('[dashboardRepository] Failed to load dashboard data:', error.message);
+      }
       return EMPTY_DATA;
     }
   },


### PR DESCRIPTION
## Description
`dashboardRepository.js` logged dashboard data load errors with `console.error` and no DEV guard — firing in production for all users who encounter API failures, leaking internal error details to the browser console. This was inconsistent with the DEV guard already added to `useDashboardData.js` for the same operation.

Changes made:
- Wrapped `console.error('Failed to load dashboard data:', error)` in `if (import.meta.env.DEV)` with `[dashboardRepository]` prefix and `error.message` for traceability in development
- Zero TypeScript errors introduced

Fixes #2217

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings