### PR TITLE
fix: wrap localStorage access in try-catch in ThemeProvider.tsx

### DIFF
--- a/website/src/context/theme/ThemeProvider.tsx
+++ b/website/src/context/theme/ThemeProvider.tsx
@@ -14,9 +14,15 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(undefine
 
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setThemeState] = useState<Theme | null>(() => {
-    // Check if user has explicitly set a preference
-    const stored = localStorage.getItem('ns-theme') as Theme | null;
-    return stored || null;
+    // Check if user has explicitly set a preference.
+    // Wrapped in try-catch — localStorage.getItem throws SecurityError
+    // in Safari private browsing mode.
+    try {
+      const stored = localStorage.getItem('ns-theme') as Theme | null;
+      return stored || null;
+    } catch {
+      return null;
+    }
   });
 
   const [systemTheme, setSystemTheme] = useState<Theme>(() => {
@@ -60,7 +66,13 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem('ns-theme', newTheme);
+    // Wrapped in try-catch — localStorage.setItem throws SecurityError
+    // in Safari private browsing or QuotaExceededError when storage is full.
+    try {
+      localStorage.setItem('ns-theme', newTheme);
+    } catch {
+      // Storage unavailable — theme applies for the session only.
+    }
   };
 
   const toggleTheme = () => {


### PR DESCRIPTION
## Description
`ThemeProvider.tsx` read and wrote `localStorage` without try-catch. In Safari private browsing mode, `localStorage.getItem()` throws `SecurityError` — crashing the `useState` initializer and potentially breaking the entire app for private browsing users.

Changes made:
- Wrapped `localStorage.getItem('ns-theme')` in the `useState` initializer in try-catch — falls back to `null` so theme defaults to system preference when storage is unavailable
- Wrapped `localStorage.setItem('ns-theme', newTheme)` in `setTheme()` in try-catch — theme applies for the session only when storage is unavailable, with a comment explaining the fallback behaviour
- Zero TypeScript errors introduced

Fixes #2244

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings