### PR TITLE
security: secure calendar dynamic window link from tabnapping exposure

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -538,7 +538,7 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
   const handleCalendarDownload = () => {
     const base = getApiBase();
     const url = `${base}/api/content/events/${event.id}/calendar`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   const color = activityColor || '#a855f7';


### PR DESCRIPTION
## Description
The calendar file download controller in `EventDetailPage.jsx` instantiated a target anchor redirection macro (`window.open(url, '_blank')`) omitting isolation metadata. This lets downstream frames hijack parent execution parameters via reverse window context tracking.

Changes made:
- Added explicit `'noopener,noreferrer'` string tokens to the active `window.open` configuration block.
- Confirmed baseline navigation safety patterns match workspace standards.
- Zero TypeScript errors introduced.

Fixes #2429

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings