### PR TITLE
fix(workspace): use authenticated user identity in real-time presence

### DIFF
--- a/website/src/pages/workspace/WorkspacePage.tsx
+++ b/website/src/pages/workspace/WorkspacePage.tsx
@@ -1,6 +1,7 @@
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import { useSocketSync } from '../../hooks/useSocketSync';
 import { useWorkspaceStore } from '../../store/workspaceStore';
+import { useStudentAuth } from '../../context/StudentAuthContext';
 import { Users, Wifi, WifiOff, RefreshCw, CheckCircle2, ChevronLeft } from 'lucide-react';
 import './WorkspacePage.css';
 
@@ -36,19 +37,24 @@ function getOrCreateAnonUser() {
 }
 
 export default function WorkspacePage({ roomId, onBack }: WorkspacePageProps) {
-  // Stable anonymous identity — persisted for the session so hot reloads
-  // and re-mounts do not generate a new user name and color each time.
-  const [user] = useState(getOrCreateAnonUser);
+  const { user: authUser } = useStudentAuth();
+  const [anonUser] = useState(getOrCreateAnonUser);
+
+  const user = useMemo(() => {
+    if (authUser?.name) {
+      return {
+        name: authUser.name,
+        initials: authUser.name.substring(0, 2).toUpperCase(),
+        color: anonUser.color,
+      };
+    }
+    return anonUser;
+  }, [authUser, anonUser]);
 
   const { emitDocumentChange, emitCursorMove, emitTyping } = useSocketSync(roomId, user);
   const { documentContent, users, status } = useWorkspaceStore();
   const editorRef = useRef<HTMLTextAreaElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    // Generate initials safely
-    user.initials = user.name.substring(0, 2).toUpperCase();
-  }, [user]);
 
   const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     const val = e.target.value;


### PR DESCRIPTION
# Summary

## Description

`website/src/pages/workspace/WorkspacePage.tsx` never reads from `StudentAuthContext`. It always generates a random `User-XXXX` anonymous identity for real-time presence, even for logged-in users. It also directly mutates the `useState` object in a `useEffect` (`user.initials = user.name.substring(0, 2).toUpperCase()`), which violates React's state immutability contract and can cause stale-closure issues in concurrent mode.

## Related Issue

Fixes #2354

## Type of Change

- [x] Bug Fix

## Changes Implemented

Imported `useStudentAuth` and `useMemo`. When `authUser.name` is available, `user` is derived from the auth context (real name, computed initials, session-stable color from `anonUser`). Otherwise falls back to `anonUser`. Removed the mutating `useEffect` entirely.

## Technical Details

### Frontend

`website/src/pages/workspace/WorkspacePage.tsx` — replaced `useEffect` import with `useMemo`, added `useStudentAuth` import, compute `user` via `useMemo` from auth context or anon fallback, removed the `useEffect` that mutated state post-render.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Log in and join workspace — avatar shows real name initials
- [x] Open room in private window (logged out) — shows `User-XXXX` anonymous identity

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

`useMemo` has negligible overhead vs the previous `useEffect`.

## Breaking Changes

- [x] No Breaking Changes

## Deployment Notes

N/A

## Rollback Plan

Revert commit `661fcc2b`.

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [x] Ready for review