### PR TITLE
fix: wrap bare console calls in DEV guards in AdminPage, DashboardPage, and AiMentor

### DIFF
--- a/website/src/components/dashboard/AiMentor.jsx
+++ b/website/src/components/dashboard/AiMentor.jsx
@@ -30,7 +30,9 @@ export default function AiMentor() {
       });
       setResult(data);
     } catch (err) {
-      console.error(err);
+      if (import.meta.env.DEV) {
+        console.error('[AiMentor] AI Mentor request failed:', err.message);
+      }
       setResult({ error: 'Failed to connect to AI Mentor. Try again later.' });
     } finally {
       setLoading(false);

--- a/website/src/pages/admin/AdminPage.jsx
+++ b/website/src/pages/admin/AdminPage.jsx
@@ -101,7 +101,9 @@ export default function AdminPage({ onBack }) {
           }
         }
       } catch (err) {
-        console.warn('Admin SSE metrics stream connection interrupted or reconnecting...', err);
+        if (import.meta.env.DEV) {
+          console.warn('[AdminPage] SSE metrics stream interrupted or reconnecting:', err.message);
+        }
       }
 
       // Re-check closed after await — if component unmounted while fetch
@@ -160,7 +162,9 @@ export default function AdminPage({ onBack }) {
           };
         });
       } catch (err) {
-        console.error('Failed to parse registration SSE message:', err);
+        if (import.meta.env.DEV) {
+          console.error('[AdminPage] Failed to parse registration SSE message:', err.message);
+        }
       }
     });
 
@@ -168,7 +172,9 @@ export default function AdminPage({ onBack }) {
       try {
         JSON.parse(event.data);
       } catch (err) {
-        console.error('Failed to parse login SSE message:', err);
+        if (import.meta.env.DEV) {
+          console.error('[AdminPage] Failed to parse login SSE message:', err.message);
+        }
       }
     });
 
@@ -208,7 +214,9 @@ export default function AdminPage({ onBack }) {
         credentials: 'include',
       });
     } catch (err) {
-      console.error(err);
+      if (import.meta.env.DEV) {
+        console.error('[AdminPage] Logout error:', err.message);
+      }
     }
     setIsLoggedIn(false);
     setData({ stats: null, growth: [], events: [] });

--- a/website/src/pages/dashboard/DashboardPage.jsx
+++ b/website/src/pages/dashboard/DashboardPage.jsx
@@ -134,7 +134,9 @@ export default function DashboardPage({ onBack }) {
         setRecommendations(data.recommended_events || []);
       }
     } catch (e) {
-      console.error(e);
+      if (import.meta.env.DEV) {
+        console.error('[DashboardPage] Failed to fetch recommendations:', e.message);
+      }
     } finally {
       setLoadingRecs(false);
     }


### PR DESCRIPTION
## Description
`AdminPage.jsx`, `DashboardPage.jsx`, and `AiMentor.jsx` had bare `console.warn`/`console.error` calls with no `import.meta.env.DEV` guard — leaking internal SSE stream details and API error messages to the production browser console.

Changes made:
- `AdminPage.jsx` — 4 calls wrapped: SSE metrics warn, registration SSE error, login SSE error, logout error
- `DashboardPage.jsx` — 1 call wrapped: recommendation fetch error
- `AiMentor.jsx` — 1 call wrapped: AI Mentor request error
- All wrapped with `if (import.meta.env.DEV)` + `[ComponentName]` prefix + `err.message` for traceability
- Zero new TypeScript errors introduced

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings