### PR TITLE
fix: tighten CSP directives, add CSP report-uri, enable XSS filter (fixes #1620)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -146,8 +146,8 @@ app.use(
     // Hide X-Powered-By
     hidePoweredBy: true,
 
-    // Disable old IE XSS filter
-    xssFilter: false,
+    // Enable XSS filter (legacy IE/Edge protection)
+    xssFilter: true,
 
     // Restrict referrer leakage
     referrerPolicy: {
@@ -169,33 +169,24 @@ app.use(
       useDefaults: false,
 
       directives: {
-        // Default restriction
         defaultSrc: ["'self'"],
 
-        // Prevent inline scripts + third-party execution
         scriptSrc: ["'self'", 'https://challenges.cloudflare.com'],
 
-        // Allow styles from self only
         styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 
-        // Images
         imgSrc: [
           "'self'",
           'data:',
           'blob:',
-          'https:',
           'https://api.dicebear.com',
           'https://images.unsplash.com',
         ],
 
-        // Fonts
-        fontSrc: ["'self'", 'https:', 'data:', 'https://fonts.gstatic.com'],
+        fontSrc: ["'self'", 'https://fonts.gstatic.com', 'data:'],
 
-        // API/WebSocket connections
         connectSrc: [
           "'self'",
-          'https:',
-          'wss:',
           'https://challenges.cloudflare.com',
           'https://*.ingest.sentry.io',
           'https://*.ingest.us.sentry.io',
@@ -203,35 +194,27 @@ app.use(
           `wss://${process.env.DOMAIN || 'localhost'}`,
         ],
 
-        // Block Flash/object/embed
         objectSrc: ["'none'"],
 
-        // Prevent <base> hijacking
         baseUri: ["'self'"],
 
-        // Prevent iframe embedding
         frameAncestors: ["'none'"],
 
-        // Restrict forms
         formAction: ["'self'"],
 
-        // Prevent mixed content
         upgradeInsecureRequests: [],
 
-        // Restrict workers
         workerSrc: ["'self'", 'blob:'],
 
-        // Restrict manifests
         manifestSrc: ["'self'"],
 
-        // Restrict media
         mediaSrc: ["'self'"],
 
-        // Restrict frames
         frameSrc: ["'self'", 'https://challenges.cloudflare.com', 'https://maps.google.com'],
 
-        // Restrict child browsing contexts
         childSrc: ["'none'"],
+
+        reportUri: '/api/v1/csp-violation',
       },
     },
 


### PR DESCRIPTION
## Description\n\nTightens Content Security Policy by removing overly permissive wildcards, adds CSP violation reporting endpoint, and re-enables the legacy XSS filter.\n\n## Changes\n\n- Remove https: and wss: wildcards from connectSrc (use explicit domains)\n- Remove https: wildcard from fontSrc (use explicit gstatic.com)\n- Remove https: wildcard from imgSrc (use explicit domains)\n- Add reportUri for CSP violation reporting\n- Enable XSS filter (was explicitly disabled)\n\n## Checklist\n\n- [x] connectSrc tightened to explicit domains only\n- [x] fontSrc tightened to explicit gstatic.com\n- [x] imgSrc tightened to explicit sources\n- [x] CSP violation reporting configured\n- [x] XSS filter re-enabled\n\nFixes #1620