### PR TITLE
fix(auth): defer setLoading(false) until fetchMe resolves on OAuth callback

### DIFF
--- a/website/src/context/StudentAuthContext.jsx
+++ b/website/src/context/StudentAuthContext.jsx
@@ -43,8 +43,7 @@ export function StudentAuthProvider({ children }) {
         (params.toString() ? '?' + params.toString() : '') +
         window.location.hash;
       window.history.replaceState({}, '', cleanUrl);
-      fetchMe(urlToken);
-      setLoading(false);
+      fetchMe(urlToken).finally(() => setLoading(false));
       return;
     }
 


### PR DESCRIPTION
# Summary

## Description

In `website/src/context/StudentAuthContext.jsx`, when an OAuth redirect lands with `?token=` in the URL, `setLoading(false)` was called synchronously right after `fetchMe(urlToken)` before the async call resolved. `RequireAuth` reads `loading: false` while `user` is still `null`, treats the session as unauthenticated, and redirects to `/login`. On slow connections the redirect is permanent.

## Related Issue

Fixes #2351

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Chained `.finally(() => setLoading(false))` onto the URL-token `fetchMe` call so loading stays true until the API response settles. Removed the standalone `setLoading(false)` that fired before the async call completed.

## Technical Details

### Frontend

`website/src/context/StudentAuthContext.jsx` — `useEffect` handling the OAuth `?token=` query param. Before: `fetchMe(urlToken)` then immediately `setLoading(false)`. After: `fetchMe(urlToken).finally(() => setLoading(false))`.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Trigger OAuth login — dashboard loads without a /login flash
- [x] Throttle to Slow 3G — no redirect to /login mid-auth

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

No impact.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit 7e338084.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review