### PR TITLE
fix: tighten CORS origin validation, reject missing origin requests (fixes #1621)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -269,10 +269,7 @@ app.use(
 app.use(
   cors({
     origin: (origin, callback) => {
-      if (!origin) {
-        return callback(null, true);
-      }
-      if (allowedOrigins.includes(origin)) {
+      if (origin && allowedOrigins.includes(origin)) {
         return callback(null, true);
       }
       if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
## Description

Tightens CORS configuration by rejecting requests without an Origin header instead of blindly allowing them.

## Changes

- Remove blanket allow for requests with no Origin header
- Only whitelisted origins are allowed

## Checklist

- [x] Missing Origin rejected
- [x] Only whitelisted origins allowed

Closes #1621
Fixes #1621