### PR TITLE
fix: add explicit radix to parseInt in ActivityDetailPage.jsx

### DIFF
--- a/website/src/pages/activities/ActivityDetailPage.jsx
+++ b/website/src/pages/activities/ActivityDetailPage.jsx
@@ -16,7 +16,7 @@ function Counter({ value, suffix = '' }) {
       ([entry]) => {
         if (entry.isIntersecting && !started.current) {
           started.current = true;
-          const num = parseInt(value) || 0;
+          const num = parseInt(value, 10) || 0;
           const dur = 1200;
           const step = 16;
           const inc = num / (dur / step);


### PR DESCRIPTION
## Description
`ActivityDetailPage.jsx` line 19 called `parseInt(value)` without a radix in the counter animation. Without an explicit radix, `parseInt` may behave unexpectedly with strings starting with `0` in legacy environments. MDN recommends always specifying the radix.

Changes made:
- Replaced `parseInt(value)` with `parseInt(value, 10)` — consistent with all other `parseInt` calls in the file (lines 345–347 already correctly specify radix 16 for hex parsing)
- Zero TypeScript errors introduced

Fixes #2260

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings