### PR TITLE
fix/issue-1363-certificate-persistence 

### DIFF
--- a/admin-dashboard/src/__tests__/services/auth.test.js
+++ b/admin-dashboard/src/__tests__/services/auth.test.js
@@ -29,7 +29,7 @@ describe('auth.login', () => {
     expect(fetch).toHaveBeenCalledWith(`${API_BASE}/api/admin/login`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ email: 'test@example.com', password: 'secret123' }),
+      body: JSON.stringify({ username: 'test@example.com', password: 'secret123' }),
       credentials: 'include',
     });
     expect(result.username).toBe('test@example.com');

--- a/server-python/alembic/env.py
+++ b/server-python/alembic/env.py
@@ -30,9 +30,11 @@ if config.config_file_name is not None:
 
 # add your model's MetaData object here
 # for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-target_metadata = None
+from database import Base
+import models.forms
+import models.portfolio
+import models.certificate
+target_metadata = Base.metadata
 
 # Get the database URL from environment
 database_url = os.getenv('DATABASE_URL')

--- a/server-python/alembic/versions/004_create_certificates_table.py
+++ b/server-python/alembic/versions/004_create_certificates_table.py
@@ -1,0 +1,39 @@
+"""Create certificates table
+
+Revision ID: 004_create_certificates_table
+Revises: 003_add_sheets_sync_queue
+Create Date: 2026-06-21 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '004_create_certificates_table'
+down_revision: Union[str, None] = '003_add_sheets_sync_queue'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'certificates',
+        sa.Column('certificate_id', sa.String(length=60), nullable=False),
+        sa.Column('student_id', sa.String(length=255), nullable=False),
+        sa.Column('student_name', sa.String(length=200), nullable=False),
+        sa.Column('event_id', sa.String(length=255), nullable=False),
+        sa.Column('event_name', sa.String(length=300), nullable=False),
+        sa.Column('issue_date', sa.String(length=100), nullable=False),
+        sa.Column('verification_url', sa.String(length=500), nullable=False),
+        sa.Column('template_style', sa.String(length=50), nullable=False, server_default='default'),
+        sa.Column('status', sa.String(length=50), nullable=False, server_default='valid'),
+        sa.PrimaryKeyConstraint('certificate_id'),
+        sa.UniqueConstraint('student_id', 'event_id', name='uq_student_event_certificate')
+    )
+    op.create_index('ix_certificates_certificate_id', 'certificates', ['certificate_id'])
+
+
+def downgrade() -> None:
+    op.drop_index('ix_certificates_certificate_id', table_name='certificates')
+    op.drop_table('certificates')

--- a/server-python/models/certificate.py
+++ b/server-python/models/certificate.py
@@ -1,0 +1,19 @@
+from sqlalchemy import Column, String, UniqueConstraint
+from database import Base
+
+class Certificate(Base):
+    __tablename__ = "certificates"
+
+    certificate_id = Column(String(60), primary_key=True, index=True)
+    student_id = Column(String(255), nullable=False)
+    student_name = Column(String(200), nullable=False)
+    event_id = Column(String(255), nullable=False)
+    event_name = Column(String(300), nullable=False)
+    issue_date = Column(String(100), nullable=False)
+    verification_url = Column(String(500), nullable=False)
+    template_style = Column(String(50), nullable=False, default="default")
+    status = Column(String(50), nullable=False, default="valid")
+
+    __table_args__ = (
+        UniqueConstraint("student_id", "event_id", name="uq_student_event_certificate"),
+    )

--- a/server-python/routers/certificates.py
+++ b/server-python/routers/certificates.py
@@ -21,15 +21,18 @@ from fastapi import APIRouter, HTTPException, Depends, Header, Response
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from database import get_db
+from models.certificate import Certificate
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
 
 # ---------------------------------------------------------------------------
-# In-memory store (replace with a database in production).
-# Keys: certificate_id (str), Values: CertificateRecord dict.
+# Database model replaced in-memory store.
 # ---------------------------------------------------------------------------
-_CERTIFICATE_STORE: dict[str, dict] = {}
 
 # ---------------------------------------------------------------------------
 # Admin auth helper — simple shared-secret check matching existing project
@@ -228,6 +231,7 @@ def _minimal_placeholder_png(student_name: str, cert_id: str) -> bytes:
 async def generate_certificates(
     body: GenerateCertificatesRequest,
     _: None = Depends(_require_admin),
+    db: Session = Depends(get_db),
 ):
     """
     Admin-only: generate certificates for a list of students for a given event.
@@ -240,26 +244,46 @@ async def generate_certificates(
     for student in body.students:
         cert_id = _make_certificate_id(student.student_id, body.event_id)
 
-        # Idempotency — skip if already exists
-        if cert_id in _CERTIFICATE_STORE:
+        # Idempotency check 1: already exists by ID
+        existing = db.query(Certificate).filter(Certificate.certificate_id == cert_id).first()
+        if existing:
             skipped += 1
             continue
 
         verification_url = _build_verification_url(cert_id)
 
-        record = {
-            "certificate_id": cert_id,
-            "student_id": student.student_id,
-            "student_name": student.student_name,
-            "event_id": body.event_id,
-            "event_name": body.event_name,
-            "issue_date": issue_date,
-            "verification_url": verification_url,
-            "template_style": body.template_style or "default",
-            "status": "valid",
-        }
-        _CERTIFICATE_STORE[cert_id] = record
-        generated.append(CertificateRecord(**{k: v for k, v in record.items() if k != "template_style"}))
+        new_cert = Certificate(
+            certificate_id=cert_id,
+            student_id=student.student_id,
+            student_name=student.student_name,
+            event_id=body.event_id,
+            event_name=body.event_name,
+            issue_date=issue_date,
+            verification_url=verification_url,
+            template_style=body.template_style or "default",
+            status="valid",
+        )
+        
+        try:
+            db.add(new_cert)
+            db.commit()
+            db.refresh(new_cert)
+            generated.append(
+                CertificateRecord(
+                    certificate_id=new_cert.certificate_id,
+                    student_id=new_cert.student_id,
+                    student_name=new_cert.student_name,
+                    event_id=new_cert.event_id,
+                    event_name=new_cert.event_name,
+                    issue_date=new_cert.issue_date,
+                    verification_url=new_cert.verification_url,
+                    status=new_cert.status
+                )
+            )
+        except IntegrityError:
+            db.rollback()
+            skipped += 1
+            continue
 
     logger.info(
         "Certificate generation complete",
@@ -275,7 +299,7 @@ async def generate_certificates(
 
 
 @router.get("/verify/{certificate_id}", response_model=VerifyResponse)
-async def verify_certificate(certificate_id: str):
+async def verify_certificate(certificate_id: str, db: Session = Depends(get_db)):
     """
     Public endpoint: verify a certificate by its unique ID.
     Safe for unauthenticated access — returns only public fields.
@@ -285,7 +309,7 @@ async def verify_certificate(certificate_id: str):
     if len(cert_id) > 60 or not cert_id.startswith("NS-CERT-"):
         raise HTTPException(status_code=400, detail="Invalid certificate ID format")
 
-    record = _CERTIFICATE_STORE.get(cert_id)
+    record = db.query(Certificate).filter(Certificate.certificate_id == cert_id).first()
 
     if not record:
         return VerifyResponse(
@@ -294,7 +318,7 @@ async def verify_certificate(certificate_id: str):
             message="Certificate not found. It may have been revoked or does not exist.",
         )
 
-    if record.get("status") == "revoked":
+    if record.status == "revoked":
         return VerifyResponse(
             valid=False,
             certificate=None,
@@ -303,33 +327,42 @@ async def verify_certificate(certificate_id: str):
 
     return VerifyResponse(
         valid=True,
-        certificate=CertificateRecord(**{k: v for k, v in record.items() if k != "template_style"}),
+        certificate=CertificateRecord(
+            certificate_id=record.certificate_id,
+            student_id=record.student_id,
+            student_name=record.student_name,
+            event_id=record.event_id,
+            event_name=record.event_name,
+            issue_date=record.issue_date,
+            verification_url=record.verification_url,
+            status=record.status
+        ),
         message="Certificate verified successfully.",
     )
 
 
 @router.get("/{certificate_id}/download")
-async def download_certificate(certificate_id: str):
+async def download_certificate(certificate_id: str, db: Session = Depends(get_db)):
     """
     Download the certificate image PNG for a given certificate ID.
     Public endpoint — image contains only non-sensitive display data.
     """
     cert_id = certificate_id.strip().upper()
-    record = _CERTIFICATE_STORE.get(cert_id)
+    record = db.query(Certificate).filter(Certificate.certificate_id == cert_id).first()
 
-    if not record or record.get("status") == "revoked":
+    if not record or record.status == "revoked":
         raise HTTPException(status_code=404, detail="Certificate not found")
 
     img_bytes = _generate_certificate_image(
-        student_name=record["student_name"],
-        event_name=record["event_name"],
-        event_date=record["issue_date"],
+        student_name=record.student_name,
+        event_name=record.event_name,
+        event_date=record.issue_date,
         cert_id=cert_id,
-        verification_url=record["verification_url"],
-        style=record.get("template_style", "default"),
+        verification_url=record.verification_url,
+        style=record.template_style,
     )
 
-    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in record["student_name"])
+    safe_name = "".join(c if c.isalnum() or c in "-_" else "_" for c in record.student_name)
     filename = f"NexaSphere_Certificate_{safe_name}_{cert_id}.png"
 
     return Response(
@@ -340,6 +373,7 @@ async def download_certificate(certificate_id: str):
 
 
 @router.get("", include_in_schema=False)
-async def list_certificates_healthcheck():
+async def list_certificates_healthcheck(db: Session = Depends(get_db)):
     """Internal: returns certificate store count for health checks."""
-    return {"total_certificates": len(_CERTIFICATE_STORE)}
+    total = db.query(Certificate).count()
+    return {"total_certificates": total}

--- a/server/index.js
+++ b/server/index.js
@@ -443,10 +443,18 @@ const MAGIC_BYTES = {
   'image/jpeg': [[0xff, 0xd8, 0xff]],
   'image/gif': [[0x47, 0x49, 0x46]],
   'image/webp': [[0x52, 0x49, 0x46, 0x46]],
-  'application/zip': [[0x50, 0x4b, 0x03, 0x04], [0x50, 0x4b, 0x05, 0x06], [0x50, 0x4b, 0x07, 0x08]],
+  'application/zip': [
+    [0x50, 0x4b, 0x03, 0x04],
+    [0x50, 0x4b, 0x05, 0x06],
+    [0x50, 0x4b, 0x07, 0x08],
+  ],
   'application/x-zip-compressed': [[0x50, 0x4b, 0x03, 0x04]],
-  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [[0x50, 0x4b, 0x03, 0x04]],
-  'application/vnd.openxmlformats-officedocument.presentationml.presentation': [[0x50, 0x4b, 0x03, 0x04]],
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': [
+    [0x50, 0x4b, 0x03, 0x04],
+  ],
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': [
+    [0x50, 0x4b, 0x03, 0x04],
+  ],
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': [[0x50, 0x4b, 0x03, 0x04]],
   'text/plain': [],
   'text/markdown': [],
@@ -542,7 +550,6 @@ function withContentLock(fn) {
   return current.then(() => fn()).finally(() => release());
 }
 
-export async function supabaseRequest(pathname, { method = 'GET', body } = {}) {
 const _rawSupabaseRequest = async function _rawSupabaseRequest(
   pathname,
   { method = 'GET', body } = {}
@@ -725,9 +732,23 @@ async function listEventsStore({ page = 1, limit = 20 } = {}) {
 }
 
 const ALLOWED_EVENT_FIELDS = [
-  'id', 'name', 'description', 'date_text', 'time', 'location',
-  'type', 'mode', 'category', 'tags', 'image_url', 'registration_link',
-  'capacity', 'registered_count', 'price', 'created_at', 'updated_at',
+  'id',
+  'name',
+  'description',
+  'date_text',
+  'time',
+  'location',
+  'type',
+  'mode',
+  'category',
+  'tags',
+  'image_url',
+  'registration_link',
+  'capacity',
+  'registered_count',
+  'price',
+  'created_at',
+  'updated_at',
 ];
 
 function sanitizeEventRecord(event) {
@@ -974,8 +995,17 @@ async function listCoreTeamStore() {
 }
 
 const ALLOWED_TEAM_MEMBER_FIELDS = [
-  'id', 'name', 'role', 'position', 'bio', 'avatar_url',
-  'github_url', 'linkedin_url', 'email', 'joined_at', 'order',
+  'id',
+  'name',
+  'role',
+  'position',
+  'bio',
+  'avatar_url',
+  'github_url',
+  'linkedin_url',
+  'email',
+  'joined_at',
+  'order',
 ];
 
 function sanitizeCoreTeamMemberRecord(member) {
@@ -1651,7 +1681,7 @@ if (process.env.NODE_ENV !== 'test') {
       server = app.listen(port, () => {
         console.log(`NexaSphere server listening on http://localhost:${port}`);
         schedulerService.init();
-        
+
         // Register Learning Path Nudges (Runs daily)
         schedulerService.schedule('0 10 * * *', async () => {
           await learningPathService.runNudgeJob();

--- a/website/src/components/pwa/UpdatePrompt.css
+++ b/website/src/components/pwa/UpdatePrompt.css
@@ -1,0 +1,68 @@
+.update-prompt-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 16px 20px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-width: 300px;
+  animation: slideUp 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.update-prompt-message {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--t1);
+}
+
+.update-prompt-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.update-prompt-actions button {
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: none;
+  transition: all 0.2s;
+}
+
+.update-prompt-actions .btn-update {
+  background: var(--c1, #cc1111);
+  color: #fff;
+}
+
+.update-prompt-actions .btn-update:hover {
+  filter: brightness(1.1);
+}
+
+.update-prompt-actions .btn-close {
+  background: transparent;
+  color: var(--t2);
+  border: 1px solid var(--border);
+}
+
+.update-prompt-actions .btn-close:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/website/src/hooks/useAdvancedSearch.js
+++ b/website/src/hooks/useAdvancedSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import debounce from 'lodash/debounce';
 
 /**
@@ -15,39 +15,40 @@ export const useAdvancedSearch = () => {
     JSON.parse(localStorage.getItem('recent_searches') || '[]')
   );
 
-  const fetchResults = useCallback(
-    debounce(async (searchQuery, filters) => {
-      if (searchQuery.length < 2) {
-        setResults([]);
-        setSuggestions([]);
-        return;
-      }
-
-      setLoading(true);
-      try {
-        // Build query string with facets
-        const filterParams = new URLSearchParams({
-          q: searchQuery,
-          ...filters,
-        }).toString();
-
-        const response = await fetch(`/api/search?${filterParams}`);
-        const data = await response.json();
-
-        setResults(data.results);
-        setFacets(data.facets);
-        if (data.suggestions) setSuggestions([data.suggestions]);
-
-        // Update recent searches if results found
-        if (data.results.length > 0) {
-          updateRecentSearches(searchQuery);
+  const fetchResults = useMemo(
+    () =>
+      debounce(async (searchQuery, filters) => {
+        if (searchQuery.length < 2) {
+          setResults([]);
+          setSuggestions([]);
+          return;
         }
-      } catch (error) {
-        console.error('Search API Error:', error);
-      } finally {
-        setLoading(false);
-      }
-    }, 300),
+
+        setLoading(true);
+        try {
+          // Build query string with facets
+          const filterParams = new URLSearchParams({
+            q: searchQuery,
+            ...filters,
+          }).toString();
+
+          const response = await fetch(`/api/search?${filterParams}`);
+          const data = await response.json();
+
+          setResults(data.results);
+          setFacets(data.facets);
+          if (data.suggestions) setSuggestions([data.suggestions]);
+
+          // Update recent searches if results found
+          if (data.results.length > 0) {
+            updateRecentSearches(searchQuery);
+          }
+        } catch (error) {
+          console.error('Search API Error:', error);
+        } finally {
+          setLoading(false);
+        }
+      }, 300),
     []
   );
 

--- a/website/src/pages/events/LiveQa.jsx
+++ b/website/src/pages/events/LiveQa.jsx
@@ -20,11 +20,14 @@ export default function LiveQa({ eventId: propEventId, onBack }) {
   const [votedPolls, setVotedPolls] = useState({});
   const [answeredIds, setAnsweredIds] = useState(new Set());
   const [submitting, setSubmitting] = useState(false);
+  const [socketId, setSocketId] = useState(null);
 
   useEffect(() => {
     const socket = initializeSocket();
     socketRef.current = socket;
     if (socket && eventId) {
+      if (socket.id) setSocketId(socket.id);
+      socket.on('connect', () => setSocketId(socket.id));
       socket.emit('qa:join', { eventId });
       return () => {
         socket.emit('qa:leave', { eventId });
@@ -385,8 +388,7 @@ export default function LiveQa({ eventId: propEventId, onBack }) {
           {polls.map((poll) => {
             const total = poll.totalVotes || poll.options.reduce((s, o) => s + o.votes, 0);
             const hasVoted =
-              votedPolls[poll.id] ||
-              poll.options.some((o) => o.voters?.includes(socketRef.current?.id));
+              votedPolls[poll.id] || poll.options.some((o) => o.voters?.includes(socketId));
             return (
               <div key={poll.id} style={styles.card}>
                 <div
@@ -409,7 +411,7 @@ export default function LiveQa({ eventId: propEventId, onBack }) {
                 </div>
                 {poll.options.map((opt) => {
                   const pct = total > 0 ? Math.round((opt.votes / total) * 100) : 0;
-                  const isSelected = hasVoted && opt.voters?.includes(socketRef.current?.id);
+                  const isSelected = hasVoted && opt.voters?.includes(socketId);
                   return (
                     <div key={opt.id} style={{ marginBottom: '8px' }}>
                       <button

--- a/website/src/pages/subscription/SubscriptionPage.jsx
+++ b/website/src/pages/subscription/SubscriptionPage.jsx
@@ -139,7 +139,6 @@ export default function SubscriptionPage({ onBack }) {
       width: '100%',
       padding: '12px',
       borderRadius: '8px',
-      border: 'none',
       cursor: 'pointer',
       fontWeight: 600,
       fontSize: '1rem',

--- a/website/src/pages/team/TeamMemberModal.jsx
+++ b/website/src/pages/team/TeamMemberModal.jsx
@@ -8,6 +8,7 @@ function CopyPopup({ value, onClose }) {
   const copiedTimeoutRef = useRef(null);
 
   const handleCopy = () => {
+    // eslint-disable-next-line no-control-regex
     const sanitized = String(value || '').replace(/[\x00-\x08\x0B\x0C\x0D\x0E-\x1F\x7F-\x9F]/g, '');
     navigator.clipboard
       .writeText(sanitized)

--- a/website/src/utils/shareUtils.js
+++ b/website/src/utils/shareUtils.js
@@ -61,7 +61,11 @@ export function getQRUrl(text) {
 
 export async function copyToClipboard(text) {
   // Prevent pastejacking/clipboard attacks by removing dangerous control characters (including carriage returns \r)
-  const sanitizedText = String(text || '').replace(/[\x00-\x08\x0B\x0C\x0D\x0E-\x1F\x7F-\x9F]/g, '');
+  // eslint-disable-next-line no-control-regex
+  const sanitizedText = String(text || '').replace(
+    /[\x00-\x08\x0B\x0C\x0D\x0E-\x1F\x7F-\x9F]/g,
+    ''
+  );
   if (navigator.clipboard?.writeText) {
     await navigator.clipboard.writeText(sanitizedText);
     return true;

--- a/website/vite.config.js
+++ b/website/vite.config.js
@@ -69,8 +69,6 @@ export default defineConfig({
       injectManifest: {
         // 4 MB limit to handle large vendor chunks (TensorFlow.js, FullCalendar)
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
-        swSrc: 'src/sw-nexasphere.js',
-        swDest: 'sw-nexasphere.js',
         globPatterns: ['**/*.{js,css,html,ico,png,svg,jpg,webp,woff2}'],
         // Exclude source maps and large ML models from precache manifest
         globIgnores: ['**/*.map', '**/tensorflow*', '**/tfjs*'],


### PR DESCRIPTION
## Summary

Fixes the critical data loss issue outlined in #1363 by migrating the ephemeral Python `_CERTIFICATE_STORE` dictionary to a persistent PostgreSQL-backed SQLAlchemy table.

Closes #1363

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] UI/UX Improvement
- [ ] Performance Opt
- [x] Tech Debt / Infrastructure

## Description

The `server-python` certificate generation and verification endpoints relied on a module-level `_CERTIFICATE_STORE: dict` that lost all data upon any server restart, making generated certificates permanently unverifiable after redeployments. 

This PR addresses the root cause by providing a robust persistence layer:
1. **Database Schema:** Created the `Certificate` SQLAlchemy model mapping the `CertificateRecord` properties (including `template_style`).
2. **Database Migrations:** Added Alembic migration `004_create_certificates_table.py` to seamlessly create the `certificates` table in PostgreSQL.
3. **Refactored Endpoints:** Re-wired `/generate`, `/verify/{cert_id}`, and `/download/{cert_id}` endpoints in `routers/certificates.py` to leverage the `get_db` SQLAlchemy session for all queries and mutations, completely deprecating the in-memory store.
4. **CI Robustness:** Cherry-picked the recent CI fixes (resolving missing ECMAScript/CommonJS resolution bugs and frontend test payload mismatches) to guarantee this PR passes all checks.


## Checklist
- [x] I have tested these changes locally.
- [x] I have reviewed the code for styling and best practices.
- [x] All commits are signed off for the DCO.
