### PR TITLE
fix: prevent blocked IP eviction in login attempt cache

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -107,26 +107,15 @@ function recordLoginAttempt(ip) {
       }
     }
 
-    // 2. If still full, evict blocked IPs first to preserve legitimate user entries
-    if (loginAttemptsByIp.size >= LOGIN_MAX_TRACKED_IPS) {
-      let evictKey = null;
-      for (const [key, entry] of loginAttemptsByIp.entries()) {
-        if (entry.attempts > LOGIN_MAX_ATTEMPTS) {
-          evictKey = key;
-          break;
-        }
-      }
+    // 2. If still full, evict the oldest tracked entry (FIFO)
+if (loginAttemptsByIp.size >= LOGIN_MAX_TRACKED_IPS) {
+  const oldestKey = loginAttemptsByIp.keys().next().value;
 
-      // Fallback to oldest entry (FIFO) if no blocked IPs found
-      if (!evictKey) {
-        evictKey = loginAttemptsByIp.keys().next().value;
-      }
-
-      if (evictKey) {
-        loginAttemptsByIp.delete(evictKey);
-      }
-    }
+  if (oldestKey) {
+    loginAttemptsByIp.delete(oldestKey);
   }
+}
+}
 
   const existing = loginAttemptsByIp.get(ip);
   const attempts = existing && existing.expiresAt > now ? existing.attempts : 0;


### PR DESCRIPTION
# Summary

This PR fixes the cache eviction strategy used in `recordLoginAttempt`.

When the login attempt tracking map reached its capacity limit, the previous implementation could evict blocked IP addresses before removing older entries. This unintentionally removed active bans and allowed malicious IPs to be tracked again.

This change removes the blocked-IP eviction logic and uses FIFO eviction after expired entries are cleaned up.

## Related Issue

Closes #2317

## Type of Change

* [x] Bug Fix

## Changes Implemented

* Removed eviction logic that targeted blocked IPs.
* Added FIFO eviction using the oldest tracked entry.
* Preserved existing cleanup of expired entries.

## Testing

### Manual Testing

* [x] Verified code changes locally
* [x] Verified FIFO eviction logic
* [x] Verified blocked IPs are no longer specifically removed

## Breaking Changes

* [x] No Breaking Changes

## Checklist

* [x] Code follows project standards
* [x] Security reviewed
* [x] Ready for review
