### PR TITLE
fix: assign stable unique composite keys for live poll choices

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -194,7 +194,7 @@ function PollPanel({ polls, onVote }) {
                 const pct = totalVotes > 0 ? Math.round((count / totalVotes) * 100) : 0;
                 return (
                   <button
-                    key={idx}
+                    key={`${poll.id}-opt-${opt}`}
                     onClick={() => handleVote(poll.id, idx)}
                     disabled={votedPolls.has(poll.id)}
                     className="w-full relative overflow-hidden rounded bg-gray-600 px-3 py-2 text-left text-sm hover:bg-gray-500 transition disabled:opacity-80 disabled:cursor-default"


### PR DESCRIPTION
## Description
Inside the dynamic live polling modules rendered on `LiveStreamPage.jsx`, poll election parameters utilized an index fallback (`key={idx}`). When stream sockets feed active changes or recalculate statistical bars, elements occasionally drop transition frames or maintain misaligned percentage layers due to unstable node reuse.

Changes made:
- Migrated option buttons tracking away from generic index placements.
- Instantiated stable, scope-separated composite strings (`key={\`${poll.id}-opt-\${opt}\`}`).
- Zero TypeScript errors introduced.

Fixes #2435

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings