### PR TITLE
fix: wrap saveSearch JSON.parse and localStorage.setItem in try-catch in useAdvancedSearch.js

### DIFF
--- a/website/src/hooks/useAdvancedSearch.js
+++ b/website/src/hooks/useAdvancedSearch.js
@@ -75,9 +75,20 @@ export const useAdvancedSearch = () => {
   const clearFilters = () => setActiveFilters({});
 
   const saveSearch = () => {
-    const saved = JSON.parse(localStorage.getItem('saved_searches') || '[]');
+    let saved = [];
+    try {
+      saved = JSON.parse(localStorage.getItem('saved_searches') || '[]');
+      if (!Array.isArray(saved)) saved = [];
+    } catch {
+      // Malformed saved_searches in storage — start fresh instead of crashing
+      saved = [];
+    }
     const newSave = { query, filters: activeFilters, timestamp: Date.now() };
-    localStorage.setItem('saved_searches', JSON.stringify([...saved, newSave]));
+    try {
+      localStorage.setItem('saved_searches', JSON.stringify([...saved, newSave]));
+    } catch {
+      // Ignore QuotaExceededError / SecurityError — save action degrades silently
+    }
   };
 
   return {


### PR DESCRIPTION
## Description
`useAdvancedSearch.js`'s `saveSearch()` called `JSON.parse(localStorage.getItem('saved_searches') || '[]')` with no try-catch. If `saved_searches` contained malformed JSON (corrupted, from a previous app version, or manually tampered), this threw an uncaught `SyntaxError`, crashing the save action entirely.

Changes made:
- Wrapped the `JSON.parse` call in try-catch with a fallback to an empty array on failure
- Added an `Array.isArray` guard in case the parsed value isn't an array
- Wrapped the subsequent `localStorage.setItem` call in try-catch to gracefully handle `QuotaExceededError`/`SecurityError`
- Zero new TypeScript errors introduced

Fixes #2501

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings