### PR TITLE
fix(analytics): generate multi-page PDF for dashboards taller than A4

### DIFF
--- a/website/src/pages/analytics/AnalyticsPage.tsx
+++ b/website/src/pages/analytics/AnalyticsPage.tsx
@@ -261,8 +261,18 @@ const AnalyticsDashboardContent: React.FC<AnalyticsPageProps> = ({ onBack }) => 
       const imgData = canvas.toDataURL('image/png');
       const pdf = new jsPDF('p', 'mm', 'a4');
       const pdfWidth = pdf.internal.pageSize.getWidth();
+      const pdfPageHeight = pdf.internal.pageSize.getHeight();
       const pdfHeight = (canvas.height * pdfWidth) / canvas.width;
-      pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
+
+      let pageNum = 0;
+      let yOffset = 0;
+      while (yOffset < pdfHeight) {
+        if (pageNum > 0) pdf.addPage();
+        pdf.addImage(imgData, 'PNG', 0, -yOffset, pdfWidth, pdfHeight);
+        yOffset += pdfPageHeight;
+        pageNum++;
+      }
+
       pdf.save(`NexaSphere_Analytics_${new Date().toISOString().split('T')[0]}.pdf`);
     } catch (err) {
       console.error('Export failed:', err);


### PR DESCRIPTION
# Summary

## Description

The PDF export in website/src/pages/analytics/AnalyticsPage.tsx calls html2canvas on the full dashboard then passes the result to a single pdf.addImage() call. jsPDF clips all content beyond the first page boundary (297mm for A4 portrait). The analytics dashboard is typically 350-440mm tall so the bottom charts are always missing from the exported file.

## Related Issue

Fixes #2358

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Replaced the single pdf.addImage() call with a while loop that advances yOffset by one page height per iteration, calls pdf.addPage() before each page after the first, and places the full image at y = -yOffset so each page shows the correct slice.

## Technical Details

### Frontend

website/src/pages/analytics/AnalyticsPage.tsx - handleExport function. Standard jsPDF multi-page pattern: negative y-offset shifts the captured canvas so each page exposes the next 297mm slice.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Export PDF - downloaded file has multiple pages, bottom charts visible on last page
- [x] Short dashboard (fits one page) - single-page export still works correctly

## Security Review

No impact.

## Accessibility Review

No impact.

## Performance Impact

Export time increases proportionally with page count, which is expected.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit e7720cf8.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review