### PR TITLE
fix: add missing ResourcesPage import and axios dependency

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "axios": "^1.7.0",
     "@fullcalendar/core": "^6.1.20",
     "@fullcalendar/daygrid": "^6.1.20",
     "@fullcalendar/interaction": "^6.1.20",

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -43,6 +43,7 @@ import TeamSection from './pages/team/TeamSection';
 import Footer from './shared/Footer';
 import CinematicOpening from './shared/CinematicOpening';
 import Chatbot from './shared/Chatbot';
+import ResourcesPage from './pages/resources/ResourcesPage';
 import {
   AmbientOrbs,
   SectionDivider,


### PR DESCRIPTION
Fixes #2480

- App.jsx: add missing import for ResourcesPage component (route was configured but component not imported, causing ReferenceError on /resources)
- package.json: add axios dependency required by useRecommendations hook