### PR TITLE
Fix: add missing lazy import for ResourcesPage causing crash on /reso…

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -94,6 +94,7 @@ const EventDetailPage = lazy(() => import('./pages/events/EventDetailPage'));
 const AboutPage = lazy(() => import('./pages/about/AboutPage'));
 const TeamPage = lazy(() => import('./pages/team/TeamPage'));
 const ContactPage = lazy(() => import('./pages/contact/ContactPage'));
+const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));
 const RoadmapsPage = lazy(() => import('./pages/roadmaps/RoadmapsPage'));
 const ProjectsPage = lazy(() => import('./pages/projects/ProjectsPage'));
 const CertificateVerifyPage = lazy(() => import('./pages/certificates/CertificateVerifyPage'));


### PR DESCRIPTION
## Fix: ResourcesPage crash on /resources route

### Context
While verifying the PWA/offline support described in #1743, I found that the `/resources` route was completely broken — it threw a runtime error and never rendered, regardless of network status.

### What I verified about #1743 first
Before writing any code, I checked the live site and the current codebase against the issue description:
- `manifest.json` is already configured via `vite-plugin-pwa` (name, icons, theme color, `display: standalone`)
- The service worker registers and activates correctly (confirmed in DevTools → Application → Service Workers)
- The install prompt appears correctly in Chrome, both as a browser tab and as an installed app
- An `offline.html` fallback page already exists in `public/`

So the core PWA infrastructure asked for in the issue is already implemented in `main`.

### Bug found during verification
While testing each route for offline behavior, `/resources` failed to load entirely:

```
ReferenceError: ResourcesPage is not defined
```

**Root cause:** `ResourcesPage` is used in the route definition in `src/App.jsx` (line ~1138) but was never imported. Every other page in this file is lazy-loaded via:
```js
const XPage = lazy(() => import('./pages/.../XPage'));
```
`ResourcesPage` was missing from that list, so the variable didn't exist and React threw, falling back to the app's generic error boundary.

### Fix
Added the missing import, following the exact same pattern as every other route:
```js
const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));
```

### Testing done
- **Before fix:** `/resources` showed "Something went wrong" with the `ReferenceError` above, both in a normal tab and the installed PWA, both online and offline.
## Fix: ResourcesPage crash on /resources route

### Context
While verifying the PWA/offline support described in #1743, I found that the `/resources` route was completely broken — it threw a runtime error and never rendered, regardless of network status.

### What I verified about #1743 first
Before writing any code, I checked the live site and the current codebase against the issue description:
- `manifest.json` is already configured via `vite-plugin-pwa` (name, icons, theme color, `display: standalone`)
- The service worker registers and activates correctly (confirmed in DevTools → Application → Service Workers)
- The install prompt appears correctly in Chrome, both as a browser tab and as an installed app
- An `offline.html` fallback page already exists in `public/`

So the core PWA infrastructure asked for in the issue is already implemented in `main`.

### Bug found during verification
While testing each route for offline behavior, `/resources` failed to load entirely:

```
ReferenceError: ResourcesPage is not defined
```

**Root cause:** `ResourcesPage` is used in the route definition in `src/App.jsx` (line ~1138) but was never imported. Every other page in this file is lazy-loaded via:
```js
const XPage = lazy(() => import('./pages/.../XPage'));
```
`ResourcesPage` was missing from that list, so the variable didn't exist and React threw, falling back to the app's generic error boundary.

### Fix
Added the missing import, following the exact same pattern as every other route:
```js
const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));
```

### Testing done
- **Before fix:** `/resources` showed "Something went wrong" with the `ReferenceError` above, both in a normal tab and the installed PWA, both online and offline.
<img width="1022" height="789" alt="Screenshot 2026-06-19 123835" src="https://github.com/user-attachments/assets/4c6b13f3-9e0f-43a3-a040-4d27a050ffeb" />

- **After fix:** Ran `npm run build` + `npm run preview`, navigated to `/resources` — the Resource Library page now renders correctly with all content (study materials, templates, past papers, etc.)
<img width="1919" height="1022" alt="Screenshot 2026-06-19 123854" src="https://github.com/user-attachments/assets/fae4bfd7-c234-47e0-bb35-dbe97899b722" />

- Re-tested with DevTools → Network → Offline + reload — the page no longer crashes from the undefined-variable error.
<img width="1619" height="852" alt="Screenshot 2026-06-19 123808" src="https://github.com/user-attachments/assets/01ae3fa8-61b5-41b4-8c66-a0aa337788c7" />


### Note on remaining offline gap
During offline testing I also noticed the service worker isn't actually serving the cached fallback on reload — `manifest.json` and page requests fail with `net::ERR_INTERNET_DISCONNECTED` instead of falling back to `offline.html`. That looks like a separate Workbox/`navigateFallback` configuration issue, out of scope for this PR. I've left details in a comment on #1743 and am happy to pick it up as a follow-up.

Relates to #1743.
- **After fix:** Ran `npm run build` + `npm run preview`, navigated to `/resources` — the Resource Library page now renders correctly with all content (study materials, templates, past papers, etc.)
- Re-tested with DevTools → Network → Offline + reload — the page no longer crashes from the undefined-variable error.
