### PR TITLE
Fix/remove manual ip parsing

### DIFF
--- a/server/routes/portfolio.js
+++ b/server/routes/portfolio.js
@@ -145,7 +145,7 @@ router.get('/api/portfolio/:username', async (req, res) => {
 router.put('/api/portfolio', protectedActionRateLimiter, async (req, res) => {
   try {
     const body = req.body || {};
-    const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
+    const ip = String(req.ip || 'unknown').trim();
 
     // 1. Validate credentials up front. Anything below this point
     //    trusts the username + passkey pair.

--- a/website/src/middleware/rateLimiter.ts
+++ b/website/src/middleware/rateLimiter.ts
@@ -5,7 +5,7 @@ const WINDOW_MS = 60 * 1000;
 const MAX_REQUESTS = 100;
 
 export const rateLimiter = (req: Request, res: Response, next: NextFunction) => {
-  const ip = req.ip || req.headers['x-forwarded-for'] || 'unknown';
+  const ip = String(req.ip || 'unknown').trim();
   const now = Date.now();
   const record = ipRequestCounts.get(ip as string);
 


### PR DESCRIPTION
# Summary
Removed manual `X-Forwarded-For` header extraction when determining client IP addresses to prevent IP spoofing and rate-limit bypasses. The application now relies purely on Express's native `req.ip` property, which securely handles proxy chains via the explicit `trust proxy` configuration.

## Related Issue

Fixes #2320

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Removed the manual parsing of `req.headers['x-forwarded-for']` in `server/index.js` for the `/api/portfolio` rate limiter and passkey enforcement.
- Removed the manual parsing of `req.headers['x-forwarded-for']` in `website/src/middleware/rateLimiter.ts` for the website rate limiter.
- Ensured both files rely strictly on `String(req.ip || 'unknown').trim()` instead.

## Technical Details

### Frontend
N/A

### Backend
- Previously, rate limiters were extracting client IPs directly from `req.headers['x-forwarded-for']`. This effectively bypassed the proxy trust hierarchies since it blindly read the header instead of checking the trusted proxy configuration.
- By switching to `req.ip`, we utilize Express's native implementation which pairs securely with our upstream server rule `app.set('trust proxy', ...)`, automatically dropping any spoofed IPs injected by attackers.

### Database
N/A

### API
- The `/api/portfolio` passkey validation and rate limiting are now protected against IP spoofing. 

### Infrastructure
N/A

## Screenshots

### Before
N/A

### After
N/A

## Testing

### Unit Tests

- [ ]

### Integration Tests

- [ ]

### E2E Tests

- [ ]

### Manual Testing

- [x] Tested passing custom `X-Forwarded-For` headers with dummy IPs to confirm that Express filters spoofed IPs correctly and the 5-attempt brute force blocks apply effectively using `req.ip`.

## Security Review
This PR directly addresses a rate-limit bypass and IP spoofing vulnerability. By avoiding manual parsing of `X-Forwarded-For` and leaning entirely on `req.ip` (guarded by `trust proxy`), attackers can no longer send arbitrary IPs to bypass the login brute-force lockouts or API rate limits.

## Accessibility Review
N/A

## Performance Impact
Negligible. Relying on Express's pre-computed `req.ip` property is slightly more efficient than doing a manual string fallback check.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes
Ensure that the `TRUST_PROXY` environment variable is set appropriately in production (e.g., `true` or the specific proxy IP distance) for `req.ip` to populate properly, as expected by the existing Express setup.

## Rollback Plan
Revert this PR to restore the explicit `req.headers['x-forwarded-for']` fallback if needed.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [x] CI/CD passing
- [x] Ready for review
