### PR TITLE
fix: add missing lazy import for ResourcesPage

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -112,7 +112,7 @@ const MentorshipDashboard = lazy(() => import('./pages/mentorship/MentorshipDash
 const StatusPage = lazy(() => import('./pages/StatusPage'));
 const LiveStreamPage = lazy(() => import('./pages/streaming/LiveStreamPage'));
 const SponsorsPage = lazy(() => import('./pages/sponsors/SponsorsPage'));
-
+const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));
 const MNH = 88,
   DNH = 64;
 


### PR DESCRIPTION
# Summary

Fixes a runtime crash when navigating to the Resources page caused by a missing lazy import.

## Related Issue

Fixes #2293

## Type of Change

* [x] Bug Fix

## Changes Implemented

* Added the missing lazy import for `ResourcesPage` in `website/src/App.jsx`.
* Ensured the `/resources` route can render correctly without throwing a `ReferenceError`.

## Technical Details

### Frontend

Added the missing import:

const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));

This matches the existing route configuration where `<ResourcesPage />` is rendered.

### Backend

N/A

### Database

N/A

### API

N/A

### Infrastructure

N/A

## Screenshots

### Before

Navigating to `/resources` resulted in:

ReferenceError: ResourcesPage is not defined

and triggered the Error Boundary fallback UI.

### After

The Resources page resolves correctly because the component is now imported before use.

## Testing

### Manual Testing

* [x] Verified that `ResourcesPage` exists in the codebase.
* [x] Confirmed the route references the imported component.
* [x] Confirmed the missing import was the cause identified in the issue.

## Security Review

No security impact.

## Accessibility Review

No accessibility impact.

## Performance Impact

Negligible. The page continues to be lazy-loaded as intended.

## Breaking Changes

* [x] No Breaking Changes

## Deployment Notes

None.

## Rollback Plan

Revert the added lazy import if required.

## Checklist

* [x] Code follows project standards
* [ ] Tests added or updated
* [ ] Documentation updated
* [x] Security reviewed
* [x] Accessibility reviewed
* [x] Performance validated
* [ ] CI/CD passing
* [x] Ready for review
