### PR TITLE
fix: add missing apiClient import in CertificateVerifyPage.jsx

### DIFF
--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useState } from 'react';
 import { getApiBase } from '../../utils/runtimeConfig';
+import { apiClient } from '../../utils/apiClient';
 
 // ---------------------------------------------------------------------------
 // Helpers


### PR DESCRIPTION
## Description
`CertificateVerifyPage.jsx` called `apiClient()` at line 213 without ever importing it. This causes a `ReferenceError: apiClient is not defined` at runtime — the certificate verification page crashes for all users who visit `/verify/:id` via QR code or direct URL.

Changes made:
- Added `import { apiClient } from '../../utils/apiClient'` alongside the existing `getApiBase` import
- No logic changes — the `apiClient` call was already correctly written, just missing its import
- Zero new TypeScript errors introduced (pre-existing errors in `KanbanBoard.tsx` and `UserDashboard.tsx` are unrelated)

Fixes #2102

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings