### PR TITLE
fix: assign stable unique composite keys for role description items

### DIFF
--- a/website/src/pages/recruitment/RecruitmentPage.jsx
+++ b/website/src/pages/recruitment/RecruitmentPage.jsx
@@ -89,7 +89,10 @@ function RolesGuideModal({ onClose }) {
       )}
       <ul style={{ margin: 0, paddingLeft: 18, display: 'grid', gap: 4 }}>
         {items.map((it, i) => (
-          <li key={i} style={{ fontSize: '.86rem', color: 'var(--t2)', lineHeight: 1.55 }}>
+          <li
+            key={`role-item-${i}-${it.slice(0, 16)}`}
+            style={{ fontSize: '.86rem', color: 'var(--t2)', lineHeight: 1.55 }}
+          >
             {it}
           </li>
         ))}


### PR DESCRIPTION
## Description
Inside the `RolesGuideModal` helper layout within `RecruitmentPage.jsx`, lists detailing duties and specific requirements fallback to index values (`key={i}`). When users switch contexts between different open positions inside the overlay, React sometimes retains elements or drops smooth height adjustments.

Changes made:
- Migrated standard list item blocks off pure loop count indices.
- Configured a clear composite string tracking identity (`key={\`role-item-\${i}-\${it.slice(0, 16)}\`}`).
- Zero TypeScript errors introduced.

Fixes #2432

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings