### PR TITLE
fix(mentorship): enforce access control and student identity validation (#2535)

### DIFF
--- a/server/controllers/forumController.js
+++ b/server/controllers/forumController.js
@@ -45,7 +45,14 @@ export const getThread = wrapAsync(async (req, res) => {
 });
 
 export const createThread = wrapAsync(async (req, res) => {
-  const input = createThreadSchema.parse(req.body);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const input = createThreadSchema.parse({
+    ...req.body,
+    author_name: req.studentUser.name,
+    author_email: req.studentUser.email,
+  });
   const thread = await forumService.createThread(input);
   if (!thread) return res.status(503).json({ error: 'Forum is in offline mode' });
   return res.status(201).json({ thread });
@@ -54,15 +61,38 @@ export const createThread = wrapAsync(async (req, res) => {
 export const updateThread = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid thread ID' });
-  const input = updateThreadSchema.parse(req.body);
-  const thread = await forumService.updateThread(id, input);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const thread = await forumService.getThread(id);
   if (!thread) return res.status(404).json({ error: 'Thread not found' });
-  return res.json({ thread });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (thread.authorEmail !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this thread' });
+  }
+
+  const input = updateThreadSchema.parse(req.body);
+  const updated = await forumService.updateThread(id, input);
+  return res.json({ thread: updated });
 });
 
 export const deleteThread = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid thread ID' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const thread = await forumService.getThread(id);
+  if (!thread) return res.status(404).json({ error: 'Thread not found' });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (thread.authorEmail !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this thread' });
+  }
+
   const deleted = await forumService.deleteThread(id);
   if (!deleted) return res.status(404).json({ error: 'Thread not found' });
   return res.status(204).send();
@@ -78,7 +108,14 @@ export const listReplies = wrapAsync(async (req, res) => {
 export const createReply = wrapAsync(async (req, res) => {
   const threadId = parseInt(req.params.id, 10);
   if (isNaN(threadId)) return res.status(400).json({ error: 'Invalid thread ID' });
-  const input = createReplySchema.parse(req.body);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const input = createReplySchema.parse({
+    ...req.body,
+    author_name: req.studentUser.name,
+    author_email: req.studentUser.email,
+  });
   const reply = await forumService.createReply(threadId, input);
   if (!reply) return res.status(503).json({ error: 'Forum is in offline mode' });
   return res.status(201).json({ reply });
@@ -87,15 +124,38 @@ export const createReply = wrapAsync(async (req, res) => {
 export const updateReply = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.replyId, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid reply ID' });
-  const { content } = updateReplySchema.parse(req.body);
-  const reply = await forumService.updateReply(id, content);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const reply = await forumService.getReply(id);
   if (!reply) return res.status(404).json({ error: 'Reply not found' });
-  return res.json({ reply });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (reply.authorEmail !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this reply' });
+  }
+
+  const { content } = updateReplySchema.parse(req.body);
+  const updated = await forumService.updateReply(id, content);
+  return res.json({ reply: updated });
 });
 
 export const deleteReply = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.replyId, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid reply ID' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const reply = await forumService.getReply(id);
+  if (!reply) return res.status(404).json({ error: 'Reply not found' });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (reply.authorEmail !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this reply' });
+  }
+
   const deleted = await forumService.deleteReply(id);
   if (!deleted) return res.status(404).json({ error: 'Reply not found' });
   return res.status(204).send();
@@ -104,8 +164,11 @@ export const deleteReply = wrapAsync(async (req, res) => {
 export const voteThread = wrapAsync(async (req, res) => {
   const threadId = parseInt(req.params.id, 10);
   if (isNaN(threadId)) return res.status(400).json({ error: 'Invalid thread ID' });
-  const { voter_email, vote_type } = req.body;
-  if (!voter_email) return res.status(400).json({ error: 'voter_email is required' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const voter_email = req.studentUser.email;
+  const { vote_type } = req.body;
   const result = await forumService.voteThread(threadId, voter_email, vote_type || 'upvote');
   return res.json({ result });
 });
@@ -113,8 +176,11 @@ export const voteThread = wrapAsync(async (req, res) => {
 export const voteReply = wrapAsync(async (req, res) => {
   const replyId = parseInt(req.params.replyId, 10);
   if (isNaN(replyId)) return res.status(400).json({ error: 'Invalid reply ID' });
-  const { voter_email, vote_type } = req.body;
-  if (!voter_email) return res.status(400).json({ error: 'voter_email is required' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const voter_email = req.studentUser.email;
+  const { vote_type } = req.body;
   const result = await forumService.voteReply(replyId, voter_email, vote_type || 'upvote');
   return res.json({ result });
 });
@@ -123,6 +189,18 @@ export const acceptReply = wrapAsync(async (req, res) => {
   const threadId = parseInt(req.params.id, 10);
   const replyId = parseInt(req.params.replyId, 10);
   if (isNaN(threadId) || isNaN(replyId)) return res.status(400).json({ error: 'Invalid IDs' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const thread = await forumService.getThread(threadId);
+  if (!thread) return res.status(404).json({ error: 'Thread not found' });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (thread.authorEmail !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this thread' });
+  }
+
   await forumService.acceptReply(threadId, replyId);
   return res.json({ success: true });
 });

--- a/server/controllers/mentorshipController.js
+++ b/server/controllers/mentorshipController.js
@@ -39,7 +39,14 @@ export const getMentor = wrapAsync(async (req, res) => {
 });
 
 export const registerMentor = wrapAsync(async (req, res) => {
-  const input = registerMentorSchema.parse(req.body);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const input = registerMentorSchema.parse({
+    ...req.body,
+    name: req.studentUser.name,
+    email: req.studentUser.email,
+  });
   const mentor = await mentorshipService.registerMentor(input);
   if (!mentor) return res.status(503).json({ error: 'Mentorship system is offline' });
   return res.status(201).json({ mentor });
@@ -48,27 +55,50 @@ export const registerMentor = wrapAsync(async (req, res) => {
 export const updateMentor = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid mentor ID' });
-  const input = updateMentorSchema.parse(req.body);
-  const mentor = await mentorshipService.updateMentor(id, input);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const mentor = await mentorshipService.getMentor(id);
   if (!mentor) return res.status(404).json({ error: 'Mentor not found' });
-  return res.json({ mentor });
+
+  const isAdmin = req.studentUser.role === 'admin';
+  if (mentor.email !== req.studentUser.email && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You do not own this mentor profile' });
+  }
+
+  const input = updateMentorSchema.parse(req.body);
+  const updated = await mentorshipService.updateMentor(id, input);
+  return res.json({ mentor: updated });
 });
 
 export const requestMentorship = wrapAsync(async (req, res) => {
-  const input = requestMentorshipSchema.parse(req.body);
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const input = requestMentorshipSchema.parse({
+    ...req.body,
+    mentee_name: req.studentUser.name,
+    mentee_email: req.studentUser.email,
+  });
   const mentorship = await mentorshipService.requestMentorship(input);
   if (!mentorship) return res.status(503).json({ error: 'Mentorship system is offline' });
   return res.status(201).json({ mentorship });
 });
 
 export const listMentorships = wrapAsync(async (req, res) => {
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
   const { page, limit, status } = req.query;
-  const email = req.query.email || req.user?.email;
+  const isAdmin = req.studentUser.role === 'admin';
+  const email = (isAdmin && req.query.email) ? req.query.email : req.studentUser.email;
+
   const result = await mentorshipService.listMentorships({
     page: Math.max(1, parseInt(page, 10) || 1),
     limit: Math.min(100, Math.max(1, parseInt(limit, 10) || 20)),
     status: status || undefined,
-    email,
+    email: isAdmin && !req.query.email ? undefined : email,
   });
   return res.json({ mentorships: result.rows, total: result.total });
 });
@@ -76,37 +106,105 @@ export const listMentorships = wrapAsync(async (req, res) => {
 export const getMentorship = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid mentorship ID' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
   const mentorship = await mentorshipService.getMentorship(id);
   if (!mentorship) return res.status(404).json({ error: 'Mentorship not found' });
+
+  const mentor = await mentorshipService.getMentor(mentorship.mentorId);
+  const mentorEmail = mentor ? mentor.email : null;
+
+  const isAdmin = req.studentUser.role === 'admin';
+  const isAuthorized = isAdmin || mentorship.menteeEmail === req.studentUser.email || mentorEmail === req.studentUser.email;
+  if (!isAuthorized) {
+    return res.status(403).json({ error: 'Forbidden: You are not authorized to view this mentorship' });
+  }
+
   return res.json({ mentorship });
 });
 
 export const updateMentorshipStatus = wrapAsync(async (req, res) => {
   const id = parseInt(req.params.id, 10);
   if (isNaN(id)) return res.status(400).json({ error: 'Invalid mentorship ID' });
+  if (!req.studentUser && !req.adminSession) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const mentorship = await mentorshipService.getMentorship(id);
+  if (!mentorship) return res.status(404).json({ error: 'Mentorship not found' });
+
   const { status } = req.body;
   if (!['active', 'rejected', 'completed'].includes(status)) {
     return res
       .status(400)
       .json({ error: 'Invalid status. Must be active, rejected, or completed' });
   }
-  const mentorship = await mentorshipService.updateMentorshipStatus(id, status);
-  if (!mentorship) return res.status(404).json({ error: 'Mentorship not found' });
-  return res.json({ mentorship });
+
+  const isAdmin = req.adminSession || req.studentUser?.role === 'admin';
+  const mentor = await mentorshipService.getMentor(mentorship.mentorId);
+  const mentorEmail = mentor ? mentor.email : null;
+
+  const isMentor = req.studentUser && req.studentUser.email === mentorEmail;
+  const isMentee = req.studentUser && req.studentUser.email === mentorship.menteeEmail;
+
+  if (!isAdmin && !isMentor && !isMentee) {
+    return res.status(403).json({ error: 'Forbidden: You are not authorized to update this status' });
+  }
+
+  if (isMentee && !isAdmin && status !== 'completed') {
+    return res.status(403).json({ error: 'Forbidden: Mentees can only mark mentorship as completed' });
+  }
+
+  const updated = await mentorshipService.updateMentorshipStatus(id, status);
+  return res.json({ mentorship: updated });
 });
 
 export const logSession = wrapAsync(async (req, res) => {
   const mentorshipId = parseInt(req.params.id, 10);
   if (isNaN(mentorshipId)) return res.status(400).json({ error: 'Invalid mentorship ID' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const mentorship = await mentorshipService.getMentorship(mentorshipId);
+  if (!mentorship) return res.status(404).json({ error: 'Mentorship not found' });
+
+  const mentor = await mentorshipService.getMentor(mentorship.mentorId);
+  const mentorEmail = mentor ? mentor.email : null;
+
+  const isAdmin = req.studentUser.role === 'admin';
+  const isAuthorized = isAdmin || mentorship.menteeEmail === req.studentUser.email || mentorEmail === req.studentUser.email;
+  if (!isAuthorized) {
+    return res.status(403).json({ error: 'Forbidden: You are not authorized to log sessions for this mentorship' });
+  }
+
   const input = logSessionSchema.parse(req.body);
   const session = await mentorshipService.logSession(mentorshipId, input);
-  if (!session) return res.status(404).json({ error: 'Mentorship not found' });
+  if (!session) return res.status(404).json({ error: 'Failed to log session' });
   return res.status(201).json({ session });
 });
 
 export const listSessions = wrapAsync(async (req, res) => {
   const mentorshipId = parseInt(req.params.id, 10);
   if (isNaN(mentorshipId)) return res.status(400).json({ error: 'Invalid mentorship ID' });
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+
+  const mentorship = await mentorshipService.getMentorship(mentorshipId);
+  if (!mentorship) return res.status(404).json({ error: 'Mentorship not found' });
+
+  const mentor = await mentorshipService.getMentor(mentorship.mentorId);
+  const mentorEmail = mentor ? mentor.email : null;
+
+  const isAdmin = req.studentUser.role === 'admin';
+  const isAuthorized = isAdmin || mentorship.menteeEmail === req.studentUser.email || mentorEmail === req.studentUser.email;
+  if (!isAuthorized) {
+    return res.status(403).json({ error: 'Forbidden: You are not authorized to view sessions for this mentorship' });
+  }
+
   const { page, limit } = req.query;
   const result = await mentorshipService.listSessions(mentorshipId, {
     page: Math.max(1, parseInt(page, 10) || 1),
@@ -116,18 +214,34 @@ export const listSessions = wrapAsync(async (req, res) => {
 });
 
 export const createBuddyPair = wrapAsync(async (req, res) => {
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
   const input = buddyPairSchema.parse(req.body);
+
+  const isAdmin = req.studentUser.role === 'admin';
+  const isSelf = input.buddy1_email === req.studentUser.email || input.buddy2_email === req.studentUser.email;
+  if (!isSelf && !isAdmin) {
+    return res.status(403).json({ error: 'Forbidden: You can only register buddy pairings for yourself' });
+  }
+
   const pair = await mentorshipService.createBuddyPair(input);
   if (!pair) return res.status(503).json({ error: 'Mentorship system is offline' });
   return res.status(201).json({ pair });
 });
 
 export const listBuddyPairs = wrapAsync(async (req, res) => {
-  const { page, limit, email } = req.query;
+  if (!req.studentUser) {
+    return res.status(401).json({ error: 'Authentication required' });
+  }
+  const { page, limit } = req.query;
+  const isAdmin = req.studentUser.role === 'admin';
+  const email = (isAdmin && req.query.email) ? req.query.email : req.studentUser.email;
+
   const result = await mentorshipService.listBuddyPairs({
     page: Math.max(1, parseInt(page, 10) || 1),
     limit: Math.min(100, Math.max(1, parseInt(limit, 10) || 50)),
-    email,
+    email: isAdmin && !req.query.email ? undefined : email,
   });
   return res.json({ pairs: result.rows, total: result.total });
 });

--- a/server/index.js
+++ b/server/index.js
@@ -1572,23 +1572,37 @@ app.patch('/api/admin/forum/threads/:id/moderate', adminAuth, forumController.mo
 app.patch('/api/admin/forum/replies/:replyId/moderate', adminAuth, forumController.moderateReply);
 app.get('/api/admin/forum/threads', adminAuth, forumController.adminListThreads);
 
+function requireMentorshipAuth(req, res, next) {
+  adminAuthMiddleware.requireAdmin(req, res, (err) => {
+    if (!err && req.adminSession) {
+      return next();
+    }
+    requireStudentAuth(req, res, (err2) => {
+      if (!err2 && req.studentUser) {
+        return next();
+      }
+      return res.status(401).json({ error: 'Unauthorized: Authentication required' });
+    });
+  });
+}
+
 // ── Mentorship & Buddy System ──
 app.get('/api/mentorship/mentors', mentorshipController.listMentors);
 app.get('/api/mentorship/mentors/:id', mentorshipController.getMentor);
-app.post('/api/mentorship/mentors', mentorshipController.registerMentor);
-app.put('/api/mentorship/mentors/:id', adminAuth, mentorshipController.updateMentor);
-app.post('/api/mentorship/requests', mentorshipController.requestMentorship);
-app.get('/api/mentorship/requests', mentorshipController.listMentorships);
-app.get('/api/mentorship/requests/:id', mentorshipController.getMentorship);
+app.post('/api/mentorship/mentors', requireStudentAuth, mentorshipController.registerMentor);
+app.put('/api/mentorship/mentors/:id', requireMentorshipAuth, mentorshipController.updateMentor);
+app.post('/api/mentorship/requests', requireStudentAuth, mentorshipController.requestMentorship);
+app.get('/api/mentorship/requests', requireMentorshipAuth, mentorshipController.listMentorships);
+app.get('/api/mentorship/requests/:id', requireMentorshipAuth, mentorshipController.getMentorship);
 app.put(
   '/api/mentorship/requests/:id/status',
-  adminAuth,
+  requireMentorshipAuth,
   mentorshipController.updateMentorshipStatus
 );
-app.post('/api/mentorship/requests/:id/sessions', mentorshipController.logSession);
-app.get('/api/mentorship/requests/:id/sessions', mentorshipController.listSessions);
-app.post('/api/mentorship/buddy-pairs', mentorshipController.createBuddyPair);
-app.get('/api/mentorship/buddy-pairs', mentorshipController.listBuddyPairs);
+app.post('/api/mentorship/requests/:id/sessions', requireStudentAuth, mentorshipController.logSession);
+app.get('/api/mentorship/requests/:id/sessions', requireStudentAuth, mentorshipController.listSessions);
+app.post('/api/mentorship/buddy-pairs', requireStudentAuth, mentorshipController.createBuddyPair);
+app.get('/api/mentorship/buddy-pairs', requireStudentAuth, mentorshipController.listBuddyPairs);
 app.get('/api/admin/mentorships', adminAuth, mentorshipController.adminListAll);
 app.get('/api/admin/mentors', adminAuth, mentorshipController.adminListMentors);
 

--- a/server/repositories/forumRepository.js
+++ b/server/repositories/forumRepository.js
@@ -239,6 +239,16 @@ export const forumRepository = {
     });
   },
 
+  async getReplyById(id) {
+    if (!process.env.DATABASE_URL) {
+      return null;
+    }
+    return withDb(async (client) => {
+      const { rows } = await client.query('select * from forum_replies where id = $1', [id]);
+      return rows.length ? mapReplyRow(rows[0]) : null;
+    });
+  },
+
   async updateReply(id, content) {
     if (!process.env.DATABASE_URL) {
       return null;

--- a/server/services/forumService.js
+++ b/server/services/forumService.js
@@ -33,6 +33,10 @@ export const forumService = {
     return forumRepository.createReply(threadId, input);
   },
 
+  async getReply(id) {
+    return forumRepository.getReplyById(id);
+  },
+
   async updateReply(id, content) {
     return forumRepository.updateReply(id, content);
   },


### PR DESCRIPTION
### Description

Resolves a critical access control vulnerability where mentorship registrations, request lists, logged session histories, and buddy pairings were publicly exposed.

### Changes
- Implemented and registered `requireMentorshipAuth` middleware to support both administrative and student session checks.
- Guarded all write, edit, log, and list routes under `/api/mentorship` in `server/index.js`.
- Hardened `server/controllers/mentorshipController.js` to bind fields to `req.studentUser` to prevent user impersonation, and verify that only match participants (or admins) can access or modify private mentorship matches, logs, and buddy pairings.

Closes #2535
