### PR TITLE
fix: replace silent .catch(() => {}) with DEV-guarded warning in useDataHooks.js

### DIFF
--- a/website/src/hooks/useDataHooks.js
+++ b/website/src/hooks/useDataHooks.js
@@ -37,8 +37,10 @@ export function useDynamicEvents(fallbackEvents) {
           setEventsData(data.events);
         }
       })
-      .catch(() => {
-        // Silent fail
+      .catch((err) => {
+        if (import.meta.env.DEV) {
+          console.warn('[useDataHooks] Failed to fetch events:', err.message);
+        }
       });
 
     return () => {


### PR DESCRIPTION
## Description
`useDynamicEvents` in `useDataHooks.js` silently swallowed all fetch errors via `.catch(() => { // Silent fail })` with no logging — developers had no way to diagnose network failures and users received stale fallback data with no indication of why.

Changes made:
- Replaced bare `.catch(() => {})` with `.catch((err) => { if (import.meta.env.DEV) { console.warn(...) } })` that emits a DEV-guarded warning with `[useDataHooks]` prefix and `err.message` for traceability
- The hook correctly falls back to `fallbackEvents` on error since `setEventsData` is not called on failure — runtime behaviour is unchanged
- Zero TypeScript errors introduced

Fixes #2248

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings