### PR TITLE
fix: mount notificationsRouter at / and enforce auth regardless of userId value

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -321,7 +321,7 @@ app.use('/', healthRouter);
 app.use('/', coreTeamRouter);
 app.use('/api', formsRouter);
 app.use('/api', portfolioRouter);
-app.use('/api', notificationsRouter);
+app.use('/', notificationsRouter);
 app.use('/api/admin', adminRouter);
 app.use('/', syncRouter);
 
@@ -1567,7 +1567,7 @@ app.get('/api/notifications', async (req, res) => {
   try {
     const userId = req.query.userId || 'global';
 
-    if (userId !== 'global') {
+    {
       let authenticated = false;
 
       // 1. Try Student Auth


### PR DESCRIPTION
<!-- dead routes + auth bypass -->

# Summary
`notificationsRouter` was mounted at `/api` but its internal paths already include `/api/notifications/...`, making all router routes respond only to `/api/api/notifications/...` — dead code. Additionally, the inline `GET /api/notifications` route only checked authentication when `userId !== 'global'`, allowing any unauthenticated request to dump all global notifications. Fixed by mounting the router at `/` and removing the `userId` condition so auth is always enforced.

## Related Issue
Closes #2323

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Changed `app.use('/api', notificationsRouter)` to `app.use('/', notificationsRouter)` in `server/index.js`
- Removed `if (userId !== 'global')` guard so authentication is enforced for all notification requests

## Technical Details
### Backend
- `server/index.js` — fixed router mount path and removed auth bypass for global userId

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review