### PR TITLE
fix: utilize useNavigate for client-side navigation in ExplorePage.jsx

### DIFF
--- a/website/src/pages/explore/ExplorePage.jsx
+++ b/website/src/pages/explore/ExplorePage.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import {
   ArrowLeft,
@@ -424,6 +425,7 @@ function SectionBlock({ icon, title, subtitle, items, renderItem, emptyText }) {
 }
 
 function EventCard({ event, detailed }) {
+  const navigate = useNavigate();
   const title = event?.title || event?.name || event?.shortName || '';
   const desc = event?.description || '';
   const tags = event?.tags || [];
@@ -450,7 +452,7 @@ function EventCard({ event, detailed }) {
       }}
       onClick={() => {
         const url = event?.url || `/events/${event?.id || ''}`;
-        window.location.href = url;
+        navigate(url);
       }}
     >
       <div


### PR DESCRIPTION
## Description
`ExplorePage.jsx` was utilizing native browser `window.location.href` redirection to push route targets inside the `EventCard` component click handler. This bypasses the virtual DOM and React Router orchestration entirely, causing an unexpected, heavy full-page browser refresh that clears app contexts.

Changes made:
- Added `useNavigate` import from `react-router-dom`.
- Updated `EventCard` layout to trigger route redirects via `Maps(url)` instead of modifying window properties.
- Zero TypeScript errors introduced.

Fixes #2261

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings