### PR TITLE
fix: wrap localStorage reads in try-catch in useNotifications.js

### DIFF
--- a/website/src/hooks/useNotifications.js
+++ b/website/src/hooks/useNotifications.js
@@ -4,7 +4,14 @@ import { buildUrl, getApiBase, getSocketServerUrl } from '../utils/runtimeConfig
 import { StudentAuthContext } from '../context/StudentAuthContext';
 
 function getAuthHeaders() {
-  const token = localStorage.getItem('ns_student_token') || localStorage.getItem('ns_admin_token');
+  // Wrapped in try-catch — localStorage.getItem throws SecurityError
+  // in Safari private browsing mode.
+  let token = null;
+  try {
+    token = localStorage.getItem('ns_student_token') || localStorage.getItem('ns_admin_token');
+  } catch {
+    // Storage unavailable — proceed without auth token.
+  }
   return token
     ? { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` }
     : { 'Content-Type': 'application/json' };
@@ -29,13 +36,20 @@ export function useNotifications() {
       try {
         let resolvedUserId = userId;
         if (!resolvedUserId) {
-          const storedUser = localStorage.getItem('ns_user');
+          let storedUser = null;
+          try {
+            storedUser = localStorage.getItem('ns_user');
+          } catch {
+            // Storage unavailable — skip stored user lookup.
+          }
           if (storedUser) {
             try {
               const u = JSON.parse(storedUser);
               resolvedUserId = u?.id || u?.userId;
             } catch (e) {
-              console.error('Error parsing stored user info', e);
+              if (import.meta.env.DEV) {
+                console.error('[useNotifications] Error parsing stored user info:', e.message);
+              }
             }
           }
         }


### PR DESCRIPTION
## Description
`useNotifications.js` read `localStorage` for auth tokens in `getAuthHeaders()` and for stored user info in the fetch effect without try-catch. In Safari private browsing mode, `localStorage.getItem()` throws `SecurityError` — crashing the notification hook and leaving users with no notifications UI.

Changes made:
- Wrapped `getAuthHeaders()` token reads in try-catch with `null` fallback — requests proceed without auth token when storage is unavailable
- Wrapped `storedUser` `localStorage.getItem('ns_user')` in try-catch with `null` fallback — userId resolution degrades gracefully when storage is unavailable
- Also wrapped the existing JSON.parse error log in a DEV guard with `[useNotifications]` prefix and `e.message` for traceability
- Zero TypeScript errors introduced

Fixes #2247

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings