### PR TITLE
fix: remove hardcoded fallback secrets and enforce env-only secret loading (fixes #1624)

### DIFF
--- a/server/services/secretsManager.js
+++ b/server/services/secretsManager.js
@@ -14,44 +14,19 @@ class SecretsManager {
   loadSecrets() {
     const env = process.env.NODE_ENV || 'development';
 
-    // Default fallback secrets if vault-secrets.json doesn't exist
     if (!fs.existsSync(VAULT_SECRETS_PATH)) {
-      console.warn(
-        `Vault file not found at ${VAULT_SECRETS_PATH}. Initializing with defaults for ${env}...`
-      );
-      const defaultSecrets = {
-        development: {
-          JWT_SECRET: 'nexasphere-jwt-dev-secret-change-in-production',
-          DATABASE_URL: 'postgresql://postgres:postgres@localhost:5432/nexasphere_dev',
-          CORS_ORIGIN: 'http://localhost:5175',
-          MONITORING_API_TOKEN: 'dev-monitoring-token-12345',
-        },
-        production: {
-          JWT_SECRET: 'super-secret-jwt-key-for-prod',
-          DATABASE_URL: 'postgresql://admin:prod-pass@prod-db:5432/nexasphere_prod',
-          CORS_ORIGIN: 'https://nexasphere.example.com',
-          MONITORING_API_TOKEN: 'prod-monitoring-token-98765',
-        },
-      };
-
-      const meta = {};
-      const now = new Date().toISOString();
-      const currentEnvSecrets = defaultSecrets[env] || defaultSecrets.development;
-
-      for (const key of Object.keys(currentEnvSecrets)) {
-        meta[key] = {
-          lastRotated: now,
-          version: 1,
-        };
+      if (env === 'production') {
+        throw new Error(
+          `FATAL: Vault file not found at ${VAULT_SECRETS_PATH}. Production requires a properly configured vault-secrets.json file.`
+        );
       }
-
-      const fileData = {
-        environment: env,
-        secrets: currentEnvSecrets,
-        metadata: meta,
-      };
-
-      fs.writeFileSync(VAULT_SECRETS_PATH, JSON.stringify(fileData, null, 2));
+      console.warn(
+        `Vault file not found at ${VAULT_SECRETS_PATH}. Secrets will be read from environment variables only.`
+      );
+      this.secrets = {};
+      this.rotationMetadata = {};
+      this.environment = env;
+      return;
     }
 
     try {

--- a/server/services/studentAuthService.js
+++ b/server/services/studentAuthService.js
@@ -5,11 +5,7 @@ import { studentUsersRepository } from '../repositories/studentUsersRepository.j
 function getJwtSecret() {
   const secret = process.env.JWT_SECRET;
   if (!secret) {
-    if (process.env.NODE_ENV === 'production') {
-      throw new Error('FATAL: JWT_SECRET environment variable is not set');
-    }
-    console.warn('WARNING: Using insecure default JWT_SECRET for development. Set JWT_SECRET in production.');
-    return 'nexasphere-jwt-dev-secret-change-in-production';
+    throw new Error('FATAL: JWT_SECRET environment variable is not set');
   }
   return secret;
 }


### PR DESCRIPTION
## Description\n\nRemoves hardcoded production/development default secrets from secretsManager.js and removes the dev-only JWT_SECRET fallback from studentAuthService.js.\n\n## Changes\n\n- Remove embedded production credentials from secretsManager.js (JWT_SECRET, DATABASE_URL, CORS_ORIGIN, MONITORING_API_TOKEN)\n- Throw fatal error in production if vault file is missing\n- Fall back to environment variables in development instead of hardcoded strings\n- Remove dev-only JWT_SECRET fallback from studentAuthService.js\n\n## Checklist\n\n- [x] No hardcoded secrets remain in secretsManager.js\n- [x] Production throws error if vault file is missing\n- [x] Dev mode falls back to env vars only\n- [x] JWT_SECRET fallback removed\n\nFixes #1624