### PR TITLE
fix: log fetch errors instead of silently swallowing them in SkillExchangePage.jsx

### DIFF
--- a/website/src/pages/skills/SkillExchangePage.jsx
+++ b/website/src/pages/skills/SkillExchangePage.jsx
@@ -38,7 +38,11 @@ export default function SkillExchangePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setListings(d.listings || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to fetch listings:', err.message);
+        }
+      }
   }, [api]);
 
   const fetchLeaderboard = useCallback(async () => {
@@ -47,7 +51,11 @@ export default function SkillExchangePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setLeaderboard(d.leaderboard || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to fetch leaderboard:', err.message);
+        }
+      }
   }, [api]);
 
   const fetchUserStats = useCallback(async () => {
@@ -57,7 +65,11 @@ export default function SkillExchangePage({ onBack }) {
         const d = await apiClient(url);
         setUserStats(d);
         setSessions(d.sessions || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to fetch user stats:', err.message);
+        }
+      }
   }, [api]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description
`SkillExchangePage.jsx`'s `fetchListings`, `fetchLeaderboard`, and `fetchUserStats` each had bare `try { ... } catch {}` blocks that completely discarded errors. If any of these requests failed, the failure was silently swallowed — no error state, no console output, nothing. This made failures invisible even during development, since there was no diagnostic trail at all.

Changes made:
- Added `import.meta.env.DEV`-guarded `console.error` calls to all three catch blocks, each with a `[SkillExchangePage]` prefix and `err.message` for traceability
- Zero new TypeScript errors introduced

Fixes #2515

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings