### PR TITLE
fix(analytics): replace raw fetch with apiClient in useAnalyticsData

### DIFF
--- a/website/src/hooks/analytics/useAnalyticsData.ts
+++ b/website/src/hooks/analytics/useAnalyticsData.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { getApiBase } from '../../utils/runtimeConfig';
+import apiClient from '../../utils/apiClient';
 import { useAnalyticsFilters } from '../../context/AnalyticsFilterContext';
 import {
   generateTrendData,
@@ -51,15 +52,13 @@ export const useAnalyticsData = () => {
     }
 
     const base = getApiBase();
+    const token = localStorage.getItem('ns_student_token');
+    const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
-    const safeJson = (r: Response) => {
-      if (!r.ok) throw new Error(`Analytics API error: ${r.status} ${r.statusText}`);
-      return r.json();
-    };
     Promise.all([
-      fetch(`${base}/api/admin/analytics/stats`).then(safeJson),
-      fetch(`${base}/api/admin/analytics/growth`).then(safeJson),
-      fetch(`${base}/api/admin/analytics/events`).then(safeJson),
+      apiClient(`${base}/api/admin/analytics/stats`, { headers }),
+      apiClient(`${base}/api/admin/analytics/growth`, { headers }),
+      apiClient(`${base}/api/admin/analytics/events`, { headers }),
     ])
       .then(([stats, growth, events]) => {
         if (!isMounted) return;


### PR DESCRIPTION
# Summary

## Description

website/src/hooks/analytics/useAnalyticsData.ts fetches three admin analytics endpoints using raw fetch() instead of the shared apiClient. Requests to /api/admin/analytics/stats, /api/admin/analytics/growth, and /api/admin/analytics/events are sent without an Authorization header, have no timeout, produce no Sentry error reports, and get no offline IndexedDB hydration.

## Related Issue

Fixes #2356

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Imported apiClient. Read ns_student_token from localStorage and passed it as an Authorization: Bearer header. Replaced all three fetch().then(safeJson) calls with apiClient() calls. Removed the hand-rolled safeJson helper since apiClient already throws on non-2xx and parses JSON.

## Technical Details

### Frontend

website/src/hooks/analytics/useAnalyticsData.ts - added apiClient import, derived auth headers from localStorage token, replaced three raw fetch calls, removed safeJson.

### Backend

N/A

### Database

N/A

### API

Admin analytics endpoints now receive the Authorization header from the client.

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Network tab shows Authorization: Bearer on all three admin analytics requests when logged in
- [x] Offline - falls back to mock data via existing .catch path

## Security Review

Auth header now sent to admin endpoints. Unauthenticated requests still reach the server but are rejected by the admin middleware.

## Accessibility Review

No impact.

## Performance Impact

Requests now have a 10-second timeout enforced by apiClient.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit 46720f34.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review