### PR TITLE
security: remove hardcoded test secret credentials from CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,8 +124,8 @@ jobs:
           NODE_ENV: test
           # Provide stub env vars so server startup helpers don't crash
           ADMIN_USERNAME: test-admin
-          ADMIN_PASSWORD: TestPass123!ABC
-          ADMIN_EVENT_PASSWORD: EventPass123!XYZ
+          ADMIN_PASSWORD: ${{ secrets.CI_ADMIN_PASSWORD || 'ci_test_password_stub' }}
+          ADMIN_EVENT_PASSWORD: ${{ secrets.CI_ADMIN_EVENT_PASSWORD || 'ci_test_event_password_stub' }}
           PORT: 8787
   report:
     name: CI Summary Report


### PR DESCRIPTION
## Description
The automated test configuration definitions inside `.github/workflows/ci.yml` listed hardcoded plain-text passwords (`ADMIN_PASSWORD` / `ADMIN_EVENT_PASSWORD`) to bypass server execution safety checks. While intended as workflow execution stubs, this exposes high-entropy values in the repository tracking tree.

Changes made:
- Removed raw values from the integration workflow file definition.
- Exchanged strings with `${{ secrets.* }}` expressions paired with safe, non-sensitive string tokens for testing public forks.

Fixes #2461

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings