### PR TITLE
fix: consolidate redundant parseInt invocations in ForumThreadPage.jsx

### DIFF
--- a/website/src/pages/forum/ForumThreadPage.jsx
+++ b/website/src/pages/forum/ForumThreadPage.jsx
@@ -7,6 +7,7 @@ import { EmptyState } from '../../components/EmptyState';
 
 export default function ForumThreadPage({ onBack }) {
   const { id } = useParams();
+  const threadIdNum = parseInt(id, 10);
   const navigate = useNavigate();
   const [thread, setThread] = useState(null);
   const [replies, setReplies] = useState([]);
@@ -20,9 +21,9 @@ export default function ForumThreadPage({ onBack }) {
   useEffect(() => {
     const base = getApiBase();
     if (!base) {
-      const t = fallbackThreads.find((th) => th.id === parseInt(id, 10));
+      const t = fallbackThreads.find((th) => th.id === threadIdNum);
       setThread(t || null);
-      setReplies(fallbackReplies.filter((r) => r.threadId === parseInt(id, 10)));
+      setReplies(fallbackReplies.filter((r) => r.threadId === threadIdNum));
       setLoading(false);
       return;
     }
@@ -32,7 +33,7 @@ export default function ForumThreadPage({ onBack }) {
         if (data?.replies) setReplies(data.replies);
       })
       .catch(() => {
-        const t = fallbackThreads.find((th) => th.id === parseInt(id, 10));
+        const t = fallbackThreads.find((th) => th.id === threadIdNum);
         setThread(t || null);
       })
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Description
`ForumThreadPage.jsx` parsed the `id` string parameter provided by `useParams()` multiple individual times using `parseInt(id, 10)` inside its lifecycle handlers. This creates unnecessary overhead and redundancy when matching properties against static datasets.

Changes made:
- Created a structural `threadIdNum` integer definition directly following route parameter evaluation metrics.
- Replaced the three separate inline string parsers across the local state verification array blocks with references to the cached variable instead.
- Zero TypeScript errors introduced.

Fixes #2263

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings