### PR TITLE
fix: replace INSERT with UPSERT in registrationsRepository to prevent duplicate key crash

### DIFF
--- a/server/repositories/registrationsRepository.js
+++ b/server/repositories/registrationsRepository.js
@@ -40,6 +40,15 @@ export const registrationsRepository = {
       const { rows } = await client.query(
         `INSERT INTO event_registrations (event_id, full_name, email, department, year, team_name, team_size, custom_fields, waitlist, status)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         ON CONFLICT (event_id, email) DO UPDATE SET
+           full_name = EXCLUDED.full_name,
+           department = EXCLUDED.department,
+           year = EXCLUDED.year,
+           team_name = EXCLUDED.team_name,
+           team_size = EXCLUDED.team_size,
+           custom_fields = EXCLUDED.custom_fields,
+           waitlist = EXCLUDED.waitlist,
+           status = EXCLUDED.status
          RETURNING *`,
         [
           eventId,


### PR DESCRIPTION
<!-- compensating delete destroys registrations -->

# Summary
The Supabase RPC already inserts a row into `event_registrations`. The subsequent `registrationsRepository.create()` call attempted a blind INSERT for the same `(event_id, email)`, always throwing a UNIQUE constraint violation. The catch block then performed a compensating DELETE, destroying every valid registration. Fixed by adding `ON CONFLICT (event_id, email) DO UPDATE` so the existing row is updated instead of crashing.

## Related Issue
Closes #2322

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `ON CONFLICT (event_id, email) DO UPDATE SET ...` to the INSERT query in `registrationsRepository.create()`

## Technical Details
### Backend
- `server/repositories/registrationsRepository.js` — converted blind INSERT to UPSERT to handle duplicate rows from Supabase RPC

## Checklist
- [x] Code follows project standards
- [x] Ready for review