### PR TITLE
fix(sw): register dashboard route before generic API catch-all

### DIFF
--- a/website/src/sw-nexasphere.js
+++ b/website/src/sw-nexasphere.js
@@ -114,7 +114,26 @@ registerRoute(
   })
 );
 
-// 5. API GET requests — NetworkFirst
+// 5. Dashboard, analytics, notifications — longer cache TTL, registered before
+// the generic API catch-all so Workbox's first-match-wins does not shadow it.
+registerRoute(
+  ({ url, request }) =>
+    request.method === 'GET' &&
+    /\/api\/(dashboard|analytics|notifications|profile)/i.test(url.pathname),
+  new NetworkFirst({
+    cacheName: 'nexasphere-dashboard-cache',
+    networkTimeoutSeconds: 5,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [200] }),
+      new ExpirationPlugin({
+        maxEntries: 30,
+        maxAgeSeconds: 60 * 10, // 10 minutes
+      }),
+    ],
+  })
+);
+
+// 6. Generic API GET requests — NetworkFirst catch-all
 // Auth/token endpoints are explicitly EXCLUDED (never cached)
 registerRoute(
   ({ url, request }) =>
@@ -132,22 +151,6 @@ registerRoute(
       new ExpirationPlugin({
         maxEntries: 50,
         maxAgeSeconds: 60 * 5, // 5 minutes
-      }),
-    ],
-  })
-);
-
-// 6. Dashboard, analytics, notifications — slightly longer NetworkFirst window
-registerRoute(
-  ({ url }) => /\/api\/(dashboard|analytics|notifications|profile)/i.test(url.pathname),
-  new NetworkFirst({
-    cacheName: 'nexasphere-dashboard-cache',
-    networkTimeoutSeconds: 5,
-    plugins: [
-      new CacheableResponsePlugin({ statuses: [200] }),
-      new ExpirationPlugin({
-        maxEntries: 30,
-        maxAgeSeconds: 60 * 10, // 10 minutes
       }),
     ],
   })


### PR DESCRIPTION
# Summary

## Description

In website/src/sw-nexasphere.js, the generic /api/ GET catch-all route (Route 5) is registered before the dashboard-specific route (Route 6). Workbox matches routes in registration order and stops at the first match. All GET requests to /api/dashboard, /api/analytics, /api/notifications, and /api/profile always match Route 5 and go into nexasphere-api-cache (5-min TTL). Route 6 and nexasphere-dashboard-cache (10-min TTL) are never reached.

## Related Issue

Fixes #2355

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [x] Infrastructure
- [ ] Integration

## Changes Implemented

Swapped the registration order so the dashboard/analytics/notifications/profile route is registered before the generic catch-all. Added request.method === 'GET' guard to the dashboard route matcher for consistency.

## Technical Details

### Frontend

website/src/sw-nexasphere.js - moved the dashboard route registration above the generic /api/ GET catch-all. No logic changed; only registration order and a method guard added.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

Service worker caching - dashboard endpoints now use the intended 10-minute TTL cache (nexasphere-dashboard-cache).

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] DevTools Application > Cache Storage - nexasphere-dashboard-cache populated after visiting /dashboard
- [x] nexasphere-api-cache still handles other non-dashboard API GETs

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

Dashboard data now gets the intended 10-minute offline window instead of 5 minutes.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

Service worker updates on next page load. Both routes use NetworkFirst with the same networkTimeoutSeconds: 5 so online behavior is unchanged.

## Rollback Plan

Revert commit a561df25.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review