### PR TITLE
fix: replace native alert() with inline error badge in AdvancedCustomizer importTheme

### DIFF
--- a/website/src/components/portfolio/AdvancedCustomizer.jsx
+++ b/website/src/components/portfolio/AdvancedCustomizer.jsx
@@ -39,6 +39,7 @@ const AdvancedCustomizer = ({ currentConfig, onUpdate }) => {
   const [history, setHistory] = useState([currentConfig]);
   const [historyIndex, setHistoryIndex] = useState(0);
   const [contrastStatus, setContrastStatus] = useState({ ok: true, ratio: 4.5 });
+  const [importError, setImportError] = useState(null);
 
   // Mock Contrast Checker (WCAG AA requirement)
   useEffect(() => {
@@ -85,11 +86,17 @@ const AdvancedCustomizer = ({ currentConfig, onUpdate }) => {
       try {
         const config = JSON.parse(event.target.result);
         updateConfig(config);
+        setImportError(null);
       } catch (err) {
-        alert('Invalid Theme JSON');
+        setImportError('Invalid theme file — please upload a valid NexaSphere theme JSON export.');
       }
     };
+    reader.onerror = () => {
+      setImportError('Could not read the selected file. Please try again.');
+    };
     reader.readAsText(file);
+    // Reset the input so re-selecting the same (still-broken) file re-triggers onChange
+    e.target.value = '';
   };
 
   return (
@@ -122,6 +129,12 @@ const AdvancedCustomizer = ({ currentConfig, onUpdate }) => {
             <Upload size={16} /> Import
             <input type="file" hidden onChange={importTheme} accept=".json" />
           </label>
+          {importError && (
+            <div className="a11y-badge a11y-fail" role="alert">
+              <AlertTriangle size={16} />
+              <span>{importError}</span>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
## Description
`AdvancedCustomizer.jsx`'s `importTheme` used a blocking native `alert('Invalid Theme JSON')` on parse failure — inconsistent with the styled `a11y-badge` error pattern already used in the same component for `contrastStatus`.

Changes made:
- Added `importError` state alongside the existing `contrastStatus` state
- Replaced `alert('Invalid Theme JSON')` with `setImportError(...)`, surfaced as a styled `a11y-badge a11y-fail` badge next to the Import button, with `role="alert"` for screen readers
- Cleared `importError` on successful import
- Added a `reader.onerror` handler for unreadable files
- Reset the file input value after reading so re-selecting the same file re-triggers `onChange` if the user fixes and re-uploads it
- Zero new TypeScript errors introduced

Fixes #2518

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings