### PR TITLE
fix: apply stable rendering keys in ResumeAnalyzerPage.jsx

### DIFF
--- a/website/src/pages/resume/ResumeAnalyzerPage.jsx
+++ b/website/src/pages/resume/ResumeAnalyzerPage.jsx
@@ -127,7 +127,7 @@ export default function ResumeAnalyzerPage({ onBack }) {
               { label: 'Skills Detected', value: result.skills.length, color: '#f59e0b' },
               { label: 'Gaps Found', value: result.missingSkills.length, color: '#ef4444' },
             ].map((s, i) => (
-              <div key={i} className="score-card">
+              <div key={s.label} className="score-card">
                 <p className="score-card-label">{s.label}</p>
                 <p className="score-card-value" style={{ color: s.color }}>
                   {s.value}
@@ -156,7 +156,7 @@ export default function ResumeAnalyzerPage({ onBack }) {
             <h3 className="section-title">Missing / In-Demand Skills</h3>
             <div className="missing-skills">
               {result.missingSkills.map((s, i) => (
-                <span key={i} className="skill-tag missing">
+                <span key={s} className="skill-tag missing">
                   {s}
                 </span>
               ))}


### PR DESCRIPTION
## Description
`ResumeAnalyzerPage.jsx` implemented unstable index iterations (`key={i}`) inside its analysis score tracking panels and missing skill item loops. When a developer re-uploads or substitutes alternative resumes, React's virtual tree reconciler can reuse indices from previous structures, causing stale rendering fragments or old calculation metrics to briefly linger.

Changes made:
- Shifted the score metric mapping to lock on `s.label`.
- Swapped out the individual tag indices to track unique skill strings directly (`key={s}`).
- Zero TypeScript errors introduced.

Fixes #2439

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings