### PR TITLE
fix: implement unknown type narrowing for error catch blocks in RoadmapBuilder

### DIFF
--- a/website/src/components/roadmaps/RoadmapBuilder.tsx
+++ b/website/src/components/roadmaps/RoadmapBuilder.tsx
@@ -123,8 +123,10 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
         setMetaTitle(validated.title);
         setMetaDesc(validated.description);
         alert('Roadmap imported and restored successfully!');
-      } catch (err: any) {
-        alert(err.message || 'Malformed JSON Schema: could not load roadmap.');
+      } catch (err: unknown) {
+        alert(
+          err instanceof Error ? err.message : 'Malformed JSON Schema: could not load roadmap.'
+        );
       }
     };
     reader.readAsText(file);


### PR DESCRIPTION
## Description
Inside `RoadmapBuilder.tsx`, exceptions raised during external file parsing operations were intercepted using an explicit `any` compiler override fallback (`catch (err: any)`). This bypasses static analysis checks when pulling error message signatures.

Changes made:
- Rewrote the block to utilize standard type-safe structural tracking (`catch (err: unknown)`).
- Implemented type narrowing via an inline `err instanceof Error` validation check before referencing the underlying runtime descriptive string.
- Zero TypeScript errors introduced.

Fixes #2437

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings