### PR TITLE
fix(roadmap): replace title-string autosave guard with hydration ref

### DIFF
--- a/website/src/context/RoadmapBuilderContext.tsx
+++ b/website/src/context/RoadmapBuilderContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useEffect, useCallback, ReactNode } from 'react';
+import React, { createContext, useState, useEffect, useCallback, useRef, ReactNode } from 'react';
 
 export interface ResourceLink {
   title: string;
@@ -49,6 +49,7 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
   );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [activeNodeId, setActiveNodeId] = useState<string | null>(null);
+  const isHydrated = useRef(false);
 
   // Restore workspace automatically from localStorage
   useEffect(() => {
@@ -90,13 +91,14 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
           (e as Error).message
         );
       }
+    } finally {
+      isHydrated.current = true;
     }
   }, []);
 
   // Autosave roadmap state using localStorage on every change
   useEffect(() => {
-    // Skip empty initial state saving to prevent overwriting
-    if (nodes.length === 0 && roadmapTitle === 'My Custom Path') return;
+    if (!isHydrated.current) return;
 
     const stateToSave = {
       title: roadmapTitle,


### PR DESCRIPTION
# Summary

## Description

The autosave `useEffect` in `website/src/context/RoadmapBuilderContext.tsx` used `nodes.length === 0 && roadmapTitle === 'My Custom Path'` to skip the pre-hydration render. This guard also silently blocked saving an intentionally empty canvas when the title still matched the default string. Deleted nodes reappear on page reload.

## Related Issue

Fixes #2353

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Added a `useRef` hydration flag set to `true` in the load `useEffect` `finally` block. Replaced the title-string guard with `if (!isHydrated.current) return` so only pre-hydration renders are skipped.

## Technical Details

### Frontend

`website/src/context/RoadmapBuilderContext.tsx` — added `useRef` import, declared `isHydrated` ref, set `isHydrated.current = true` in the hydration `useEffect` `finally` block, replaced the title-string guard in the autosave `useEffect`.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Delete all nodes, reload — empty canvas restored (not the default node)
- [x] loadRoadmap() with empty array — saves without being silently dropped

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

No impact. `useRef` has no re-render cost.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit 78c336b3.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review