### PR TITLE
fix: add explicit radix to parseInt in EventDetailPage.jsx

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -56,7 +56,7 @@ function StatCard({ label, value, color }) {
       ([e]) => {
         if (e.isIntersecting && !started.current) {
           started.current = true;
-          const num = parseInt(value);
+          const num = parseInt(value, 10);
           if (isNaN(num)) {
             setCount(value);
             return;


### PR DESCRIPTION
## Description
`EventDetailPage.jsx` line 59 called `parseInt(value)` without a radix argument. Without an explicit radix, `parseInt` may behave unexpectedly with strings starting with `0` in legacy environments. MDN explicitly recommends always specifying the radix.

Changes made:
- Replaced `parseInt(value)` with `parseInt(value, 10)` — consistent with all other `parseInt` calls in the codebase which correctly specify radix 10
- Zero TypeScript errors introduced

Fixes #2259

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings