### PR TITLE
fix(admin): detect runtime network loss in OfflineBanner via browser events

### DIFF
--- a/admin-dashboard/src/components/OfflineBanner.jsx
+++ b/admin-dashboard/src/components/OfflineBanner.jsx
@@ -2,21 +2,23 @@ import { useState, useEffect } from 'react';
 import { auth } from '../services/auth';
 
 export function OfflineBanner() {
-  const [isOffline, setIsOffline] = useState(false);
+  const isEnvOffline = auth && typeof auth.isOfflineMode === 'function' && auth.isOfflineMode();
+  const [isNetworkOffline, setIsNetworkOffline] = useState(!navigator.onLine);
 
   useEffect(() => {
-    if (!auth || typeof auth.isOfflineMode !== 'function') return;
+    const handleOffline = () => setIsNetworkOffline(true);
+    const handleOnline = () => setIsNetworkOffline(false);
 
-    setIsOffline(auth.isOfflineMode());
+    window.addEventListener('offline', handleOffline);
+    window.addEventListener('online', handleOnline);
 
-    const checkInterval = setInterval(() => {
-      if (typeof auth.isOfflineMode === 'function') {
-        setIsOffline(auth.isOfflineMode());
-      }
-    }, 2000);
-
-    return () => clearInterval(checkInterval);
+    return () => {
+      window.removeEventListener('offline', handleOffline);
+      window.removeEventListener('online', handleOnline);
+    };
   }, []);
+
+  const isOffline = isEnvOffline || isNetworkOffline;
 
   if (!isOffline) return null;
 
@@ -26,7 +28,11 @@ export function OfflineBanner() {
         &#9888;
       </span>
       <span>
-        <strong>Offline Mode</strong> — Changes are saved locally and will not sync to the server.
+        {isEnvOffline ? (
+          <><strong>Offline Mode</strong> — Changes are saved locally and will not sync to the server.</>
+        ) : (
+          <><strong>No Connection</strong> — Changes cannot be saved until connectivity is restored.</>
+        )}
       </span>
     </div>
   );


### PR DESCRIPTION
## Related Issue

Fixes #2180

## Type of Change

- [x] Bug Fix

## Changes Implemented

Rewrote `admin-dashboard/src/components/OfflineBanner.jsx` to detect both configured offline mode and runtime network loss.

## Technical Details

### Frontend

**Before:** The component polled `auth.isOfflineMode()` every 2 seconds via `setInterval`. `isOfflineMode()` reads `import.meta.env.VITE_API_BASE` — a compile-time constant that never changes at runtime. The banner could only appear when `VITE_API_BASE` was left unset at build time. If the network dropped at runtime while `VITE_API_BASE` was set, no banner appeared and every API call failed silently as a thrown error.

**After:**
- `isEnvOffline` is computed once from `auth.isOfflineMode()` (static, no polling needed)
- `isNetworkOffline` is initialised from `navigator.onLine` and updated by `window` `online`/`offline` event listeners
- Banner shows when either condition is true with a distinct message for each case:
  - Env offline: "Offline Mode — Changes are saved locally and will not sync to the server."
  - Network offline: "No Connection — Changes cannot be saved until connectivity is restored."
- Event listeners are cleaned up in the `useEffect` return

The 2-second `setInterval` is removed entirely — event-driven updates are immediate and have zero polling overhead.

### Backend / Database / API / Infrastructure

No changes.

## Screenshots

N/A

## Testing

### Manual Testing

- [x] Verified `setInterval` is removed
- [x] Verified `navigator.onLine` initialisation is present
- [x] Verified `offline`/`online` event listeners are registered and cleaned up
- [x] Verified `aria-live` attribute is preserved on the banner container

## Security Review

No security impact.

## Accessibility Review

`role="alert"` and `aria-live="assertive"` are preserved on the banner container. Screen readers will announce the banner immediately when it appears.

## Performance Impact

Removes a 2-second polling interval. The component now has zero periodic work when the network is stable.

## Breaking Changes

- [x] No Breaking Changes

## Deployment Notes

None.

## Rollback Plan

Revert commit. Banner returns to polling-only behaviour.

## Checklist

- [x] Code follows project standards
- [x] Accessibility reviewed
- [x] Performance validated
- [x] Ready for review