### PR TITLE
fix: add missing location.pathname dependency to useEffect in App.jsx

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -393,7 +393,7 @@ function AppShell() {
     if (location.pathname !== '/') {
       setCinDone(true);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
 
   // Socket + cross-origin localStorage sync
   useEffect(() => {


### PR DESCRIPTION
## Description
The `useEffect` hook handling the cinematic opening toggle inside `App.jsx` was ignoring updates to the router location state by using an empty dependency array (`[]`) combined with an `eslint-disable-line` flag. 

Changes made:
- Added `location.pathname` to the dependency array to resolve potential stale closure situations.
- Removed the inline `eslint-disable-line react-hooks/exhaustive-deps` rule override.
- Zero TypeScript errors introduced.

Fixes #2267

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings