### PR TITLE
fix: add error handling to handleJoinSubmit fetch in CollabPage.jsx

### DIFF
--- a/website/src/pages/collab/CollabPage.jsx
+++ b/website/src/pages/collab/CollabPage.jsx
@@ -78,11 +78,21 @@ export default function CollabPage({ onBack }) {
     const requestsUrl = buildUrl(getApiBase(), '/api/collab/requests');
     if (!requestsUrl) return;
 
-    await fetch(requestsUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestData),
-    });
+    try {
+      const res = await fetch(requestsUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestData),
+      });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[CollabPage] Failed to submit join request:', err.message);
+      }
+      alert('Something went wrong submitting your join request. Please try again.');
+    }
   };
 
   const filteredTeams = teams.filter(


### PR DESCRIPTION
## Description
`CollabPage.jsx`'s `handleJoinSubmit` called `await fetch(requestsUrl, ...)` with no try-catch, no `.catch()`, and no `response.ok` check. A failed join request (network error, server error, validation failure) threw an unhandled promise rejection with no feedback to the user — the join modal would behave as if the request succeeded.

Changes made:
- Wrapped the fetch in try-catch
- Added a `response.ok` check that throws on non-2xx status
- On failure, alert the user the request didn't go through, consistent with the existing `alert()` pattern already used for the demo-mode case in the same function
- Errors logged via `import.meta.env.DEV`-guarded `console.error` with a `[CollabPage]` prefix
- Zero new TypeScript errors introduced

Fixes #2516

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings