### PR TITLE
fix: assign stable composite keys for roadmap side panel lists

### DIFF
--- a/website/src/pages/roadmaps/RoadmapsPage.jsx
+++ b/website/src/pages/roadmaps/RoadmapsPage.jsx
@@ -261,7 +261,10 @@ export default function RoadmapsPage({ onBack }) {
                 </h4>
                 <ul className="concepts-pill-list">
                   {selectedNode.concepts.map((concept, idx) => (
-                    <li key={idx} className="concept-badge-pill">
+                    <li
+                      key={`concept-${selectedNode.id}-${concept}`}
+                      className="concept-badge-pill"
+                    >
                       {concept}
                     </li>
                   ))}
@@ -297,7 +300,7 @@ export default function RoadmapsPage({ onBack }) {
                 <div className="resources-vertical-stack">
                   {selectedNode.tutorials.map((tutorial, idx) => (
                     <a
-                      key={idx}
+                      key={`tutorial-${selectedNode.id}-${tutorial.url}`}
                       href={tutorial.url}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -321,7 +324,7 @@ export default function RoadmapsPage({ onBack }) {
                 <div className="resources-vertical-stack">
                   {selectedNode.practice.map((item, idx) => (
                     <a
-                      key={idx}
+                      key={`practice-${selectedNode.id}-${item.url}`}
                       href={item.url}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
## Description
Inside the detail presentation drawer layout within `RoadmapsPage.jsx`, iteration listings for conceptual focus points, video materials, and coding practice URLs fall back to positional indices (`key={idx}`). When developers switch domains or change node selections, old structural properties or card interactions cache incorrectly.

Changes made:
- Updated key profiles for concepts mapping layers to leverage unique literal tokens (`key={\`concept-\${selectedNode.id}-\${concept}\`}`).
- Reconfigured resource links maps to decouple tracking elements via distinct addresses (`key={\`tutorial-\${selectedNode.id}-\${tutorial.url}\`}` and `key={\`practice-\${selectedNode.id}-\${item.url}\`}`).
- Zero TypeScript errors introduced.

Fixes #2431

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings