### PR TITLE
feat: add structured JSON API request logging with sensitive data redaction (fixes #1636)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -34,6 +34,7 @@ import bulkRouter from './routes/bulk.js';
 import { validateEnvironment } from './utils/envValidator.js';
 import { performanceMonitor } from './middleware/performanceMonitor.js';
 import { enhancedTracingMiddleware } from './middleware/enhancedTracingMiddleware.js';
+import { apiLogger } from './middleware/apiLogger.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
 import { notificationAnalyticsRepository } from './repositories/notificationAnalyticsRepository.js';
 import { initializeSentry, addSentryErrorHandler } from './utils/sentry.js';
@@ -305,7 +306,9 @@ app.use(enhancedTracingMiddleware);
 app.use(express.json({ limit: '10kb' }));
 app.use(express.urlencoded({ extended: true, limit: '10kb' }));
 app.use(xssSanitizer);
-if (!useStructuredHttpLog) {
+if (useStructuredHttpLog) {
+  app.use(apiLogger);
+} else {
   app.use(morgan('combined'));
 }
 app.use(performanceMonitor);

--- a/server/middleware/apiLogger.js
+++ b/server/middleware/apiLogger.js
@@ -1,0 +1,62 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const LOG_DIR = path.join(__dirname, '..', 'logs');
+const LOG_FILE = path.join(LOG_DIR, 'api-requests.log');
+
+const SENSITIVE_FIELDS = new Set([
+  'password', 'passkey', 'token', 'secret', 'authorization',
+  'cookie', 'session', 'key', 'apiKey', 'apikey', 'accessToken',
+  'refreshToken', 'jwt', 'auth',
+]);
+
+function sanitize(obj) {
+  if (!obj || typeof obj !== 'object') return obj;
+  if (Array.isArray(obj)) return obj.map(sanitize);
+  const sanitized = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (SENSITIVE_FIELDS.has(key)) {
+      sanitized[key] = '[REDACTED]';
+    } else if (typeof value === 'object' && value !== null) {
+      sanitized[key] = sanitize(value);
+    } else {
+      sanitized[key] = value;
+    }
+  }
+  return sanitized;
+}
+
+function ensureLogDir() {
+  if (!fs.existsSync(LOG_DIR)) {
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+  }
+}
+
+const logStream = (() => {
+  ensureLogDir();
+  return fs.createWriteStream(LOG_FILE, { flags: 'a' });
+})();
+
+export function apiLogger(req, res, next) {
+  const start = Date.now();
+
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    const entry = {
+      timestamp: new Date().toISOString(),
+      method: req.method,
+      path: req.originalUrl || req.url,
+      status: res.statusCode,
+      responseTimeMs: duration,
+      ip: req.ip || req.headers['x-forwarded-for'] || req.connection?.remoteAddress,
+      userAgent: req.headers['user-agent'],
+      query: Object.keys(req.query || {}).length ? sanitize(req.query) : undefined,
+    };
+
+    logStream.write(JSON.stringify(entry) + '\n');
+  });
+
+  next();
+}


### PR DESCRIPTION
## Description

Adds structured JSON API request logging with automatic sensitive data redaction. All requests are logged to `server/logs/api-requests.log` for audit trail and debugging.

## Changes

- **New `apiLogger` middleware** (`server/middleware/apiLogger.js`):
  - Logs method, path, status code, response time (ms), timestamp, IP, and user agent
  - Sensitive fields (passwords, tokens, secrets, keys, auth, cookies, sessions) are automatically redacted with `[REDACTED]`
  - Writes logs in newline-delimited JSON format for easy ingestion by Logstash/ELK
  - Auto-creates the `logs/` directory on first use
  - Uses streaming write approach (non-buffered) via `fs.createWriteStream`

- **Updated `server/index.js`**:
  - Replaces standard `morgan('combined')` with structured `apiLogger` when `LOG_FORMAT=json` is set
  - Falls back to `morgan` + existing `requestLogger` for non-structured output

## Checklist

- [x] Logs include method, path, status, response time
- [x] Sensitive data is excluded/redacted
- [x] JSON format for ELK compatibility
- [x] Logs directory auto-created

Closes #1636
Fixes #1636
