### PR TITLE
fix: implement clearTimeout cleanup for copy feedback in ContactPage.jsx

### DIFF
--- a/website/src/pages/contact/ContactPage.jsx
+++ b/website/src/pages/contact/ContactPage.jsx
@@ -395,12 +395,17 @@ function MessageCTA() {
   const [message, setMessage] = useState('');
   const [copied, setCopied] = useState(false);
 
+  useEffect(() => {
+    if (!copied) return;
+    const timer = setTimeout(() => setCopied(false), 2200);
+    return () => clearTimeout(timer);
+  }, [copied]);
+
   const handleCopy = () => {
     navigator.clipboard
       .writeText(EMAIL)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 2200);
       })
       .catch(() => {});
   };


### PR DESCRIPTION
## Description
Inside the `MessageCTA` component context within `ContactPage.jsx`, copying information to the clipboard dispatched an unchecked asynchronous `setTimeout` sequence to clear visual indicator states. When navigating away from the contact layout immediately after execution, the timer would trigger state mutations on an unmounted target, sparking execution warning signals.

Changes made:
- Migrated the reset timer strategy out of the handle macro into a dedicated tracking `useEffect`.
- Implemented explicit garbage-collection criteria that clears active layout thread hooks upon component unmount schedules.
- Zero TypeScript errors introduced.

Fixes #2422

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings