### PR TITLE
fix: cancel copy timeout state reset on modal popup unmount

### DIFF
--- a/website/src/pages/team/TeamMemberModal.jsx
+++ b/website/src/pages/team/TeamMemberModal.jsx
@@ -5,13 +5,18 @@ import { createPortal } from 'react-dom';
 function CopyPopup({ value, onClose }) {
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef(null);
+  const copiedTimeoutRef = useRef(null);
 
   const handleCopy = () => {
     navigator.clipboard
       .writeText(value)
       .then(() => {
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+        copiedTimeoutRef.current = setTimeout(() => {
+          setCopied(false);
+          copiedTimeoutRef.current = null;
+        }, 2000);
       })
       .catch(() => {});
   };
@@ -27,6 +32,9 @@ function CopyPopup({ value, onClose }) {
     return () => {
       if (timeoutRef.current) {
         clearTimeout(timeoutRef.current);
+      }
+      if (copiedTimeoutRef.current) {
+        clearTimeout(copiedTimeoutRef.current);
       }
       document.removeEventListener('click', handler);
     };


### PR DESCRIPTION
## Description
Inside the contextual `CopyPopup` component rendered by `TeamMemberModal.jsx`, an unmanaged macro timer schedules a clipboard feedback transition reset (`setCopied(false)`). When a user clicks elsewhere to immediately dismiss the layout container, this async loop remains scheduled, leaking memory operations on unmounted fiber branches.

Changes made:
- Added a dedicated tracking ref instance (`copiedTimeoutRef`) to catch running execution tokens.
- Wrapped active unmount lifecycles to clear lingering handles gracefully using `clearTimeout`.
- Zero TypeScript errors introduced.

Fixes #2427

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings