### PR TITLE
fix: store setTimeout IDs in ref and clear on unmount in useAppNavigation.js

### DIFF
--- a/website/src/hooks/useAppNavigation.js
+++ b/website/src/hooks/useAppNavigation.js
@@ -1,30 +1,50 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { NAV_HEIGHTS } from '../data/config';
 
 export function useAppNavigation(setPage, setActiveTab, mobile) {
   const [wipeOn, setWipeOn] = useState(false);
   const [wipePh, setWipePh] = useState(0);
 
-  const performTransition = useCallback((action) => {
-    setWipeOn(true);
-    setWipePh(0);
-    setTimeout(() => setWipePh(1), 10);
-    setTimeout(() => {
-      action();
-      setWipePh(2);
-      setTimeout(() => {
-        setWipeOn(false);
-        setWipePh(0);
-      }, 500);
-    }, 600);
+  // Store all active timer IDs so they can be cleared on unmount —
+  // prevents state updates on unmounted components during page transitions.
+  const timersRef = useRef([]);
+
+  const safeTimeout = useCallback((fn, delay) => {
+    const id = setTimeout(fn, delay);
+    timersRef.current.push(id);
+    return id;
   }, []);
+
+  useEffect(() => {
+    return () => {
+      timersRef.current.forEach(clearTimeout);
+      timersRef.current = [];
+    };
+  }, []);
+
+  const performTransition = useCallback(
+    (action) => {
+      setWipeOn(true);
+      setWipePh(0);
+      safeTimeout(() => setWipePh(1), 10);
+      safeTimeout(() => {
+        action();
+        setWipePh(2);
+        safeTimeout(() => {
+          setWipeOn(false);
+          setWipePh(0);
+        }, 500);
+      }, 600);
+    },
+    [safeTimeout]
+  );
 
   const handleTabChange = useCallback(
     (tab) => {
       setActiveTab(tab);
       if (tab === 'Home') {
         performTransition(() => setPage(null));
-        setTimeout(() => window.scrollTo({ top: 0, behavior: 'smooth' }), 100);
+        safeTimeout(() => window.scrollTo({ top: 0, behavior: 'smooth' }), 100);
       } else {
         const id = `section-${tab.toLowerCase()}`;
         const element = document.getElementById(id);
@@ -37,7 +57,7 @@ export function useAppNavigation(setPage, setActiveTab, mobile) {
         }
       }
     },
-    [setActiveTab, setPage, mobile, performTransition]
+    [setActiveTab, setPage, mobile, performTransition, safeTimeout]
   );
 
   return { wipeOn, wipePh, handleTabChange, performTransition };


### PR DESCRIPTION
## Description
`useAppNavigation.js` `performTransition` used three nested `setTimeout` calls with no timer ID storage or cleanup. If the component unmounts mid-transition (user navigates away during a page wipe animation), the callbacks fire on an unmounted component — triggering React state update warnings and memory leaks.

Changes made:
- Added `timersRef` to collect all active timer IDs
- Added `safeTimeout()` wrapper that registers each timer ID in `timersRef`
- Added `useEffect` cleanup that calls `clearTimeout` on all pending timers when the component unmounts
- Replaced all `setTimeout` calls with `safeTimeout()` in both `performTransition` and `handleTabChange`
- Zero TypeScript errors introduced

Fixes #2258

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings