### PR TITLE
fix: guard against missing parsed.name in getOrCreateAnonUser in WorkspacePage.tsx

### DIFF
--- a/website/src/pages/workspace/WorkspacePage.tsx
+++ b/website/src/pages/workspace/WorkspacePage.tsx
@@ -19,13 +19,22 @@ function getOrCreateAnonUser() {
     const stored = sessionStorage.getItem(STORAGE_KEY);
     if (stored) {
       const parsed = JSON.parse(stored);
+      // Guard against malformed stored objects (e.g. missing `name` from a
+      // future schema change) so we don't lose the user's existing color/id
+      // and silently regenerate a brand new identity for a recoverable case.
+      const safeName =
+        typeof parsed?.name === 'string' && parsed.name.length > 0
+          ? parsed.name
+          : `User-${Math.floor(Math.random() * 9000) + 1000}`;
       return {
         ...parsed,
-        initials: parsed.name.substring(0, 2).toUpperCase(),
+        name: safeName,
+        initials: safeName.substring(0, 2).toUpperCase(),
       };
     }
   } catch {
-    // sessionStorage unavailable (private browsing) — fall through to create
+    // sessionStorage unavailable (private browsing), or stored value is not
+    // valid JSON — fall through to create
   }
   const id = Math.floor(Math.random() * 9000) + 1000;
   const hue = Math.floor(Math.random() * 360);


### PR DESCRIPTION
## Description
`getOrCreateAnonUser` accessed `parsed.name.substring(0, 2)` with no guard. If a stored anonymous user object was missing the `name` field (malformed storage, future schema change), the resulting `TypeError` was caught by the surrounding try-catch — so it didn't crash the page — but it silently discarded the entire recoverable user object (losing `color`/`id`) and regenerated a brand new identity. The catch comment only mentioned `sessionStorage` being unavailable, not this case.

Changes made:
- Added an explicit `safeName` guard that only falls back to a freshly generated name when `parsed.name` is missing or invalid, while preserving the rest of the parsed user object
- Updated the catch comment to accurately describe both failure modes it now covers
- Note: pre-existing `useEffect` import error at line 64 of this file is unrelated to this change and untouched by this diff

Fixes #2502

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings