### PR TITLE
feat: add admin 2fa and session management

### DIFF
--- a/admin-dashboard/src/App.jsx
+++ b/admin-dashboard/src/App.jsx
@@ -20,6 +20,7 @@ import { PortfolioManager } from './pages/PortfolioManager';
 import { StreamManager } from './pages/StreamManager';
 import { CircuitBreakerManager } from './pages/CircuitBreakerManager';
 import { SponsorshipsManager } from './pages/SponsorshipsManager';
+import { SecurityCenter } from './pages/SecurityCenter';
 import './styles/admin.css';
 
 function RequireAuth() {
@@ -76,6 +77,7 @@ export default function App() {
             <Route path="/dashboard/streams" element={<StreamManager />} />
             <Route path="/dashboard/circuit-breaker" element={<CircuitBreakerManager />} />
             <Route path="/dashboard/sponsorships" element={<SponsorshipsManager />} />
+            <Route path="/dashboard/security" element={<SecurityCenter />} />
           </Route>
         </Route>
         <Route path="*" element={<Navigate to="/login" replace />} />

--- a/admin-dashboard/src/components/Sidebar.jsx
+++ b/admin-dashboard/src/components/Sidebar.jsx
@@ -66,6 +66,12 @@ const links = [
     icon: 'Clock',
     requiredScope: 'settings:admin',
   },
+  {
+    to: '/dashboard/security',
+    label: 'Security',
+    icon: 'Globe',
+    requiredScope: 'settings:admin',
+  },
 ];
 
 export function Sidebar() {

--- a/admin-dashboard/src/pages/LoginPage.jsx
+++ b/admin-dashboard/src/pages/LoginPage.jsx
@@ -9,6 +9,8 @@ export function LoginPage() {
   const [showPassword, setShowPassword] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
+  const [twoFactor, setTwoFactor] = useState(null);
+  const [verificationCode, setVerificationCode] = useState('');
   const navigate = useNavigate();
 
   const handleSubmit = async (e) => {
@@ -16,8 +18,31 @@ export function LoginPage() {
     setError('');
     setLoading(true);
     try {
-      await auth.login(email, password);
+      const result = await auth.login(email, password);
+      if (result.requiresTwoFactor || result.requiresTwoFactorSetup) {
+        setTwoFactor(result);
+        setVerificationCode('');
+        return;
+      }
       navigate(adminPath('/dashboard'));
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleTwoFactorSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      if (twoFactor.requiresTwoFactorSetup) {
+        await auth.verifyTwoFactorSetup(twoFactor.setupToken, verificationCode);
+      } else {
+        await auth.verifyTwoFactor(twoFactor.challengeToken, verificationCode);
+      }
+      navigate(adminPath('/dashboard/security'));
     } catch (err) {
       setError(err.message);
     } finally {
@@ -33,86 +58,128 @@ export function LoginPage() {
         </div>
         <h1 className="login-title">NexaSphere Admin</h1>
         <p className="login-sub">GL Bajaj Group of Institutions</p>
-        <form onSubmit={handleSubmit} className="form">
-          <div className="form-row">
-            <label>Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="admin@nexasphere.in"
-              required
-              autoFocus
-            />
-          </div>
-          <div className="form-row">
-            <label>Password</label>
-            <div style={{ position: 'relative' }}>
+        {twoFactor ? (
+          <form onSubmit={handleTwoFactorSubmit} className="form">
+            {twoFactor.requiresTwoFactorSetup && (
+              <div className="two-factor-setup">
+                <img src={twoFactor.qrCodeDataUrl} alt="Authenticator QR code" />
+                <div className="backup-codes" aria-label="Backup codes">
+                  {twoFactor.backupCodes?.map((code) => (
+                    <code key={code}>{code}</code>
+                  ))}
+                </div>
+              </div>
+            )}
+            {twoFactor.suspicious && (
+              <div className="form-error">Additional verification required for this login.</div>
+            )}
+            <div className="form-row">
+              <label>Authenticator code</label>
               <input
-                type={showPassword ? 'text' : 'password'}
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                placeholder="••••••••"
+                type="text"
+                inputMode="numeric"
+                value={verificationCode}
+                onChange={(e) => setVerificationCode(e.target.value)}
+                placeholder="123456"
                 required
-                style={{ width: '100%', paddingRight: '40px' }}
+                autoFocus
               />
-              <button
-                type="button"
-                onClick={() => setShowPassword(!showPassword)}
-                style={{
-                  position: 'absolute',
-                  right: '10px',
-                  top: '50%',
-                  transform: 'translateY(-50%)',
-                  background: 'none',
-                  border: 'none',
-                  color: 'var(--t3)',
-                  cursor: 'pointer',
-                  padding: '4px',
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                }}
-                title={showPassword ? 'Hide password' : 'Show password'}
-                aria-label={showPassword ? 'Hide password' : 'Show password'}
-              >
-                {showPassword ? (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
-                    <line x1="1" y1="1" x2="23" y2="23"></line>
-                  </svg>
-                ) : (
-                  <svg
-                    width="20"
-                    height="20"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
-                    <circle cx="12" cy="12" r="3"></circle>
-                  </svg>
-                )}
-              </button>
             </div>
-          </div>
-          {error && <div className="form-error">{error}</div>}
-          <button type="submit" className="btn-primary full-width" disabled={loading}>
-            {loading ? 'Signing in...' : 'Sign In'}
-          </button>
-        </form>
+            {error && <div className="form-error">{error}</div>}
+            <button type="submit" className="btn-primary full-width" disabled={loading}>
+              {loading ? 'Verifying...' : 'Verify and continue'}
+            </button>
+            <button
+              type="button"
+              className="btn-secondary full-width"
+              onClick={() => setTwoFactor(null)}
+              disabled={loading}
+            >
+              Back
+            </button>
+          </form>
+        ) : (
+          <form onSubmit={handleSubmit} className="form">
+            <div className="form-row">
+              <label>Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="admin@nexasphere.in"
+                required
+                autoFocus
+              />
+            </div>
+            <div className="form-row">
+              <label>Password</label>
+              <div style={{ position: 'relative' }}>
+                <input
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••"
+                  required
+                  style={{ width: '100%', paddingRight: '40px' }}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  style={{
+                    position: 'absolute',
+                    right: '10px',
+                    top: '50%',
+                    transform: 'translateY(-50%)',
+                    background: 'none',
+                    border: 'none',
+                    color: 'var(--t3)',
+                    cursor: 'pointer',
+                    padding: '4px',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}
+                  title={showPassword ? 'Hide password' : 'Show password'}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                >
+                  {showPassword ? (
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19m-6.72-1.07a3 3 0 1 1-4.24-4.24"></path>
+                      <line x1="1" y1="1" x2="23" y2="23"></line>
+                    </svg>
+                  ) : (
+                    <svg
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"></path>
+                      <circle cx="12" cy="12" r="3"></circle>
+                    </svg>
+                  )}
+                </button>
+              </div>
+            </div>
+            {error && <div className="form-error">{error}</div>}
+            <button type="submit" className="btn-primary full-width" disabled={loading}>
+              {loading ? 'Signing in...' : 'Sign In'}
+            </button>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/admin-dashboard/src/pages/SecurityCenter.jsx
+++ b/admin-dashboard/src/pages/SecurityCenter.jsx
@@ -1,0 +1,180 @@
+import { useEffect, useState } from 'react';
+import { adminSecurity } from '../services/auth';
+import { AdminIcon } from '../components/AdminIcon';
+
+function formatDate(value) {
+  if (!value) return 'Unknown';
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  }).format(new Date(value));
+}
+
+export function SecurityCenter() {
+  const [overview, setOverview] = useState({ sessions: [], loginHistory: [] });
+  const [auditLogs, setAuditLogs] = useState([]);
+  const [search, setSearch] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    setError('');
+    setLoading(true);
+    try {
+      const [securityData, auditData] = await Promise.all([
+        adminSecurity.getOverview(),
+        adminSecurity.searchAuditLogs(search),
+      ]);
+      setOverview(securityData);
+      setAuditLogs(auditData.logs || []);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    load();
+  }, []);
+
+  const revoke = async (sessionId) => {
+    await adminSecurity.revokeSession(sessionId);
+    await load();
+  };
+
+  const logoutOthers = async () => {
+    await adminSecurity.logoutOtherSessions();
+    await load();
+  };
+
+  return (
+    <div className="page security-page">
+      <div className="page-header">
+        <div className="header-info">
+          <h1 className="page-title">Security Center</h1>
+          <p className="page-subtitle">
+            Session timeout: {overview.sessionTimeoutMinutes || 30} minutes
+          </p>
+        </div>
+        <button className="btn-secondary" onClick={logoutOthers}>
+          Logout other sessions
+        </button>
+      </div>
+
+      {error && <div className="page-error">{error}</div>}
+
+      <section className="content-card security-section">
+        <div className="security-section-header">
+          <h2>Active sessions</h2>
+        </div>
+        {loading ? (
+          <div className="empty-state">Loading sessions...</div>
+        ) : (
+          <div className="security-list">
+            {overview.sessions.map((session) => (
+              <div className="security-row" key={session.id}>
+                <div className="item-icon">
+                  <AdminIcon name="Globe" />
+                </div>
+                <div className="security-row-main">
+                  <div className="item-name">
+                    {session.metadata?.device || 'Unknown device'}
+                    {session.current && <span className="status-tag success">Current</span>}
+                  </div>
+                  <div className="item-meta">
+                    {session.metadata?.ip || 'Unknown IP'} -{' '}
+                    {session.metadata?.location || 'Unknown location'} - Last active{' '}
+                    {formatDate(session.lastSeenAt)}
+                  </div>
+                </div>
+                <button
+                  className="btn-secondary"
+                  onClick={() => revoke(session.id)}
+                  disabled={session.current}
+                >
+                  Revoke
+                </button>
+              </div>
+            ))}
+            {!overview.sessions.length && <div className="empty-state">No active sessions</div>}
+          </div>
+        )}
+      </section>
+
+      <section className="content-card security-section">
+        <div className="security-section-header">
+          <h2>Login history</h2>
+        </div>
+        <div className="security-list">
+          {overview.loginHistory.map((login) => (
+            <div className="security-row" key={login.id}>
+              <div className="item-icon">
+                <AdminIcon name={login.suspicious ? 'Target' : 'Clock'} />
+              </div>
+              <div className="security-row-main">
+                <div className="item-name">
+                  {login.device}
+                  {login.suspicious && <span className="status-tag info">Suspicious</span>}
+                </div>
+                <div className="item-meta">
+                  {login.ipAddress} - {login.location} - {formatDate(login.createdAt)}
+                </div>
+              </div>
+            </div>
+          ))}
+          {!overview.loginHistory.length && <div className="empty-state">No login history</div>}
+        </div>
+      </section>
+
+      <section className="content-card security-section">
+        <div className="security-section-header">
+          <h2>Audit trail</h2>
+          <div className="security-actions">
+            <input
+              className="search-input"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search audit trail"
+            />
+            <button className="btn-secondary" onClick={load}>
+              Search
+            </button>
+            <a className="btn-secondary" href={adminSecurity.getAuditExportUrl(search)}>
+              Export CSV
+            </a>
+          </div>
+        </div>
+        <div className="overflow-x">
+          <table className="admin-table">
+            <thead>
+              <tr>
+                <th>Time</th>
+                <th>Admin</th>
+                <th>Action</th>
+                <th>IP</th>
+              </tr>
+            </thead>
+            <tbody>
+              {auditLogs.map((log) => (
+                <tr key={log.id}>
+                  <td>{formatDate(log.timestamp)}</td>
+                  <td>{log.adminId}</td>
+                  <td>{log.action}</td>
+                  <td>{log.ipAddress || 'Unknown'}</td>
+                </tr>
+              ))}
+              {!auditLogs.length && (
+                <tr>
+                  <td colSpan="4" className="empty-row">
+                    No audit entries found
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/admin-dashboard/src/services/auth.js
+++ b/admin-dashboard/src/services/auth.js
@@ -25,11 +25,23 @@ export const auth = {
 
     const data = await res.json();
 
+    if (data.requiresTwoFactor || data.requiresTwoFactorSetup) {
+      return data;
+    }
+
     _email = cleanEmail;
     _role = data.role || null;
     _scopes = data.scopes || [];
 
     return data;
+  },
+
+  async verifyTwoFactor(challengeToken, code) {
+    return finishTwoFactorRequest('/api/admin/2fa/verify', { challengeToken, code });
+  },
+
+  async verifyTwoFactorSetup(setupToken, code) {
+    return finishTwoFactorRequest('/api/admin/2fa/setup/verify', { setupToken, code });
   },
 
   async logout() {
@@ -121,5 +133,69 @@ export const auth = {
 
   isOfflineMode() {
     return this.isOffline();
+  },
+};
+
+async function finishTwoFactorRequest(path, body) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+    credentials: 'include',
+  });
+
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.error || err.message || 'Verification failed');
+  }
+
+  const data = await res.json();
+  _email = data.email || data.username || null;
+  _role = data.role || null;
+  _scopes = data.scopes || [];
+  return data;
+}
+
+export const adminSecurity = {
+  async getOverview() {
+    const res = await fetch(`${API_BASE}/api/admin/security`, { credentials: 'include' });
+    if (!res.ok) throw new Error('Unable to load security overview');
+    return res.json();
+  },
+
+  async revokeSession(sessionId) {
+    const res = await fetch(`${API_BASE}/api/admin/security/sessions/${sessionId}`, {
+      method: 'DELETE',
+      credentials: 'include',
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      throw new Error(err.error || 'Unable to revoke session');
+    }
+    return res.json();
+  },
+
+  async logoutOtherSessions() {
+    const res = await fetch(`${API_BASE}/api/admin/security/sessions/logout-others`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!res.ok) throw new Error('Unable to logout other sessions');
+    return res.json();
+  },
+
+  async searchAuditLogs(query = '') {
+    const res = await fetch(
+      `${API_BASE}/api/admin/audit-logs?search=${encodeURIComponent(query)}`,
+      {
+        credentials: 'include',
+      }
+    );
+    if (!res.ok) throw new Error('Unable to load audit trail');
+    return res.json();
+  },
+
+  getAuditExportUrl(query = '') {
+    return `${API_BASE}/api/admin/audit-logs/export?search=${encodeURIComponent(query)}`;
   },
 };

--- a/admin-dashboard/src/styles/admin.css
+++ b/admin-dashboard/src/styles/admin.css
@@ -626,6 +626,11 @@ body {
   color: var(--text);
 }
 
+.btn-secondary.full-width {
+  width: 100%;
+  justify-content: center;
+}
+
 .btn-icon {
   background: transparent;
   border: none;
@@ -713,6 +718,35 @@ body {
   padding: 8px 12px;
   border-radius: var(--radius);
   font-size: 13px;
+}
+
+.two-factor-setup {
+  display: grid;
+  gap: 12px;
+}
+
+.two-factor-setup img {
+  width: 180px;
+  height: 180px;
+  justify-self: center;
+  border-radius: var(--radius);
+  background: white;
+  padding: 8px;
+}
+
+.backup-codes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.backup-codes code {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 6px;
+  text-align: center;
+  font-size: 12px;
 }
 
 .form-actions {
@@ -961,6 +995,70 @@ body {
   border: 1px solid var(--border);
   border-radius: 12px;
   overflow: hidden;
+}
+
+.security-page {
+  max-width: 1100px;
+}
+
+.security-section {
+  margin-bottom: 20px;
+}
+
+.security-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.security-section-header h2 {
+  font-size: 15px;
+}
+
+.security-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.security-list {
+  display: grid;
+}
+
+.security-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+}
+
+.security-row:last-child {
+  border-bottom: 0;
+}
+
+.security-row-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.security-row .item-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+@media (max-width: 768px) {
+  .security-row,
+  .security-section-header,
+  .security-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
 }
 
 .overflow-x {

--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -1,10 +1,31 @@
 import {
   createAdminSession,
+  getAdminSession,
+  listAdminSessions,
   revokeAdminSession,
+  revokeAdminSessionById,
+  revokeOtherAdminSessions,
   startAdminSessionCleanup,
 } from '../repositories/adminSessionsRepository.js';
+import {
+  assessSuspiciousLogin,
+  describeDevice,
+  describeLocation,
+  enableAdminTwoFactor,
+  getOrCreateAdminSecurityAccount,
+  listAdminLoginHistory,
+  recordAdminLoginAttempt,
+  verifyAndConsumeBackupCode,
+} from '../repositories/adminSecurityRepository.js';
+import {
+  buildOtpAuthUrl,
+  generateBackupCodes,
+  generateTotpSecret,
+  verifyTotpCode,
+} from '../utils/adminTotp.js';
 import { getRedisClient } from '../utils/redis.js';
 import crypto from 'crypto';
+import QRCode from 'qrcode';
 import { getScopesForRole } from '../config/rbac.js';
 
 // lgtm[js/weak-cryptographic-algorithm]
@@ -44,6 +65,9 @@ const SESSION_TTL_SECONDS = 8 * 60 * 60; // 8 hours — must match Java TokenSer
 const REDIS_SESSION_PREFIX = 'session:admin:'; // Shared namespace with Java backend
 
 const loginAttemptsByIp = new Map();
+const pendingTwoFactorSetups = new Map();
+const pendingTwoFactorChallenges = new Map();
+const PENDING_2FA_TTL_MS = 10 * 60 * 1000;
 
 // Periodic background cleanup of expired IPs to prevent memory exhaustion
 const cleanupAttemptsTimer = setInterval(() => {
@@ -152,6 +176,39 @@ function clearLoginAttempts(ip) {
   loginAttemptsByIp.delete(ip);
 }
 
+function normalizeUsername(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase();
+}
+
+function getLoginUsername(body = {}) {
+  return normalizeUsername(body.username || body.email);
+}
+
+function createPendingToken(store, payload) {
+  const token = crypto.randomBytes(32).toString('hex');
+  store.set(token, {
+    ...payload,
+    expiresAt: Date.now() + PENDING_2FA_TTL_MS,
+  });
+  return token;
+}
+
+function consumePendingToken(store, token) {
+  const pending = store.get(token);
+  store.delete(token);
+  if (!pending || pending.expiresAt <= Date.now()) return null;
+  return pending;
+}
+
+function prunePendingTokens(store) {
+  const now = Date.now();
+  for (const [token, pending] of store.entries()) {
+    if (pending.expiresAt <= now) store.delete(token);
+  }
+}
+
 /**
  * Compute the SHA-256 hash of a token string.
  * This MUST match the Java TokenService.hashToken() algorithm exactly
@@ -205,24 +262,29 @@ async function requireAdmin(req, res, next) {
     const redisKey = REDIS_SESSION_PREFIX + tokenHash;
 
     const redis = getRedisClient();
-    // lgtm[js/missing-rate-limiting]
-    const sessionJson = await redis.get(redisKey);
-
-    if (!sessionJson) {
-      return res.status(401).json({ error: 'Unauthorized' });
+    let session = null;
+    if (redis) {
+      // lgtm[js/missing-rate-limiting]
+      const sessionJson = await redis.get(redisKey);
+      if (sessionJson) session = JSON.parse(sessionJson);
     }
 
-    const session = JSON.parse(sessionJson);
+    if (!session) {
+      session = await getAdminSession(token);
+      if (!session) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+    }
 
     // Double-check expiry even though Redis TTL should auto-evict
     if (new Date(session.expiresAt) <= new Date()) {
-      await redis.del(redisKey);
+      await redis?.del(redisKey);
       return res.status(401).json({ error: 'Unauthorized' });
     }
 
     req.adminSession = {
       token,
-      username: session.email,
+      username: session.email || session.username,
       metadata: session.metadata || {},
       createdAt: session.createdAt,
       expiresAt: session.expiresAt,
@@ -278,9 +340,13 @@ function requireScope(requiredScope) {
 
 async function login(req, res) {
   try {
-    const u = String(req.body?.username || '').trim();
+    prunePendingTokens(pendingTwoFactorSetups);
+    prunePendingTokens(pendingTwoFactorChallenges);
+
+    const u = getLoginUsername(req.body);
     const p = String(req.body?.password || '');
     const ip = getClientIp(req);
+    const userAgent = req.get('user-agent') || '';
 
     const state = getLoginAttemptState(ip);
     if (state && state.attempts > LOGIN_MAX_ATTEMPTS) {
@@ -293,6 +359,14 @@ async function login(req, res) {
 
     if (!matchedUser) {
       recordLoginAttempt(ip);
+      await recordAdminLoginAttempt({
+        username: u || 'unknown',
+        ipAddress: ip,
+        userAgent,
+        success: false,
+        suspicious: false,
+        reason: 'invalid_credentials',
+      }).catch(() => {});
       return res.status(401).json({ error: 'Invalid credentials' });
     }
 
@@ -300,50 +374,167 @@ async function login(req, res) {
 
     const role = matchedUser.role || 'SuperAdmin';
     const scopes = getScopesForRole(role);
+    const securityAccount = await getOrCreateAdminSecurityAccount(u, matchedUser.email || u);
+    const suspicious = await assessSuspiciousLogin({ username: u, ipAddress: ip, userAgent }).catch(
+      () => ({ suspicious: false, reason: null })
+    );
 
-    // Create session in PostgreSQL (audit trail + persistence)
-    const session = await createAdminSession({
-      username: u,
-      metadata: {
-        userAgent: req.get('user-agent') || '',
-        ip,
+    if (!securityAccount?.two_factor_enabled) {
+      const secret = generateTotpSecret();
+      const backupCodes = generateBackupCodes(8);
+      const otpAuthUrl = buildOtpAuthUrl({ username: u, secret });
+      const qrCodeDataUrl = await QRCode.toDataURL(otpAuthUrl);
+      const setupToken = createPendingToken(pendingTwoFactorSetups, {
+        username: u,
         role,
         scopes,
-      },
-    });
-
-    // Write session to shared Redis for cross-service validation
-    try {
-      const tokenHash = hashToken(session.token);
-      const redisKey = REDIS_SESSION_PREFIX + tokenHash;
-      const redisPayload = JSON.stringify({
-        token: tokenHash,
-        email: u,
-        createdAt: new Date().toISOString(),
-        expiresAt: session.expiresAt,
+        secret,
+        backupCodes,
+        ip,
+        userAgent,
+        suspicious,
       });
-      const redis = getRedisClient();
-      await redis.set(redisKey, redisPayload, 'EX', SESSION_TTL_SECONDS);
-    } catch (redisErr) {
-      // Log but don't fail the login — PostgreSQL session is the fallback
-      console.error('[Admin Login] Failed to write session to Redis:', redisErr);
+
+      return res.status(202).json({
+        requiresTwoFactorSetup: true,
+        setupToken,
+        qrCodeDataUrl,
+        otpAuthUrl,
+        secret,
+        backupCodes,
+        graceEndsAt: securityAccount?.grace_ends_at,
+      });
     }
 
-    res.cookie('ns_admin_token', session.token, {
-      httpOnly: true,
-      secure: process.env.NODE_ENV === 'production',
-      sameSite: 'lax',
-      expires: new Date(session.expiresAt),
-    });
-
-    return res.json({
+    const challengeToken = createPendingToken(pendingTwoFactorChallenges, {
       username: u,
-      expiresAt: session.expiresAt,
       role,
       scopes,
+      secret: securityAccount.totp_secret,
+      ip,
+      userAgent,
+      suspicious,
     });
+
+    return res.status(202).json({
+      requiresTwoFactor: true,
+      challengeToken,
+      suspicious: suspicious.suspicious,
+      reason: suspicious.reason,
+    });
+  } catch (error) {
+    console.error('[Admin Login] Failed before 2FA challenge:', error);
+    return res.status(500).json({ error: 'Unable to create admin session' });
+  }
+}
+
+async function completeAdminLogin({ res, username, role, scopes, ip, userAgent, suspicious }) {
+  // Create session in PostgreSQL (audit trail + persistence)
+  const session = await createAdminSession({
+    username,
+    metadata: {
+      userAgent,
+      ip,
+      location: describeLocation(ip),
+      device: describeDevice(userAgent),
+      role,
+      scopes,
+      twoFactorVerified: true,
+      suspiciousLogin: !!suspicious?.suspicious,
+      suspiciousReason: suspicious?.reason || null,
+    },
+  });
+
+  // Write session to shared Redis for cross-service validation
+  try {
+    const tokenHash = hashToken(session.token);
+    const redisKey = REDIS_SESSION_PREFIX + tokenHash;
+    const redisPayload = JSON.stringify({
+      token: tokenHash,
+      email: username,
+      username,
+      metadata: session.metadata || { userAgent, ip, role, scopes },
+      createdAt: new Date().toISOString(),
+      expiresAt: session.expiresAt,
+    });
+    const redis = getRedisClient();
+    if (redis) await redis.set(redisKey, redisPayload, 'EX', SESSION_TTL_SECONDS);
+  } catch (redisErr) {
+    // Log but don't fail the login — PostgreSQL session is the fallback
+    console.error('[Admin Login] Failed to write session to Redis:', redisErr);
+  }
+
+  res.cookie('ns_admin_token', session.token, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    expires: new Date(session.expiresAt),
+  });
+
+  await recordAdminLoginAttempt({
+    username,
+    ipAddress: ip,
+    userAgent,
+    success: true,
+    suspicious: !!suspicious?.suspicious,
+    reason: suspicious?.reason,
+  }).catch(() => {});
+
+  return res.json({
+    username,
+    email: username,
+    expiresAt: session.expiresAt,
+    role,
+    scopes,
+    suspicious: !!suspicious?.suspicious,
+  });
+}
+
+async function verifyTwoFactor(req, res) {
+  try {
+    const { challengeToken, code } = req.body || {};
+    const pending = consumePendingToken(pendingTwoFactorChallenges, challengeToken);
+    if (!pending) {
+      return res.status(400).json({ error: 'Two-factor challenge expired. Please sign in again.' });
+    }
+
+    const validTotp = verifyTotpCode(pending.secret, code);
+    const validBackup = validTotp
+      ? false
+      : await verifyAndConsumeBackupCode(pending.username, code).catch(() => false);
+
+    if (!validTotp && !validBackup) {
+      return res.status(401).json({ error: 'Invalid verification code' });
+    }
+
+    return completeAdminLogin({ res, ...pending });
   } catch {
     return res.status(500).json({ error: 'Unable to create admin session' });
+  }
+}
+
+async function verifyTwoFactorSetup(req, res) {
+  try {
+    const { setupToken, code } = req.body || {};
+    const pending = consumePendingToken(pendingTwoFactorSetups, setupToken);
+    if (!pending) {
+      return res.status(400).json({ error: 'Two-factor setup expired. Please sign in again.' });
+    }
+
+    if (!verifyTotpCode(pending.secret, code)) {
+      return res.status(401).json({ error: 'Invalid authenticator code' });
+    }
+
+    await enableAdminTwoFactor({
+      username: pending.username,
+      secret: pending.secret,
+      backupCodes: pending.backupCodes,
+    });
+
+    return completeAdminLogin({ res, ...pending });
+  } catch (error) {
+    console.error('[Admin 2FA] Setup verification failed:', error);
+    return res.status(500).json({ error: 'Unable to verify two-factor setup' });
   }
 }
 
@@ -359,7 +550,7 @@ async function logout(req, res) {
         const tokenHash = hashToken(token);
         const redisKey = REDIS_SESSION_PREFIX + tokenHash;
         const redis = getRedisClient();
-        await redis.del(redisKey);
+        await redis?.del(redisKey);
       } catch (redisErr) {
         console.error('[Admin Logout] Failed to delete session from Redis:', redisErr);
       }
@@ -380,9 +571,75 @@ async function logout(req, res) {
   }
 }
 
+async function getSecurityOverview(req, res) {
+  try {
+    const username = req.adminSession.username;
+    const currentSessionId = hashToken(req.adminSession.token).slice(0, 16);
+    const sessions = await listAdminSessions(username);
+    const loginHistory = await listAdminLoginHistory(username, 10);
+
+    return res.json({
+      sessions: sessions.map((session) => ({
+        ...session,
+        current: session.id === currentSessionId,
+      })),
+      loginHistory,
+      sessionTimeoutMinutes: Math.round(
+        (Number(process.env.ADMIN_SESSION_IDLE_TIMEOUT_MS) || 30 * 60 * 1000) / 60000
+      ),
+    });
+  } catch {
+    return res.status(500).json({ error: 'Unable to load security overview' });
+  }
+}
+
+async function revokeSession(req, res) {
+  try {
+    const sessionId = String(req.params.sessionId || '');
+    const currentSessionId = hashToken(req.adminSession.token).slice(0, 16);
+    if (sessionId === currentSessionId) {
+      return res.status(400).json({ error: 'Use logout to end the current session.' });
+    }
+
+    const revokedTokenHash = await revokeAdminSessionById(req.adminSession.username, sessionId);
+    if (revokedTokenHash) {
+      const redis = getRedisClient();
+      await redis?.del(REDIS_SESSION_PREFIX + revokedTokenHash);
+    }
+
+    return res.json({ revoked: !!revokedTokenHash });
+  } catch {
+    return res.status(500).json({ error: 'Unable to revoke session' });
+  }
+}
+
+async function logoutOtherSessions(req, res) {
+  try {
+    const result = await revokeOtherAdminSessions(
+      req.adminSession.username,
+      req.adminSession.token
+    );
+    const redis = getRedisClient();
+    if (redis) {
+      await Promise.all(
+        result.tokenHashes.map((tokenHash) => redis.del(REDIS_SESSION_PREFIX + tokenHash))
+      );
+    }
+
+    return res.json({ revoked: result.count });
+  } catch {
+    return res.status(500).json({ error: 'Unable to logout other sessions' });
+  }
+}
+
 export const adminAuthMiddleware = {
   login,
+  verifyTwoFactor,
+  verifyTwoFactorSetup,
   logout,
+  getSecurityOverview,
+  revokeSession,
+  logoutOtherSessions,
   requireAdmin,
   requireRole,
   requireScope,
@@ -401,4 +658,15 @@ export const adminAuthMiddleware = {
   _safeEqual: safeEqual,
 };
 
-export { login, logout, requireAdmin, requireRole, requireScope };
+export {
+  login,
+  logout,
+  verifyTwoFactor,
+  verifyTwoFactorSetup,
+  getSecurityOverview,
+  revokeSession,
+  logoutOtherSessions,
+  requireAdmin,
+  requireRole,
+  requireScope,
+};

--- a/server/repositories/adminSecurityRepository.js
+++ b/server/repositories/adminSecurityRepository.js
@@ -1,0 +1,273 @@
+import crypto from 'crypto';
+
+import { withDb } from './db.js';
+import { hashSecurityValue } from '../utils/adminTotp.js';
+
+let schemaReady = null;
+
+async function ensureSchema(client) {
+  await client.query(`
+    create table if not exists admin_security_accounts (
+      username text primary key,
+      totp_secret text,
+      backup_code_hashes jsonb not null default '[]'::jsonb,
+      two_factor_enabled boolean not null default false,
+      grace_ends_at timestamptz not null default (now() + interval '30 days'),
+      recovery_email text,
+      ip_whitelist jsonb not null default '[]'::jsonb,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    )
+  `);
+
+  await client.query(`
+    create table if not exists admin_login_history (
+      id uuid primary key,
+      username text not null,
+      ip_address text,
+      location text,
+      user_agent text,
+      device text,
+      suspicious boolean not null default false,
+      reason text,
+      success boolean not null default true,
+      created_at timestamptz not null default now()
+    )
+  `);
+
+  await client.query(
+    'create index if not exists idx_admin_login_history_username_created on admin_login_history (username, created_at desc)'
+  );
+}
+
+async function ensureReady() {
+  if (!schemaReady) {
+    schemaReady = withDb(async (client) => ensureSchema(client)).catch((err) => {
+      schemaReady = null;
+      throw err;
+    });
+  }
+
+  return schemaReady;
+}
+
+function normalizeUsername(username) {
+  return String(username || '')
+    .trim()
+    .toLowerCase();
+}
+
+export function describeDevice(userAgent = '') {
+  const ua = String(userAgent || '');
+  const browser = /edg/i.test(ua)
+    ? 'Edge'
+    : /chrome/i.test(ua)
+      ? 'Chrome'
+      : /firefox/i.test(ua)
+        ? 'Firefox'
+        : /safari/i.test(ua)
+          ? 'Safari'
+          : 'Unknown browser';
+  const os = /windows/i.test(ua)
+    ? 'Windows'
+    : /mac os|macintosh/i.test(ua)
+      ? 'macOS'
+      : /android/i.test(ua)
+        ? 'Android'
+        : /iphone|ipad/i.test(ua)
+          ? 'iOS'
+          : /linux/i.test(ua)
+            ? 'Linux'
+            : 'Unknown OS';
+
+  return `${browser} on ${os}`;
+}
+
+export function describeLocation(ip = '') {
+  const value = String(ip || '').trim();
+  if (!value || value === 'unknown') return 'Unknown location';
+  if (
+    value === '::1' ||
+    value === '127.0.0.1' ||
+    value.startsWith('10.') ||
+    value.startsWith('192.168.') ||
+    /^172\.(1[6-9]|2\d|3[01])\./.test(value)
+  ) {
+    return 'Private network';
+  }
+  return process.env.ADMIN_GEOLOCATION_LABEL || 'External network';
+}
+
+export async function getOrCreateAdminSecurityAccount(username, recoveryEmail) {
+  const normalized = normalizeUsername(username);
+  await ensureReady();
+
+  return withDb(async (client) => {
+    await client.query(
+      `insert into admin_security_accounts (username, recovery_email)
+       values ($1, $2)
+       on conflict (username) do nothing`,
+      [normalized, recoveryEmail || normalized]
+    );
+
+    const { rows } = await client.query(
+      `select username, totp_secret, backup_code_hashes, two_factor_enabled, grace_ends_at,
+              recovery_email, ip_whitelist, created_at, updated_at
+       from admin_security_accounts
+       where username = $1`,
+      [normalized]
+    );
+
+    return rows[0] || null;
+  });
+}
+
+export async function enableAdminTwoFactor({ username, secret, backupCodes }) {
+  const normalized = normalizeUsername(username);
+  const hashes = backupCodes.map((code) => hashSecurityValue(code));
+  await ensureReady();
+
+  await withDb(async (client) => {
+    await client.query(
+      `insert into admin_security_accounts
+         (username, totp_secret, backup_code_hashes, two_factor_enabled, grace_ends_at, updated_at)
+       values ($1, $2, $3, true, now(), now())
+       on conflict (username) do update set
+         totp_secret = excluded.totp_secret,
+         backup_code_hashes = excluded.backup_code_hashes,
+         two_factor_enabled = true,
+         grace_ends_at = now(),
+         updated_at = now()`,
+      [normalized, secret, JSON.stringify(hashes)]
+    );
+  });
+}
+
+export async function verifyAndConsumeBackupCode(username, code) {
+  const normalized = normalizeUsername(username);
+  const codeHash = hashSecurityValue(code);
+  await ensureReady();
+
+  return withDb(async (client) => {
+    const { rows } = await client.query(
+      `select backup_code_hashes from admin_security_accounts
+       where username = $1 and two_factor_enabled = true`,
+      [normalized]
+    );
+    const hashes = rows[0]?.backup_code_hashes || [];
+    if (!hashes.includes(codeHash)) return false;
+
+    const remaining = hashes.filter((hash) => hash !== codeHash);
+    await client.query(
+      `update admin_security_accounts
+       set backup_code_hashes = $2, updated_at = now()
+       where username = $1`,
+      [normalized, JSON.stringify(remaining)]
+    );
+    return true;
+  });
+}
+
+export async function recordAdminLoginAttempt({
+  username,
+  ipAddress,
+  userAgent,
+  success,
+  suspicious,
+  reason,
+}) {
+  const normalized = normalizeUsername(username);
+  await ensureReady();
+
+  const entry = {
+    id: crypto.randomUUID(),
+    username: normalized,
+    ipAddress,
+    userAgent,
+    device: describeDevice(userAgent),
+    location: describeLocation(ipAddress),
+    success: !!success,
+    suspicious: !!suspicious,
+    reason: reason || null,
+  };
+
+  await withDb(async (client) => {
+    await client.query(
+      `insert into admin_login_history
+        (id, username, ip_address, location, user_agent, device, success, suspicious, reason)
+       values ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+      [
+        entry.id,
+        entry.username,
+        entry.ipAddress,
+        entry.location,
+        entry.userAgent,
+        entry.device,
+        entry.success,
+        entry.suspicious,
+        entry.reason,
+      ]
+    );
+  });
+
+  return entry;
+}
+
+export async function assessSuspiciousLogin({ username, ipAddress, userAgent }) {
+  const normalized = normalizeUsername(username);
+  await ensureReady();
+
+  return withDb(async (client) => {
+    const { rows } = await client.query(
+      `select ip_address, device, extract(hour from created_at) as login_hour
+       from admin_login_history
+       where username = $1 and success = true
+       order by created_at desc
+       limit 20`,
+      [normalized]
+    );
+
+    if (!rows.length) {
+      return { suspicious: false, reason: null };
+    }
+
+    const device = describeDevice(userAgent);
+    const hour = new Date().getHours();
+    const knownIp = rows.some((row) => row.ip_address === ipAddress);
+    const knownDevice = rows.some((row) => row.device === device);
+    const knownHour = rows.some((row) => Math.abs(Number(row.login_hour) - hour) <= 3);
+
+    if (!knownIp) return { suspicious: true, reason: 'new_ip' };
+    if (!knownDevice) return { suspicious: true, reason: 'new_device' };
+    if (!knownHour) return { suspicious: true, reason: 'unusual_time' };
+    return { suspicious: false, reason: null };
+  });
+}
+
+export async function listAdminLoginHistory(username, limit = 10) {
+  const normalized = normalizeUsername(username);
+  await ensureReady();
+
+  return withDb(async (client) => {
+    const { rows } = await client.query(
+      `select id, username, ip_address, location, user_agent, device, success, suspicious, reason, created_at
+       from admin_login_history
+       where username = $1
+       order by created_at desc
+       limit $2`,
+      [normalized, Math.min(Math.max(Number(limit) || 10, 1), 50)]
+    );
+    return rows.map((row) => ({
+      id: row.id,
+      username: row.username,
+      ipAddress: row.ip_address,
+      location: row.location,
+      userAgent: row.user_agent,
+      device: row.device,
+      success: row.success,
+      suspicious: row.suspicious,
+      reason: row.reason,
+      createdAt: row.created_at,
+    }));
+  });
+}

--- a/server/repositories/adminSessionsRepository.js
+++ b/server/repositories/adminSessionsRepository.js
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 import { withDb } from './db.js';
 
 const DEFAULT_SESSION_TTL_MS = 8 * 60 * 60 * 1000;
+const DEFAULT_SESSION_IDLE_TIMEOUT_MS = 30 * 60 * 1000;
 const DEFAULT_CLEANUP_INTERVAL_MS = 15 * 60 * 1000;
 const DEFAULT_TOUCH_THROTTLE_MS = 60 * 1000; // 1 minute default
 
@@ -15,6 +16,11 @@ const lastSeenThrottleMap = new Map();
 function getSessionTtlMs() {
   const value = Number(process.env.ADMIN_SESSION_TTL_MS);
   return Number.isFinite(value) && value > 0 ? value : DEFAULT_SESSION_TTL_MS;
+}
+
+function getSessionIdleTimeoutMs() {
+  const value = Number(process.env.ADMIN_SESSION_IDLE_TIMEOUT_MS);
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_SESSION_IDLE_TIMEOUT_MS;
 }
 
 function getCleanupIntervalMs() {
@@ -137,8 +143,9 @@ export async function getAdminSession(token) {
        from admin_sessions
        where token_hash = $1
          and revoked_at is null
-         and expires_at > now()`,
-      [tokenHash]
+         and expires_at > now()
+         and last_seen_at > now() - ($2::text || ' milliseconds')::interval`,
+      [tokenHash, getSessionIdleTimeoutMs()]
     );
 
     if (!rows.length) {
@@ -203,6 +210,77 @@ export async function revokeAdminSession(token) {
       [tokenHash]
     );
     return rowCount > 0;
+  });
+}
+
+export async function listAdminSessions(username) {
+  if (!username) return [];
+  await ensureReady();
+  await triggerLazyCleanup(false);
+
+  return withDb(async (client) => {
+    const { rows } = await client.query(
+      `select token_hash, username, metadata, created_at, last_seen_at, expires_at
+       from admin_sessions
+       where username = $1
+         and revoked_at is null
+         and expires_at > now()
+         and last_seen_at > now() - ($2::text || ' milliseconds')::interval
+       order by last_seen_at desc
+       limit 50`,
+      [username, getSessionIdleTimeoutMs()]
+    );
+
+    return rows.map((row) => ({
+      id: row.token_hash.slice(0, 16),
+      username: row.username,
+      metadata: row.metadata || {},
+      createdAt: row.created_at,
+      lastSeenAt: row.last_seen_at,
+      expiresAt: row.expires_at,
+    }));
+  });
+}
+
+export async function revokeAdminSessionById(username, sessionId) {
+  if (!username || !sessionId) return null;
+  await ensureReady();
+
+  return withDb(async (client) => {
+    const { rows } = await client.query(
+      `update admin_sessions
+       set revoked_at = now()
+       where username = $1
+         and token_hash like $2
+         and revoked_at is null
+       returning token_hash`,
+      [username, `${sessionId}%`]
+    );
+    return rows[0]?.token_hash || null;
+  });
+}
+
+export async function revokeOtherAdminSessions(username, currentToken) {
+  if (!username || !currentToken) return { count: 0, tokenHashes: [] };
+  await ensureReady();
+
+  const currentHash = hashToken(currentToken);
+  lastSeenThrottleMap.clear();
+
+  return withDb(async (client) => {
+    const { rows, rowCount } = await client.query(
+      `update admin_sessions
+       set revoked_at = now()
+       where username = $1
+         and token_hash <> $2
+         and revoked_at is null
+       returning token_hash`,
+      [username, currentHash]
+    );
+    return {
+      count: rowCount,
+      tokenHashes: rows.map((row) => row.token_hash).filter(Boolean),
+    };
   });
 }
 

--- a/server/repositories/auditLogRepository.js
+++ b/server/repositories/auditLogRepository.js
@@ -54,6 +54,74 @@ class AuditLogRepository {
     }
   }
 
+  async searchAuditLogs({ search = '', action = '', adminId = '', limit = 50, offset = 0 } = {}) {
+    await this.init();
+    const filters = [];
+    const params = [];
+
+    if (search) {
+      params.push(`%${search}%`);
+      filters.push(
+        `(action ilike $${params.length} or admin_id ilike $${params.length} or new_state::text ilike $${params.length} or old_state::text ilike $${params.length})`
+      );
+    }
+    if (action) {
+      params.push(`%${action}%`);
+      filters.push(`action ilike $${params.length}`);
+    }
+    if (adminId) {
+      params.push(adminId);
+      filters.push(`admin_id = $${params.length}`);
+    }
+
+    const where = filters.length ? `where ${filters.join(' and ')}` : '';
+    params.push(Math.min(Math.max(Number(limit) || 50, 1), 500));
+    const limitParam = params.length;
+    params.push(Math.max(Number(offset) || 0, 0));
+    const offsetParam = params.length;
+
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `select id, admin_id, action, ip_address, user_agent, old_state, new_state, timestamp
+         from audit_logs
+         ${where}
+         order by timestamp desc
+         limit $${limitParam} offset $${offsetParam}`,
+        params
+      );
+
+      return rows.map((row) => ({
+        id: row.id,
+        adminId: row.admin_id,
+        action: row.action,
+        ipAddress: row.ip_address,
+        userAgent: row.user_agent,
+        oldState: row.old_state,
+        newState: row.new_state,
+        timestamp: row.timestamp,
+      }));
+    });
+  }
+
+  async exportAuditLogsCsv(filters = {}) {
+    const rows = await this.searchAuditLogs({ ...filters, limit: 500 });
+    const header = ['timestamp', 'adminId', 'action', 'ipAddress', 'details'];
+    const escape = (value) => `"${String(value ?? '').replace(/"/g, '""')}"`;
+    const lines = rows.map((row) =>
+      [
+        row.timestamp,
+        row.adminId,
+        row.action,
+        row.ipAddress,
+        JSON.stringify({ oldState: row.oldState, newState: row.newState }),
+      ]
+        .map(escape)
+        .join(',')
+    );
+
+    return [header.join(','), ...lines].join('\n');
+  }
+
   async clearAll_TEST_ONLY() {
     if (process.env.NODE_ENV === 'test') {
       await withDb(async (client) => {

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -22,13 +22,7 @@ import {
   deactivateReadOnlyMode,
   getReadOnlyStatus,
   createIncidentLog,
-} from '../routes/readOnlyMode.js';
-import {
-  activateReadOnlyMode,
-  deactivateReadOnlyMode,
-  getReadOnlyStatus,
-  createIncidentLog,
-} from '../utils/readOnlyMode.js';
+} from './readOnlyMode.js';
 import {
   getServiceStatus,
   getIncidentTimeline,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -16,6 +16,7 @@ import { achievementsRepository } from '../repositories/achievementsRepository.j
 import { portfolioService } from '../services/portfolioService.js';
 import * as sponsorshipsController from '../controllers/sponsorshipsController.js';
 import { achievementSchema } from '../validators/portfolioSchemas.js';
+import { auditLogRepository } from '../repositories/auditLogRepository.js';
 
 const router = Router();
 
@@ -92,7 +93,38 @@ router.delete(
   usersController.adminDeactivateUser
 );
 router.post('/api/admin/login', authRateLimiter, adminAuthMiddleware.login);
+router.post('/api/admin/2fa/verify', authRateLimiter, adminAuthMiddleware.verifyTwoFactor);
+router.post(
+  '/api/admin/2fa/setup/verify',
+  authRateLimiter,
+  adminAuthMiddleware.verifyTwoFactorSetup
+);
 router.post('/api/admin/logout', adminAuthMiddleware.requireAdmin, adminAuthMiddleware.logout);
+router.get(
+  '/api/admin/security',
+  adminAuthMiddleware.requireAdmin,
+  adminAuthMiddleware.getSecurityOverview
+);
+router.delete(
+  '/api/admin/security/sessions/:sessionId',
+  adminAuthMiddleware.requireAdmin,
+  adminAuthMiddleware.revokeSession
+);
+router.post(
+  '/api/admin/security/sessions/logout-others',
+  adminAuthMiddleware.requireAdmin,
+  adminAuthMiddleware.logoutOtherSessions
+);
+router.get('/api/admin/audit-logs', adminAuthMiddleware.requireAdmin, async (req, res) => {
+  const logs = await auditLogRepository.searchAuditLogs(req.query);
+  return res.json({ logs });
+});
+router.get('/api/admin/audit-logs/export', adminAuthMiddleware.requireAdmin, async (req, res) => {
+  const csv = await auditLogRepository.exportAuditLogsCsv(req.query);
+  res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+  res.setHeader('Content-Disposition', 'attachment; filename="admin-audit-logs.csv"');
+  return res.send(csv);
+});
 
 router.get(
   '/api/admin/events',

--- a/server/test/adminSessions.test.js
+++ b/server/test/adminSessions.test.js
@@ -29,6 +29,9 @@ pg.Pool = class MockPool {
           return { rows: mockQueriesResult.select, rowCount: mockQueriesResult.select.length };
         }
         if (sqlLower.includes('update admin_sessions')) {
+          if (sqlLower.includes('returning token_hash')) {
+            return { rows: mockQueriesResult.select, rowCount: mockQueriesResult.select.length };
+          }
           return { rows: [], rowCount: mockQueriesResult.rowCount };
         }
         if (sqlLower.includes('delete from admin_sessions')) {
@@ -178,6 +181,14 @@ test('Revoking a session deletes the throttled entry and updates DB', async () =
   );
   assert.ok(revokeQuery, 'Should execute DB revocation query');
   assert.equal(revokeQuery.params[0], insertQueryParamHash('mock_token'));
+});
+
+test('Revoking a session by id returns the revoked token hash when found', async () => {
+  const { revokeAdminSessionById } = await import('../repositories/adminSessionsRepository.js');
+  mockQueriesResult.select = [{ token_hash: 'abc123' }];
+
+  const result = await revokeAdminSessionById('admin_user', 'abc');
+  assert.equal(result, 'abc123');
 });
 
 test('Periodic cleanup clears the throttled sessions and purges database', async () => {

--- a/server/utils/adminTotp.js
+++ b/server/utils/adminTotp.js
@@ -1,0 +1,104 @@
+import crypto from 'crypto';
+
+const BASE32_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+const DEFAULT_PERIOD_SECONDS = 30;
+const DEFAULT_DIGITS = 6;
+
+function base32Encode(buffer) {
+  let bits = '';
+  let output = '';
+
+  for (const byte of buffer) {
+    bits += byte.toString(2).padStart(8, '0');
+  }
+
+  for (let i = 0; i < bits.length; i += 5) {
+    const chunk = bits.slice(i, i + 5).padEnd(5, '0');
+    output += BASE32_ALPHABET[parseInt(chunk, 2)];
+  }
+
+  return output;
+}
+
+function base32Decode(value) {
+  const clean = String(value || '')
+    .replace(/=+$/g, '')
+    .replace(/\s+/g, '')
+    .toUpperCase();
+  let bits = '';
+
+  for (const char of clean) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index === -1) throw new Error('Invalid base32 secret');
+    bits += index.toString(2).padStart(5, '0');
+  }
+
+  const bytes = [];
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2));
+  }
+
+  return Buffer.from(bytes);
+}
+
+export function generateTotpSecret() {
+  return base32Encode(crypto.randomBytes(20));
+}
+
+export function buildOtpAuthUrl({ issuer = 'NexaSphere Admin', username, secret }) {
+  const label = `${issuer}:${username}`;
+  const params = new URLSearchParams({
+    secret,
+    issuer,
+    algorithm: 'SHA1',
+    digits: String(DEFAULT_DIGITS),
+    period: String(DEFAULT_PERIOD_SECONDS),
+  });
+
+  return `otpauth://totp/${encodeURIComponent(label)}?${params.toString()}`;
+}
+
+export function generateTotpCode(secret, timestamp = Date.now()) {
+  const counter = Math.floor(timestamp / 1000 / DEFAULT_PERIOD_SECONDS);
+  const counterBuffer = Buffer.alloc(8);
+  counterBuffer.writeBigUInt64BE(BigInt(counter));
+
+  const hmac = crypto.createHmac('sha1', base32Decode(secret)).update(counterBuffer).digest();
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const binary =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  return String(binary % 10 ** DEFAULT_DIGITS).padStart(DEFAULT_DIGITS, '0');
+}
+
+export function verifyTotpCode(secret, code, { window = 1, timestamp = Date.now() } = {}) {
+  const cleanCode = String(code || '').replace(/\s+/g, '');
+  if (!/^\d{6}$/.test(cleanCode)) return false;
+
+  for (let step = -window; step <= window; step += 1) {
+    const stepTime = timestamp + step * DEFAULT_PERIOD_SECONDS * 1000;
+    const expected = generateTotpCode(secret, stepTime);
+    if (crypto.timingSafeEqual(Buffer.from(cleanCode), Buffer.from(expected))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function hashSecurityValue(value, salt = process.env.ADMIN_SECURITY_PEPPER || '') {
+  return crypto
+    .createHash('sha256')
+    .update(`${salt}:${String(value)}`)
+    .digest('hex');
+}
+
+export function generateBackupCodes(count = 8) {
+  return Array.from({ length: count }, () => {
+    const raw = crypto.randomBytes(5).toString('hex').toUpperCase();
+    return `${raw.slice(0, 5)}-${raw.slice(5)}`;
+  });
+}


### PR DESCRIPTION
Closes #1803 

## Summary

- Added enforced admin 2FA flow with TOTP setup, QR code generation, verification, and backup codes
- Added admin Security Center UI for active sessions, login history, audit trail search, and CSV export
- Added session management APIs for listing sessions, revoking a session, and logging out other sessions
- Added suspicious login tracking using IP, device, and login-time heuristics
- Enforced 30-minute admin session inactivity timeout and immediate Redis/Postgres session revocation

## Testing

- `node --test test/adminSessions.test.js test/adminAuth.test.js`
- `npm run test:admin -- --run src/__tests__/services/auth.test.js`
- `npm run build:admin`

## Notes

- Real IP geolocation and email security alerts are left as follow-up enhancements.
- Broader server tests currently have an unrelated existing failure in `server/routes/monitoring.js`.