### PR TITLE
fix: assign stable unique composite keys for incident status timeline updates

### DIFF
--- a/website/src/pages/StatusPage.jsx
+++ b/website/src/pages/StatusPage.jsx
@@ -169,7 +169,10 @@ export default function StatusPage() {
                   </div>
                   <div className="space-y-2 mt-2">
                     {incident.updates.map((update, idx) => (
-                      <div key={idx} className="text-sm text-gray-400">
+                      <div
+                        key={`${incident.id}-update-${update.timestamp}`}
+                        className="text-sm text-gray-400"
+                      >
                         <span className="text-xs text-gray-600 block">
                           {new Date(update.timestamp).toLocaleTimeString()}
                         </span>


### PR DESCRIPTION
## Description
Inside the incident tracking log elements rendered within `StatusPage.jsx`, nested timeline changes utilized list-index iteration fallbacks (`key={idx}`). When an item state refreshes or real-time polling logs append updates, matching indices can lead to stale message content caching or text mismatching.

Changes made:
- Shifted timeline elements away from generic index trackers.
- Configured unique scope keys integrating incident IDs and timestamps (`key={\`${incident.id}-update-\${update.timestamp}\`}`).
- Zero TypeScript errors introduced.

Fixes #2434

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings