### PR TITLE
fix: explicitly reset categories to fallbackCategories on forum fetch failure

### DIFF
--- a/website/src/pages/forum/ForumPage.jsx
+++ b/website/src/pages/forum/ForumPage.jsx
@@ -44,6 +44,7 @@ export default function ForumPage({ onBack }) {
         if (threadData?.threads) setThreads(threadData.threads);
       })
       .catch(() => {
+        setCategories(fallbackCategories);
         setThreads(fallbackThreads);
       })
       .finally(() => setLoading(false));


### PR DESCRIPTION
## Description
`ForumPage.jsx` initializes `categories` with `fallbackCategories`, but the `Promise.all().catch()` handler only reset `threads` back to `fallbackThreads` on failure — it never reset `categories`. Since the `useEffect` reruns whenever `sort` or `activeCategory` changes, a re-fetch failure after `categories` had already been populated with live data would leave `categories` stuck on stale data instead of falling back gracefully.

Changes made:
- Added `setCategories(fallbackCategories)` to the `.catch()` block alongside the existing `setThreads(fallbackThreads)`, so both pieces of state fall back together consistently on any fetch failure
- Zero new TypeScript errors introduced

Fixes #2517

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings