### PR TITLE
fix: change push subscriptions query order to asc so oldest are evicted first

### DIFF
--- a/server/repositories/pushSubscriptionsRepository.js
+++ b/server/repositories/pushSubscriptionsRepository.js
@@ -14,7 +14,7 @@ export const pushSubscriptionsRepository = {
   async list({ limit = 10000 } = {}) {
     return withDb(async (client) => {
       const { rows } = await client.query(
-        'select endpoint, p256dh, auth from push_subscriptions order by created_at desc limit $1',
+        'select endpoint, p256dh, auth from push_subscriptions order by created_at asc limit $1',
         [limit]
       );
       return rows.map(mapRow);


### PR DESCRIPTION
<!-- newest subscription evicted instead of oldest -->

# Summary
The push subscriptions query used `order by created_at desc`, loading the newest subscriptions first into the JavaScript `Set`. Since `Set` maintains insertion order, memory eviction was deleting the newest subscription instead of the oldest. Changed to `order by created_at asc` so the oldest subscriptions are at the front of the Set and are correctly evicted first.

## Related Issue
Closes #2324

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Changed `order by created_at desc` to `order by created_at asc` in `pushSubscriptionsRepository.js` line 17

## Technical Details
### Backend
- `server/repositories/pushSubscriptionsRepository.js` — fixed query sort order to ensure oldest subscriptions are evicted first

## Checklist
- [x] Code follows project standards
- [x] Ready for review