### PR TITLE
fix: wrap all PWA service worker console calls in DEV guard in main.jsx

### DIFF
--- a/website/src/main.jsx
+++ b/website/src/main.jsx
@@ -33,19 +33,25 @@ let _updateSW = null;
 
 _updateSW = registerSW({
   onNeedRefresh() {
-    console.log('[PWA] New service worker available — notifying UI.');
+    if (import.meta.env.DEV) {
+      console.log('[PWA] New service worker available — notifying UI.');
+    }
     window.dispatchEvent(
       new CustomEvent('nexasphere:sw-update', { detail: { updateSW: _updateSW } })
     );
   },
 
   onOfflineReady() {
-    console.log('[PWA] App is ready to work offline.');
+    if (import.meta.env.DEV) {
+      console.log('[PWA] App is ready to work offline.');
+    }
     window.dispatchEvent(new CustomEvent('nexasphere:sw-offline-ready'));
   },
 
   onRegisterError(error) {
-    console.error('[PWA] Service worker registration failed:', error);
+    if (import.meta.env.DEV) {
+      console.error('[PWA] Service worker registration failed:', error);
+    }
     Sentry.captureException(error, { tags: { type: 'sw-register-error' } });
   },
 });
@@ -54,7 +60,9 @@ _updateSW = registerSW({
 if ('serviceWorker' in navigator) {
   navigator.serviceWorker.ready.then((registration) => {
     registration.update().catch((err) => {
-      console.warn('[PWA] Service worker update check failed on app load:', err);
+      if (import.meta.env.DEV) {
+        console.warn('[PWA] Service worker update check failed on app load:', err.message);
+      }
     });
   });
 }


### PR DESCRIPTION
## Description
`main.jsx` used `console.log` for `onNeedRefresh` and `onOfflineReady` PWA service worker events with no DEV guard — firing in production on every page load for all users, polluting the browser console. `onRegisterError` `console.error` and the update check `console.warn` also had no DEV guard.

Changes made:
- Wrapped `onNeedRefresh` `console.log` in `if (import.meta.env.DEV)`
- Wrapped `onOfflineReady` `console.log` in `if (import.meta.env.DEV)`
- Wrapped `onRegisterError` `console.error` in `if (import.meta.env.DEV)` — Sentry already captures the error in production so the console log is only needed in development
- Wrapped update check `console.warn` in `if (import.meta.env.DEV)` with `err.message`
- Consistent with DEV guards added to `PWAHandler.jsx` for the same service worker lifecycle events
- Zero TypeScript errors introduced

Fixes #2235

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings