### PR TITLE
fix: implement cleanup for mock resume analysis timeout ticker

### DIFF
--- a/website/src/pages/resume/ResumeAnalyzerPage.jsx
+++ b/website/src/pages/resume/ResumeAnalyzerPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ResumeUploader from '../../components/ResumeAnalyzer/ResumeUploader';
 import SkillGapChart from '../../components/ResumeAnalyzer/SkillGapChart';
 import CareerRecommendationCard from '../../components/ResumeAnalyzer/CareerRecommendationCard';
@@ -55,12 +55,20 @@ export default function ResumeAnalyzerPage({ onBack }) {
   const [step, setStep] = useState('upload');
   const [result, setResult] = useState(null);
 
-  const handleUpload = () => {
-    setStep('analyzing');
-    setTimeout(() => {
+  // Track timer across unmount scopes
+  useEffect(() => {
+    if (step !== 'analyzing') return;
+
+    const timer = setTimeout(() => {
       setResult(MOCK_RESULT);
       setStep('result');
     }, 2500);
+
+    return () => clearTimeout(timer);
+  }, [step]);
+
+  const handleUpload = () => {
+    setStep('analyzing');
   };
 
   return (


### PR DESCRIPTION
## Description
The submission simulator inside `ResumeAnalyzerPage.jsx` executed an unmanaged raw async timeout macro to represent AI text slicing loops. When an analyst hits back or jumps contexts while execution is pending, an unmount error occurs because state setters trigger on nonexistent layout targets.

Changes made:
- Migrated asynchronous loading triggers under controlled `useEffect` hooks.
- Configured native cleanup pipelines via active `clearTimeout` allocations.
- Zero TypeScript errors introduced.

Fixes #2423

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings