### PR TITLE
fix: prevent timer leaks on unmount in ContactPage.jsx

### DIFF
--- a/website/src/pages/contact/ContactPage.jsx
+++ b/website/src/pages/contact/ContactPage.jsx
@@ -45,8 +45,35 @@ function useBurst(ref) {
         setTimeout(() => p.remove(), 600);
       }
     };
-    el.addEventListener('click', burst);
-    return () => el.removeEventListener('click', burst);
+    const timers = [];
+    const trackingBurst = (e) => {
+      // Create a modified burst that collects its timeouts
+      for (let i = 0; i < 8; i++) {
+        const p = document.createElement('span');
+        const angle = (i / 8) * Math.PI * 2;
+        const dist = 40 + Math.random() * 30;
+        p.style.cssText = `
+          position:absolute;
+          left:${e.clientX - el.getBoundingClientRect().left}px;
+          top:${e.clientY - el.getBoundingClientRect().top}px;
+          width:5px; height:5px; border-radius:50%;
+          background:var(--c1);
+          pointer-events:none; z-index:10;
+          animation:contactBurst .55s ease forwards;
+          --tx:${Math.cos(angle) * dist}px;
+          --ty:${Math.sin(angle) * dist}px;
+        `;
+        el.appendChild(p);
+        const t = setTimeout(() => p.remove(), 600);
+        timers.push(t);
+      }
+    };
+
+    el.addEventListener('click', trackingBurst);
+    return () => {
+      el.removeEventListener('click', trackingBurst);
+      timers.forEach(clearTimeout);
+    };
   }, []);
 }
 
@@ -394,16 +421,24 @@ function MessageCTA() {
   const [name, setName] = useState('');
   const [message, setMessage] = useState('');
   const [copied, setCopied] = useState(false);
+  const copyTimeoutRef = useRef(null);
 
   const handleCopy = () => {
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
     navigator.clipboard
       .writeText(EMAIL)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 2200);
+        copyTimeoutRef.current = setTimeout(() => setCopied(false), 2200);
       })
       .catch(() => {});
   };
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+    };
+  }, []);
 
   const subject = encodeURIComponent(`Hi NexaSphere${name ? ` — ${name}` : ''}`);
   const body = encodeURIComponent(


### PR DESCRIPTION
## Description
`ContactPage.jsx` contained two unmanaged asynchronously scheduled timers (`setTimeout`) that could execute on unmounted elements/states, leading to runtime memory leaks if a user navigated away from the contact layout mid-action.

Changes made:
- **`useBurst` Hook**: Created a `timers` array scope reference to track element removals, clear out all pending macro-tasks during structural teardown inside the hook cleanup return block.
- **`MessageCTA` Component**: Placed a `copyTimeoutRef` tracker on the email copy notification feedback lifecycle. Clears pending resets when triggered successively or on immediate unmount.
- Zero TypeScript errors introduced.

Fixes #2266

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings