### PR TITLE
[fix] Add magic byte verification, reduce file size limit, sanitize filenames (fixes #2204)

### DIFF
--- a/server/controllers/resourcesController.js
+++ b/server/controllers/resourcesController.js
@@ -101,18 +101,23 @@ export const moderateResource = wrapAsync(async (req, res) => {
   return res.json(updated);
 });
 
+function sanitizeFilename(name) {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').substring(0, 200);
+}
+
 export const uploadFile = wrapAsync(async (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No file uploaded' });
   }
 
   const fileUrl = `/uploads/${req.file.filename}`;
+  const displayName = sanitizeFilename(req.body.title || req.file.originalname);
 
   const input = {
-    title: req.body.title || req.file.originalname,
+    title: displayName,
     description: req.body.description || '',
     file_url: fileUrl,
-    file_type: req.file.mimetype || req.file.originalname.split('.').pop(),
+    file_type: req.file.mimetype || 'application/octet-stream',
     file_size: req.file.size,
     category: req.body.category || 'other',
     tags: req.body.tags

--- a/server/index.js
+++ b/server/index.js
@@ -382,22 +382,39 @@ const storage = multer.diskStorage({
   },
 });
 
+const MAGIC_BYTES = {
+  'application/pdf': [[0x25, 0x50, 0x44, 0x46]],
+  'image/png': [[0x89, 0x50, 0x4e, 0x47]],
+  'image/jpeg': [[0xff, 0xd8, 0xff]],
+  'image/gif': [[0x47, 0x49, 0x46]],
+  'image/webp': [[0x52, 0x49, 0x46, 0x46]],
+  'application/zip': [[0x50, 0x4b, 0x03, 0x04], [0x50, 0x4b, 0x05, 0x06], [0x50, 0x4b, 0x07, 0x08]],
+  'application/x-zip-compressed': [[0x50, 0x4b, 0x03, 0x04]],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [[0x50, 0x4b, 0x03, 0x04]],
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': [[0x50, 0x4b, 0x03, 0x04]],
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [[0x50, 0x4b, 0x03, 0x04]],
+  'text/plain': [],
+  'text/markdown': [],
+  'application/json': [],
+};
+
+function validateMagicBytes(filepath, mimeType) {
+  const signatures = MAGIC_BYTES[mimeType];
+  if (!signatures || signatures.length === 0) return true;
+  const fd = fs.openSync(filepath, 'r');
+  const buffer = Buffer.alloc(8);
+  fs.readSync(fd, buffer, 0, 8, 0);
+  fs.closeSync(fd);
+  return signatures.some((sig) => sig.every((byte, i) => buffer[i] === byte));
+}
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
 const fileFilter = (_req, file, cb) => {
-  const allowedMimes = [
-    'application/pdf',
-    'image/png',
-    'image/jpeg',
-    'image/gif',
-    'image/webp',
-    'application/zip',
-    'application/x-zip-compressed',
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'text/plain',
-    'text/markdown',
-    'application/json',
-  ];
+  if (!file.originalname || file.originalname.includes('..') || file.originalname.includes('/')) {
+    return cb(new Error('Invalid file name'), false);
+  }
+  const allowedMimes = Object.keys(MAGIC_BYTES);
   if (allowedMimes.includes(file.mimetype)) {
     cb(null, true);
   } else {
@@ -408,8 +425,24 @@ const fileFilter = (_req, file, cb) => {
 const upload = multer({
   storage,
   fileFilter,
-  limits: { fileSize: 50 * 1024 * 1024 }, // 50MB
+  limits: { fileSize: MAX_FILE_SIZE },
 });
+
+const uploadWithMagicCheck = (req, res, next) => {
+  upload.single('file')(req, res, (err) => {
+    if (err) {
+      if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+        return res.status(413).json({ error: 'File too large. Maximum size is 10MB.' });
+      }
+      return res.status(400).json({ error: err.message });
+    }
+    if (req.file && !validateMagicBytes(req.file.path, req.file.mimetype)) {
+      fs.unlink(req.file.path, () => {});
+      return res.status(400).json({ error: 'File content does not match its declared type.' });
+    }
+    next();
+  });
+};
 
 // Serve uploaded files statically
 app.use('/uploads', express.static(UPLOADS_DIR));
@@ -1716,7 +1749,7 @@ app.post('/api/resources/:id/download-track', resourcesController.downloadResour
 app.post(
   '/api/resources/upload',
   requireStudentAuth,
-  upload.single('file'),
+  uploadWithMagicCheck,
   resourcesController.uploadFile
 );
 


### PR DESCRIPTION
## Description

Hardens file upload security: reduced max file size from 50MB to 10MB, added magic byte verification to validate actual file content matches declared MIME type, added filename sanitization to prevent path traversal.

## Changes

- Reduced file size limit from 50MB to 10MB
- Added magic byte verification for PDF, PNG, JPEG, GIF, WebP, ZIP, and OOXML formats
- Added uploadWithMagicCheck middleware combining multer + magic byte validation
- Added filename sanitization to strip path traversal characters
- Proper error responses for oversized files and invalid content

## Checklist

- [x] Reduced file size limit to 10MB
- [x] Added magic byte signatures for all allowed MIME types
- [x] Added validateMagicBytes function
- [x] Added uploadWithMagicCheck middleware
- [x] Added filename sanitization
- [x] Updated upload route to use new middleware

Fixes #2204