### PR TITLE
fix(kanban): roll back optimistic task when socket is null

### DIFF
--- a/website/src/components/workspace/KanbanBoard.tsx
+++ b/website/src/components/workspace/KanbanBoard.tsx
@@ -442,6 +442,12 @@ export default function KanbanBoard({
             }
           }
         );
+      } else {
+        dispatch({ type: 'REMOVE_TASK', payload: tempId });
+        dispatch({
+          type: 'ROLLBACK',
+          payload: 'Not connected. Task could not be created.',
+        });
       }
     },
     [newTaskTitle, socket, roomId]


### PR DESCRIPTION
# Summary

## Description

In website/src/components/workspace/KanbanBoard.tsx, handleAddTask dispatches ADD_TASK optimistically before checking if the socket is available. When socket is null, the if (socket) block is skipped entirely with no else branch. The temp-ID task stays in the UI permanently, cannot be synced to collaborators, and is only removed by a full page reload.

## Related Issue

Fixes #2357

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Added an else branch after the if (socket) block in handleAddTask that dispatches REMOVE_TASK + ROLLBACK. This mirrors the server-rejection rollback path already present inside the socket callback.

## Technical Details

### Frontend

website/src/components/workspace/KanbanBoard.tsx - 6-line addition: else block dispatching REMOVE_TASK + ROLLBACK after the if (socket) guard in handleAddTask.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Disconnect socket, add task - error shown, task does not persist in the board
- [x] Connected socket, add task - optimistic add and server confirm unchanged

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

No extra re-renders beyond what the existing error toast already triggers.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit 9bc00e5d.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review