### PR TITLE
fix: use stable name identity key for project team lists

### DIFF
--- a/website/src/pages/projects/ProjectsPage.jsx
+++ b/website/src/pages/projects/ProjectsPage.jsx
@@ -218,7 +218,7 @@ export default function ProjectsPage({ onBack }) {
                   </h4>
                   <div className="project-team-list">
                     {selectedProject.team.map((member, idx) => (
-                      <div key={idx} className="team-member">
+                      <div key={member.name} className="team-member">
                         <SafeImage
                           src={member.photo}
                           alt={member.name}


### PR DESCRIPTION
## Description
Inside the custom modal interface inside `ProjectsPage.jsx`, team roster elements utilized sequential map positions (`key={idx}`). When changing the active modal view from one project card directly to another, React uses the same layout mappings, occasionally leaving old profile components or image shells improperly cleared.

Changes made:
- Migrated the key tracking pointer off array iteration indices.
- Tied node tracking explicitly to structural keys (`key={member.name}`).
- Zero TypeScript errors introduced.

Fixes #2438

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings