### PR TITLE
fix: guard window.location.origin access in PortfolioBuilder.jsx

### DIFF
--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -256,7 +256,8 @@ export default function PortfolioBuilder() {
   };
 
   const getPortfolioUrl = () => {
-    return `${window.location.origin}/p/${username}`;
+    const base = typeof window !== 'undefined' ? window.location.origin : '';
+    return `${base}/p/${username}`;
   };
 
   const handleCopyLink = () => {


### PR DESCRIPTION
## Description
Inside `PortfolioBuilder.jsx`, the helper function `getPortfolioUrl` evaluated structural share links by reading properties directly off of the top-level browser global `window`. This pattern breaks or throws runtime unhandled crashes in Node.js-based environments (such as testing environments like Jest/Vitest or explicit SSR render routines) where `window` is completely omitted.

Changes made:
- Added an environment condition check checking for a valid structural `window` reference context (`typeof window !== 'undefined'`) prior to extracting the active base layout location parameters.
- Zero TypeScript errors introduced.

Fixes #2264

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings