### PR TITLE
fix: tighten CORS origin validation, reject missing origin requests (fixes #1621)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -269,10 +269,7 @@ app.use(
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin) {
-        return callback(null, true);
-      }
-      if (allowedOrigins.includes(origin)) {
+      if (origin && allowedOrigins.includes(origin)) {
         return callback(null, true);
       }
       if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
## Description\n\nTightens CORS configuration by rejecting requests without an Origin header instead of blindly allowing them.\n\n## Changes\n\n- Remove blanket allow for requests with no Origin header\n- Only allow origins in the configured allowedOrigins whitelist\n- Server-to-server and non-browser clients must send explicit Origin header\n\n## Checklist\n\n- [x] Requests without Origin header are rejected\n- [x] Only whitelisted origins are allowed\n- [x] Backward compatible for all configured origins\n\nFixes #1621