### PR TITLE
fix: prevent memory leaks by managing live stream toast timers

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -232,10 +232,22 @@ function LiveStreamPage() {
   const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('chat');
   const [toast, setToast] = useState(null);
+  const toastTimerRef = React.useRef(null);
+
+  // Clear running timers when the stream layout unmounts
+  React.useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
+    };
+  }, []);
 
   const showToast = useCallback((message, type) => {
+    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
     setToast({ message, type });
-    setTimeout(() => setToast(null), 4000);
+    toastTimerRef.current = setTimeout(() => {
+      setToast(null);
+      toastTimerRef.current = null;
+    }, 4000);
   }, []);
 
   const fetchStream = useCallback(async () => {


### PR DESCRIPTION
## Description
The notification system inside `LiveStreamPage.jsx` executed a generic unmanaged `setTimeout` callback that remained active when navigating out of the stream view, triggering React state updates on unmounted fibers.

Changes made:
- Integrated a component-level tracker reference (`toastTimerRef`) to manage the macro's execution life cycle.
- Preemptively clean up active animations/timers prior to issuing new toast states and during layout unmounts.
- Zero TypeScript errors introduced.

Fixes #2424

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings