### PR TITLE
fix: use unique identity keys for upcoming event animation wrappers

### DIFF
--- a/website/src/pages/activities/ActivityDetailPage.jsx
+++ b/website/src/pages/activities/ActivityDetailPage.jsx
@@ -619,7 +619,7 @@ export default function ActivityDetailPage({ activity, onBack, onSelectEvent }) 
             </h2>
             <div style={{ display: 'flex', flexDirection: 'column', gap: '12px' }}>
               {activity.upcomingEvents.map((event, i) => (
-                <div key={i} className="pop-in">
+                <div key={event.id || i} className="pop-in">
                   <UpcomingCard event={event} color={color} />
                 </div>
               ))}


### PR DESCRIPTION
## Description
Inside the upcoming events rendering pipeline of `ActivityDetailPage.jsx`, elements with entry transitions (`className="pop-in"`) were configured with unstable index-based identification pointers (`key={i}`). This causes React to re-evaluate structural identities incorrectly on list updates, disrupting entry or layout-shift animations.

Changes made:
- Swapped out the dynamic list evaluation tracker index assignment in favor of a unique identifier structure (`key={event.id || i}`).
- Ensures stable VDOM references during rendering lifecycles without disrupting CSS entry configurations.
- Zero TypeScript errors introduced.

Fixes #2440

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings