### PR TITLE
fix: wrap console.error in DEV guard in RoadmapBuilderContext.tsx

### DIFF
--- a/website/src/context/RoadmapBuilderContext.tsx
+++ b/website/src/context/RoadmapBuilderContext.tsx
@@ -84,7 +84,12 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
         setNodesState(defaultNodes);
       }
     } catch (e) {
-      console.error('Failed to load roadmap from localStorage:', e);
+      if (import.meta.env.DEV) {
+        console.error(
+          '[RoadmapBuilderContext] Failed to load roadmap from localStorage:',
+          (e as Error).message
+        );
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Description
`RoadmapBuilderContext.tsx` logged `localStorage` load errors with `console.error` and no DEV guard — firing in production for all users who encounter storage errors (private browsing, quota exceeded), leaking internal error details to the browser console — inconsistent with the DEV guard pattern used in `bookmarkStorage.ts` and other utils.

Changes made:
- Wrapped `console.error('Failed to load roadmap from localStorage:', e)` in `if (import.meta.env.DEV)` with `[RoadmapBuilderContext]` prefix and `(e as Error).message` cast for traceability in development
- Zero TypeScript errors introduced

Fixes #2233

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings