### PR TITLE
Fix PWA service worker build path and missing CSS import (Closes #2480)

### DIFF
--- a/website/src/components/pwa/UpdatePrompt.jsx
+++ b/website/src/components/pwa/UpdatePrompt.jsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import './UpdatePrompt.css';
+import '../../styles/pwa.css';
 
 export default function UpdatePrompt() {
   const [updateSW, setUpdateSW] = useState(null);


### PR DESCRIPTION
## Description
This Pull Request resolves compile-time/bundle-time errors introduced on `main`:
1. **Workbox InjectManifest Error**: The build failed because `swSrc` and `swDest` were configured in `vite.config.js`, causing path resolution errors in Vite. Removing them allows `vite-plugin-pwa` to handle the paths automatically.
2. **Missing CSS Import**: `UpdatePrompt.jsx` attempted to import `./UpdatePrompt.css`, which did not exist. The styling is already globally imported via `pwa.css`.

## Changes Made
- **[vite.config.js](file:///e:/GSSOC/NexaSphere/website/vite.config.js)**: Removed manual `swSrc` and `swDest` properties from the PWA config block.
- **[UpdatePrompt.jsx](file:///e:/GSSOC/NexaSphere/website/src/components/pwa/UpdatePrompt.jsx)**: Removed the unused/broken CSS import.

## Verification & Testing
- Aligned branch with `upstream/main`.
- Executed `npm run build` in the workspace root. The production bundle compiled successfully without any errors.

Closes #2480
