### PR TITLE
fix: build CI report comment dynamically from job results instead of hardcoding success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,15 +147,24 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
+            const results = {
+              lint: '${{ needs.lint.result }}',
+              website: '${{ needs.website.result }}',
+              adminDashboard: '${{ needs.admin-dashboard.result }}',
+              server: '${{ needs.server.result }}',
+            };
+
+            const icon = (r) => r === 'success' ? '✅' : r === 'skipped' ? '⏭️' : '❌';
+
             const body = `
             ## CI Pipeline Results
 
-            ✅ Lint passed
-            ✅ Website build passed
-            ✅ Admin dashboard tests passed
-            ✅ Server tests passed
+            ${icon(results.lint)} Lint — ${results.lint}
+            ${icon(results.website)} Website build — ${results.website}
+            ${icon(results.adminDashboard)} Admin dashboard tests — ${results.adminDashboard}
+            ${icon(results.server)} Server tests — ${results.server}
 
-            CI pipeline completed successfully.
+            ${Object.values(results).every(r => r === 'success') ? 'CI pipeline completed successfully.' : '⚠️ One or more jobs failed. Please review the logs.'}
             `;
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
<!-- hardcoded CI success -->

# Summary
The `report` job in `ci.yml` was hardcoding `✅ Lint passed` and `CI pipeline completed successfully` regardless of actual job results. A PR that failed every test would still receive a bot comment claiming the pipeline passed. Fixed by reading `needs.<job>.result` for each job and constructing the comment body dynamically with accurate pass/fail indicators.

## Related Issue
Closes #2310

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [x] Documentation
- [ ] Testing
- [x] Infrastructure
- [ ] Integration

## Changes Implemented
- Replaced hardcoded success strings with dynamic `needs.<job>.result` values for `lint`, `website`, `admin-dashboard`, and `server` jobs
- Added `icon()` helper to show ✅/❌/⏭️ based on actual result
- Summary line now reflects overall pass/fail status

## Technical Details
### Infrastructure
- `.github/workflows/ci.yml` — fixed `report` job to post accurate CI status based on real job outcomes

## Checklist
- [x] Code follows project standards
- [x] Ready for review