### PR TITLE
fix: wrap localStorage access in try-catch in useDataHooks.js

### DIFF
--- a/website/src/hooks/useDataHooks.js
+++ b/website/src/hooks/useDataHooks.js
@@ -3,16 +3,29 @@ import { THEME_STORAGE_KEY, DEFAULT_THEME, EVENTS_API_ENDPOINT } from '../data/c
 import { getApiBase } from '../utils/runtimeConfig';
 
 export function useThemeManagement() {
-  const [theme, setTheme] = useState(
-    () =>
-      document.documentElement.getAttribute('data-theme') ||
-      localStorage.getItem(THEME_STORAGE_KEY) ||
-      DEFAULT_THEME
-  );
+  const [theme, setTheme] = useState(() => {
+    // Wrapped in try-catch — localStorage.getItem throws SecurityError
+    // in Safari private browsing mode.
+    try {
+      return (
+        document.documentElement.getAttribute('data-theme') ||
+        localStorage.getItem(THEME_STORAGE_KEY) ||
+        DEFAULT_THEME
+      );
+    } catch {
+      return document.documentElement.getAttribute('data-theme') || DEFAULT_THEME;
+    }
+  });
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem(THEME_STORAGE_KEY, theme);
+    // Wrapped in try-catch — localStorage.setItem throws SecurityError
+    // in Safari private browsing or QuotaExceededError when storage is full.
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {
+      // Storage unavailable — theme applies for the session only.
+    }
   }, [theme]);
 
   const toggleTheme = useCallback(() => {


### PR DESCRIPTION
## Description
`useDataHooks.js` read and wrote `localStorage` for theme persistence without try-catch. In Safari private browsing mode, `localStorage.getItem()` throws `SecurityError` — crashing the `useState` initializer and leaving users with no theme applied.

Changes made:
- Wrapped `localStorage.getItem(THEME_STORAGE_KEY)` in the `useState` initializer in try-catch — falls back to `data-theme` attribute or `DEFAULT_THEME` when storage is unavailable
- Wrapped `localStorage.setItem(THEME_STORAGE_KEY, theme)` in `useEffect` in try-catch — theme applies for the session only when storage is unavailable, with a comment explaining the fallback behaviour
- Zero TypeScript errors introduced

Fixes #2245

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings