### PR TITLE
fix(events): fix wrong ID in updateTicketToken and add compensating rollback on PG failure

### DIFF
--- a/server/controllers/eventRegistrationController.js
+++ b/server/controllers/eventRegistrationController.js
@@ -6,6 +6,7 @@ import { eventsRepository } from '../repositories/eventsRepository.js';
 import { emitToRole } from '../config/socket.js';
 import { broadcastSSEEvent } from '../services/sseService.js';
 import { recordEventRegistration } from '../observability/metrics.js';
+import { supabaseRequest } from '../storage/supabaseClient.js';
 
 function wrapAsync(fn) {
   return (req, res) =>
@@ -73,23 +74,41 @@ export const registerForEvent = wrapAsync(async (req, res) => {
       email: sanitizedEmail,
     });
 
-    await registrationsRepository.create({
-      eventId,
-      fullName: sanitizedFullName,
-      email: sanitizedEmail,
-      department,
-      year,
-      teamName,
-      teamSize,
-      customFields,
-      waitlist: false,
-    });
+    let localReg;
+    try {
+      localReg = await registrationsRepository.create({
+        eventId,
+        fullName: sanitizedFullName,
+        email: sanitizedEmail,
+        department,
+        year,
+        teamName,
+        teamSize,
+        customFields,
+        waitlist: false,
+      });
 
-    if (ticket.token) {
-      await registrationsRepository.updateTicketToken(
-        result.id || result.registration_id,
-        ticket.token
-      );
+      if (ticket.token && localReg?.id) {
+        await registrationsRepository.updateTicketToken(localReg.id, ticket.token);
+      }
+    } catch (pgErr) {
+      // Supabase already decremented capacity and inserted a row. Attempt a
+      // compensating delete so the slot is not permanently orphaned.
+      // A full capacity restore would require a dedicated rollback RPC on the
+      // Supabase side; this at minimum removes the ghost registration row.
+      try {
+        await supabaseRequest(
+          `event_registrations?event_id=eq.${encodeURIComponent(eventId)}&email=eq.${encodeURIComponent(sanitizedEmail)}`,
+          { method: 'DELETE' }
+        );
+      } catch (rollbackErr) {
+        console.error(
+          '[EventRegistration] Compensating delete failed — orphaned Supabase row for',
+          sanitizedEmail,
+          rollbackErr.message
+        );
+      }
+      throw pgErr;
     }
 
     try {


### PR DESCRIPTION
## Related Issue

Fixes #2177

## Type of Change

- [x] Bug Fix

## Changes Implemented

Two bugs fixed in `server/controllers/eventRegistrationController.js`.

**Bug 1 — updateTicketToken called with wrong ID**

`updateTicketToken` was called with `result.id || result.registration_id`, where `result` is the object returned by `capacityLockingService.registerForEvent()` — a Supabase row ID. The local PostgreSQL `event_registrations` table generates its own UUID. The `UPDATE event_registrations SET ticket_token =  WHERE id = ` query matched no rows, so `ticket_token` was never written.

Fixed to use `localReg.id` — the ID returned by `registrationsRepository.create()`, which is the actual local PG row.

**Bug 2 — no rollback when local PG insert fails after Supabase capacity decrement**

`capacityLockingService.registerForEvent()` calls the Supabase RPC `register_for_event` which atomically decrements capacity and inserts a row. The subsequent `registrationsRepository.create()` is a separate transaction against a different database connection. If it threw (connection drop, constraint violation, timeout), the Supabase slot was permanently consumed with no local record — the user would get a 500 and then a 409 on retry.

Wrapped the local PG operations in a try/catch. On failure, a compensating `DELETE` is issued to Supabase via PostgREST to remove the orphaned row. This does not restore the capacity counter (that requires a dedicated Supabase `rollback_registration` RPC — noted in the comment for a follow-up), but prevents a ghost registration from permanently blocking the email/event combination.

## Technical Details

### Backend

- `server/controllers/eventRegistrationController.js`: added `supabaseRequest` import, wrapped local PG block in try/catch with compensating delete, fixed `updateTicketToken` to use `localReg.id`

### Frontend / Database / API / Infrastructure

No changes.

## Screenshots

N/A

## Testing

### Manual Testing

- [x] Verified old `result.id || result.registration_id` pattern is removed
- [x] Verified `localReg.id` is used for `updateTicketToken`
- [x] Verified compensating delete path logs and re-throws on PG failure

### Integration Tests

- [ ] Simulate PG failure after Supabase RPC succeeds — assert compensating delete is attempted and error is returned to caller

## Security Review

The compensating Supabase DELETE filters by `event_id` and `email`, both of which are validated and sanitised before this point. No injection risk.

## Accessibility Review

N/A

## Performance Impact

No change to the happy path. The catch block only runs on error.

## Breaking Changes

- [x] No Breaking Changes

## Deployment Notes

None.

## Rollback Plan

Revert commit. Behaviour returns to previous state (wrong ID for ticket token update, no rollback on PG failure).

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Performance validated
- [x] Ready for review