### PR TITLE
fix: replace key={i} with key={t} for tag list items in ExplorePage.jsx

### DIFF
--- a/website/src/pages/explore/ExplorePage.jsx
+++ b/website/src/pages/explore/ExplorePage.jsx
@@ -512,9 +512,9 @@ function EventCard({ event, detailed }) {
             <Calendar size={11} /> {date}
           </span>
         )}
-        {tags.slice(0, 3).map((t, i) => (
+        {tags.slice(0, 3).map((t) => (
           <span
-            key={i}
+            key={t}
             style={{
               fontSize: '0.68rem',
               padding: '2px 8px',


### PR DESCRIPTION
## Description
`ExplorePage.jsx` used array index `key={i}` for tag `<span>` elements in the event/activity card tag list. Array index keys are unstable — when the tag list changes order or length, React reuses stale DOM nodes incorrectly leading to incorrect rendering and broken reconciliation.

Changes made:
- Replaced `key={i}` with `key={t}` using the tag string itself as the key — tags are unique strings within a single item so this produces a stable, meaningful key
- Removed unused `i` parameter from the `.map()` callback

Fixes #2240

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings