### PR TITLE
fix(notifications): persist push subscriptions to DB and drop volatile store

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1277,7 +1277,6 @@ const validatePushSubscription = [
 
 app.post(
   '/api/notifications/subscribe',
-  adminAuth,
   notificationRateLimiter,
   validatePushSubscription,
   async (req, res) => {
@@ -1300,7 +1299,6 @@ app.post(
 
 app.post(
   '/api/notifications/unsubscribe',
-  adminAuth,
   notificationRateLimiter,
   validatePushSubscription,
   async (req, res) => {
@@ -1751,6 +1749,7 @@ if (process.env.NODE_ENV !== 'test') {
   if (!process.env.VERCEL) {
     const boot = HAS_SUPABASE ? studentUsersRepository.ensureSchema() : ensureContentFile();
     boot.then(() => {
+      loadPersistedPushSubscriptions();
       server = app.listen(port, () => {
         console.log(`NexaSphere server listening on http://localhost:${port}`);
         schedulerService.init();

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -5,7 +5,6 @@
  */
 
 import { Router } from 'express';
-import { body, validationResult } from 'express-validator';
 import { adminAuthMiddleware } from '../middleware/adminAuthMiddleware.js';
 import { requireStudentAuth } from '../middleware/studentAuthMiddleware.js';
 import { notificationRateLimiter } from '../middleware/rateLimiter.js';
@@ -13,77 +12,6 @@ import notificationsService from '../services/notificationsService.js';
 
 const router = Router();
 const adminAuth = adminAuthMiddleware.requireAdmin;
-
-// ── In-memory push subscription store ──────────────────────────────────────
-const pushSubscriptions = new Set();
-
-// ── Push subscription validation middleware ────────────────────────────────
-const validatePushSubscription = [
-  body('subscription').isObject().withMessage('subscription must be an object'),
-  body('subscription.endpoint')
-    .isURL()
-    .withMessage('endpoint must be a valid URL')
-    .isLength({ max: 2048 }),
-  body('subscription.keys').isObject().withMessage('keys must be an object'),
-  body('subscription.keys.p256dh')
-    .isString()
-    .isLength({ max: 256 })
-    .withMessage('p256dh must be a string up to 256 chars'),
-  body('subscription.keys.auth')
-    .isString()
-    .isLength({ max: 128 })
-    .withMessage('auth must be a string up to 128 chars'),
-  (req, res, next) => {
-    const errors = validationResult(req);
-    if (!errors.isEmpty()) {
-      return res
-        .status(400)
-        .json({ error: 'Invalid subscription payload', details: errors.array() });
-    }
-
-    // Strict sanitization: reconstruct object to drop malicious properties
-    const {
-      endpoint,
-      keys: { p256dh, auth },
-    } = req.body.subscription;
-    req.body.subscription = { endpoint, keys: { p256dh, auth } };
-
-    next();
-  },
-];
-
-/**
- * POST /api/notifications/subscribe — Register a push subscription.
- * Limits total stored subscriptions to 10 000 (FIFO eviction).
- */
-router.post('/api/notifications/subscribe', validatePushSubscription, (req, res) => {
-  try {
-    const { subscription } = req.body;
-    if (subscription) {
-      pushSubscriptions.add(JSON.stringify(subscription));
-      if (pushSubscriptions.size > 10000) {
-        const oldest = pushSubscriptions.values().next().value;
-        pushSubscriptions.delete(oldest);
-      }
-    }
-    return res.json({ success: true });
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
-  }
-});
-
-/**
- * POST /api/notifications/unsubscribe — Remove a push subscription.
- */
-router.post('/api/notifications/unsubscribe', validatePushSubscription, (req, res) => {
-  try {
-    const { subscription } = req.body;
-    if (subscription) pushSubscriptions.delete(JSON.stringify(subscription));
-    return res.json({ success: true });
-  } catch (err) {
-    return res.status(500).json({ error: err.message });
-  }
-});
 
 /**
  * POST /api/notifications/mark-read — Mark a single notification as read.


### PR DESCRIPTION
## Related Issue

Fixes #2176

## Type of Change

- [x] Bug Fix

## Changes Implemented

Three targeted changes across two files:

1. **Removed dead subscribe/unsubscribe handlers from `server/routes/notifications.js`** — these handlers stored subscriptions in a module-level `Set` with no DB writes, and were unreachable anyway because the router is mounted at `app.use('/api', notificationsRouter)` which strips the `/api` prefix before path matching, so `router.post('/api/notifications/subscribe', ...)` never matched any request.

2. **Removed `adminAuth` from the live subscribe/unsubscribe handlers in `server/index.js`** (lines 1278, 1301) — push subscription is initiated by browser clients when they call `PushManager.subscribe()`. Gating it on admin auth caused every browser subscription attempt to return 401. The `notificationRateLimiter` and `validatePushSubscription` middleware remain in place.

3. **Added `loadPersistedPushSubscriptions()` to the non-Vercel boot path** — the call existed only in the `VERCEL` branch. Local dev and non-Vercel deployments never hydrated the in-memory mirror from the DB on startup, so subscriptions were lost on every server restart even though `persistPushSubscription()` was correctly writing to the `push_subscriptions` table.

The repository, DB helpers (`persistPushSubscription`, `removePersistedPushSubscription`), and `pushSubscriptionsRepository` were already correct and wired to the index.js handlers — only the auth guard and the missing startup call were broken.

## Technical Details

### Backend

- `server/routes/notifications.js`: removed volatile `Set`, `validatePushSubscription` middleware, subscribe and unsubscribe route handlers, and unused `body`/`validationResult` imports (-72 lines)
- `server/index.js`: dropped `adminAuth` from two route definitions, added `loadPersistedPushSubscriptions()` call in non-Vercel boot path (+1 line)

### Database

No schema changes. Existing `push_subscriptions` table and repository are unchanged.

## Screenshots

N/A

## Testing

### Manual Testing

- [x] Verified removed symbols (`pushSubscriptions`, `validatePushSubscription`, `body`, `validationResult`) are absent from `notifications.js`
- [x] Verified `adminAuth` is absent from both subscribe and unsubscribe route definitions in `index.js`
- [x] Verified `loadPersistedPushSubscriptions()` is called in both boot paths

## Security Review

Removing `adminAuth` from subscribe is intentional — Web Push subscriptions originate from browser clients. The `notificationRateLimiter` (60 req/15 min) and strict `validatePushSubscription` payload validation remain, limiting abuse surface.

## Accessibility Review

N/A

## Performance Impact

No regression. Startup hydration is a one-time async DB read, already present for the Vercel path.

## Breaking Changes

- [x] No Breaking Changes

## Deployment Notes

No migration required. On first deploy after this change, `loadPersistedPushSubscriptions()` will load any existing rows from `push_subscriptions` into the in-memory mirror on startup.

## Rollback Plan

Revert commit. Push subscriptions will return to volatile in-memory-only behavior (prior state).

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Performance validated
- [x] CI/CD passing
- [x] Ready for review