### PR TITLE
fix(notifications): derive userId from auth context instead of defaulting to 'global'

### DIFF
--- a/website/src/components/notifications/NotificationPreferencesPanel.jsx
+++ b/website/src/components/notifications/NotificationPreferencesPanel.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import apiClient from '../../utils/apiClient';
+import { useStudentAuth } from '../../context/StudentAuthContext';
 
 const CATEGORIES = [
   { key: 'events', label: 'Event Updates', desc: 'New events, registration openings' },
@@ -17,15 +18,18 @@ const CHANNELS = [
   { key: 'email', label: 'Email', desc: 'Email notifications' },
 ];
 
-export default function NotificationPreferencesPanel({ userId = 'global', onClose }) {
+export default function NotificationPreferencesPanel({ userId, onClose }) {
+  const { user: authUser } = useStudentAuth();
+  const effectiveUserId = userId ?? authUser?.sub ?? authUser?.id;
   const [prefs, setPrefs] = useState({});
   const [saving, setSaving] = useState(false);
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
+    if (!effectiveUserId) return;
     (async () => {
       try {
-        const data = await apiClient(`/api/notifications/preferences?userId=${userId}`);
+        const data = await apiClient(`/api/notifications/preferences?userId=${effectiveUserId}`);
         const map = {};
         for (const p of data.preferences || []) {
           map[p.category] = { email: p.email, push: p.push, in_app: p.in_app };
@@ -36,7 +40,7 @@ export default function NotificationPreferencesPanel({ userId = 'global', onClos
       }
       setLoaded(true);
     })();
-  }, [userId]);
+  }, [effectiveUserId]);
 
   const toggle = useCallback((category, channel) => {
     setPrefs((prev) => {
@@ -55,13 +59,13 @@ export default function NotificationPreferencesPanel({ userId = 'global', onClos
       await apiClient('/api/notifications/preferences/bulk', {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId, preferences: bulk }),
+        body: JSON.stringify({ userId: effectiveUserId, preferences: bulk }),
       });
     } catch {
       // ignore
     }
     setSaving(false);
-  }, [prefs, userId]);
+  }, [prefs, effectiveUserId]);
 
   if (!loaded)
     return (

--- a/website/src/pages/notifications/NotificationHistoryPage.jsx
+++ b/website/src/pages/notifications/NotificationHistoryPage.jsx
@@ -2,6 +2,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import apiClient from '../../utils/apiClient';
 import { formatRelativeTime } from '../../utils/formatRelativeTime';
+import { useStudentAuth } from '../../context/StudentAuthContext';
+
 const TYPE_ICONS = {
   message: '💬',
   connection: '🔗',
@@ -9,7 +11,10 @@ const TYPE_ICONS = {
   system: '🔔',
 };
 
-export default function NotificationHistoryPage({ userId = 'global' }) {
+export default function NotificationHistoryPage({ userId }) {
+  const { user: authUser } = useStudentAuth();
+  const effectiveUserId = userId ?? authUser?.sub ?? authUser?.id;
+
   const [notifications, setNotifications] = useState([]);
   const [loading, setLoading] = useState(true);
   const [offset, setOffset] = useState(0);
@@ -20,11 +25,12 @@ export default function NotificationHistoryPage({ userId = 'global' }) {
 
   const fetchNotifications = useCallback(
     async (reset = false) => {
+      if (!effectiveUserId) return;
       setLoading(true);
       try {
         const currentOffset = reset ? 0 : offset;
         const data = await apiClient(
-          `/api/notifications?userId=${userId}&offset=${currentOffset}&limit=${limit}`
+          `/api/notifications?userId=${effectiveUserId}&offset=${currentOffset}&limit=${limit}`
         );
         const list = data.notifications || [];
         if (reset) {
@@ -39,13 +45,13 @@ export default function NotificationHistoryPage({ userId = 'global' }) {
       }
       setLoading(false);
     },
-    [userId, offset]
+    [effectiveUserId, offset]
   );
 
   useEffect(() => {
     setOffset(0);
     fetchNotifications(true);
-  }, [userId]);
+  }, [effectiveUserId]);
 
   const markRead = useCallback(
     async (id) => {
@@ -54,13 +60,13 @@ export default function NotificationHistoryPage({ userId = 'global' }) {
         await apiClient('/api/notifications/mark-read', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ id, userId }),
+          body: JSON.stringify({ id, userId: effectiveUserId }),
         });
       } catch {
         /* ignore */
       }
     },
-    [userId]
+    [effectiveUserId]
   );
 
   const markAllRead = useCallback(async () => {
@@ -69,22 +75,22 @@ export default function NotificationHistoryPage({ userId = 'global' }) {
       await apiClient('/api/notifications/mark-all-read', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId }),
+        body: JSON.stringify({ userId: effectiveUserId }),
       });
     } catch {
       /* ignore */
     }
-  }, [userId]);
+  }, [effectiveUserId]);
 
   const clearAll = useCallback(async () => {
     setNotifications([]);
     setHasMore(false);
     try {
-      await apiClient(`/api/notifications?userId=${userId}`, { method: 'DELETE' });
+      await apiClient(`/api/notifications?userId=${effectiveUserId}`, { method: 'DELETE' });
     } catch {
       /* ignore */
     }
-  }, [userId]);
+  }, [effectiveUserId]);
 
   const filteredList = filter === 'all' ? notifications : notifications.filter((n) => !n.isRead);
 


### PR DESCRIPTION
# Summary

## Description

NotificationHistoryPage and NotificationPreferencesPanel both default userId to the literal string 'global' when the prop is not passed. All notification API calls use this value as the user ID. Any server record stored under the key 'global' is accessible to all visitors without authentication (IDOR, OWASP A01:2021).

## Related Issue

Fixes #2359

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

Imported useStudentAuth in both components. Derived effectiveUserId = userId ?? authUser?.sub ?? authUser?.id. Replaced all userId references in API calls with effectiveUserId. Added guards to bail early when effectiveUserId is null. Updated all useCallback and useEffect dependency arrays.

## Technical Details

### Frontend

website/src/pages/notifications/NotificationHistoryPage.jsx and website/src/components/notifications/NotificationPreferencesPanel.jsx - removed the 'global' default, added useStudentAuth, computed effectiveUserId, updated all API calls and dependency arrays.

### Backend

N/A

### Database

N/A

### API

Notification endpoints now receive the authenticated user's actual ID instead of the literal string 'global'.

### Infrastructure

N/A

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

- [ ] N/A

### Integration Tests

- [ ] N/A

### E2E Tests

- [ ] N/A

### Manual Testing

- [x] Logged in - network tab shows real user ID in notification requests, not 'global'
- [x] Logged out - no API calls fire (components bail when effectiveUserId is null)

## Security Review

Addresses IDOR (OWASP A01:2021). Unauthenticated requests no longer target a shared 'global' user record.

## Accessibility Review

No impact.

## Performance Impact

No impact.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

N/A

## Rollback Plan

Revert commit f383783c.

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review