### PR TITLE
fix: bind and cancel unmanaged member card click timers in TeamPage

### DIFF
--- a/website/src/pages/team/TeamPage.jsx
+++ b/website/src/pages/team/TeamPage.jsx
@@ -34,17 +34,31 @@ function MemberCard({ member, idx, onClick, triggerRef }) {
     c.style.transform = '';
     c.style.animationPlayState = '';
   };
+  const clickTimerRef = useRef(null);
+  const animTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+      if (animTimerRef.current) clearTimeout(animTimerRef.current);
+    };
+  }, []);
+
   const click = () => {
     const c = ref.current;
     if (c) {
       c.style.transform = 'scale(.9)';
-      setTimeout(() => {
-        c.style.transform = '';
+      if (animTimerRef.current) clearTimeout(animTimerRef.current);
+      animTimerRef.current = setTimeout(() => {
+        if (c) c.style.transform = '';
+        animTimerRef.current = null;
       }, 140);
     }
-    setTimeout(() => {
+    if (clickTimerRef.current) clearTimeout(clickTimerRef.current);
+    clickTimerRef.current = setTimeout(() => {
       triggerRef.current = ref.current;
       onClick(member);
+      clickTimerRef.current = null;
     }, 110);
   };
 


### PR DESCRIPTION
## Description
The standalone `MemberCard` mapping defined within `TeamPage.jsx` executed raw, untracked `setTimeout` operations to coordinate click animation frame updates and modal triggers. If a user quickly toggles routes or unmounts the view while an animation tick is active, these timers execute against expired fiber states.

Changes made:
- Leveraged `clickTimerRef` and `animTimerRef` tracking targets inside the card context.
- Added an implicit cleanup tracking phase into a `useEffect` unmount loop to force-abort pending frames.
- Zero TypeScript errors introduced.

Fixes #2425

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings