### PR TITLE
fix: add r.ok check before r.json() in UserDashboard.tsx dashboard fetch calls

### DIFF
--- a/website/src/pages/dashboard/UserDashboard.tsx
+++ b/website/src/pages/dashboard/UserDashboard.tsx
@@ -147,10 +147,14 @@ export default function UserDashboard() {
     // hardcoded as 'user_123' so all users see identical placeholder data.
     setIsDemo(true);
 
+    const safeJson = (r: Response) => {
+      if (!r.ok) throw new Error(`Dashboard API error: ${r.status} ${r.statusText}`);
+      return r.json();
+    };
     Promise.all([
-      fetch(`${base}/api/dashboard/profile/${userId}`).then((r) => r.json()),
-      fetch(`${base}/api/dashboard/quests/${userId}`).then((r) => r.json()),
-      fetch(`${base}/api/dashboard/leaderboard`).then((r) => r.json()),
+      fetch(`${base}/api/dashboard/profile/${userId}`).then(safeJson),
+      fetch(`${base}/api/dashboard/quests/${userId}`).then(safeJson),
+      fetch(`${base}/api/dashboard/leaderboard`).then(safeJson),
     ])
       .then(([profile, quests, leaderboard]) => {
         // isDemo stays true — userId is still hardcoded as 'user_123'


### PR DESCRIPTION
## Description
`UserDashboard.tsx` chained `.then((r) => r.json())` on three dashboard API fetch calls with no `r.ok` check. A 4xx/5xx response would silently parse the error body as valid data. A non-JSON response (e.g. nginx error page) would throw an unhandled promise rejection crashing the entire `Promise.all` — bypassing any `.catch()` fallback.

Changes made:
- Extracted `safeJson()` helper that checks `r.ok` before calling `r.json()` and throws a descriptive error on non-OK responses
- All three fetch chains now use `safeJson` so the existing `.catch()` handler correctly handles API failures
- Consistent with the same `safeJson()` pattern introduced in `useAnalyticsData.ts`
- Zero TypeScript errors introduced

Fixes #2239

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings