### PR TITLE
fix: tighten CSP directives, add CSP report-uri, enable XSS filter (fixes #1620)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -146,8 +146,8 @@ app.use(
     // Hide X-Powered-By
     hidePoweredBy: true,
 
-    // Disable old IE XSS filter
-    xssFilter: false,
+    // Enable XSS filter (legacy IE/Edge protection)
+    xssFilter: true,
 
     // Restrict referrer leakage
     referrerPolicy: {
@@ -169,33 +169,24 @@ app.use(
       useDefaults: false,
 
       directives: {
-        // Default restriction
         defaultSrc: ["'self'"],
 
-        // Prevent inline scripts + third-party execution
         scriptSrc: ["'self'", 'https://challenges.cloudflare.com'],
 
-        // Allow styles from self only
         styleSrc: ["'self'", "'unsafe-inline'", 'https://fonts.googleapis.com'],
 
-        // Images
         imgSrc: [
           "'self'",
           'data:',
           'blob:',
-          'https:',
           'https://api.dicebear.com',
           'https://images.unsplash.com',
         ],
 
-        // Fonts
-        fontSrc: ["'self'", 'https:', 'data:', 'https://fonts.gstatic.com'],
+        fontSrc: ["'self'", 'https://fonts.gstatic.com', 'data:'],
 
-        // API/WebSocket connections
         connectSrc: [
           "'self'",
-          'https:',
-          'wss:',
           'https://challenges.cloudflare.com',
           'https://*.ingest.sentry.io',
           'https://*.ingest.us.sentry.io',
@@ -203,35 +194,27 @@ app.use(
           `wss://${process.env.DOMAIN || 'localhost'}`,
         ],
 
-        // Block Flash/object/embed
         objectSrc: ["'none'"],
 
-        // Prevent <base> hijacking
         baseUri: ["'self'"],
 
-        // Prevent iframe embedding
         frameAncestors: ["'none'"],
 
-        // Restrict forms
         formAction: ["'self'"],
 
-        // Prevent mixed content
         upgradeInsecureRequests: [],
 
-        // Restrict workers
         workerSrc: ["'self'", 'blob:'],
 
-        // Restrict manifests
         manifestSrc: ["'self'"],
 
-        // Restrict media
         mediaSrc: ["'self'"],
 
-        // Restrict frames
         frameSrc: ["'self'", 'https://challenges.cloudflare.com', 'https://maps.google.com'],
 
-        // Restrict child browsing contexts
         childSrc: ["'none'"],
+
+        reportUri: '/api/v1/csp-violation',
       },
     },
 


### PR DESCRIPTION
## Description

Tightens Content Security Policy by removing overly permissive wildcards, adds CSP violation reporting, and re-enables the legacy XSS filter.

## Changes

- Remove https: and wss: wildcards from connectSrc
- Remove https: wildcard from fontSrc
- Remove https: wildcard from imgSrc
- Add reportUri for CSP violation reporting
- Enable XSS filter

## Checklist

- [x] CSP wildcards removed
- [x] CSP violation reporting configured
- [x] XSS filter re-enabled

Closes #1620
Fixes #1620