### PR TITLE
fix: validate dates before formatting in ForumThreadPage.jsx

### DIFF
--- a/website/src/pages/forum/ForumThreadPage.jsx
+++ b/website/src/pages/forum/ForumThreadPage.jsx
@@ -5,6 +5,16 @@ import { getApiBase } from '../../utils/runtimeConfig';
 import { fallbackThreads, fallbackReplies } from '../../data/forumData.js';
 import { EmptyState } from '../../components/EmptyState';
 
+// Formats a date string, falling back to a safe placeholder if the value
+// is missing or cannot be parsed — avoids rendering literal "Invalid Date"
+// text to users when the API returns a malformed or null timestamp.
+function formatThreadDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
+
 export default function ForumThreadPage({ onBack }) {
   const { id } = useParams();
   const threadIdNum = parseInt(id, 10);
@@ -226,7 +236,7 @@ export default function ForumThreadPage({ onBack }) {
             {thread.title}
           </h1>
           <div style={{ color: 'var(--text-secondary)', fontSize: '0.875rem' }}>
-            Posted by {thread.authorName} · {new Date(thread.createdAt).toLocaleDateString()} ·{' '}
+            Posted by {thread.authorName} · {formatThreadDate(thread.createdAt)} ·{' '}
             {thread.viewCount || 0} views
           </div>
         </div>
@@ -368,7 +378,7 @@ export default function ForumThreadPage({ onBack }) {
                         {reply.authorName}
                       </span>
                       <span style={{ color: 'var(--text-secondary)', fontSize: '0.8rem' }}>
-                        {new Date(reply.createdAt).toLocaleDateString()}
+                        {formatThreadDate(reply.createdAt)}
                       </span>
                       {reply.isAccepted && (
                         <span style={{ fontSize: '0.8rem', color: '#22c55e' }}>


### PR DESCRIPTION
## Description
`thread.createdAt` and `reply.createdAt` were passed directly into `new Date(...).toLocaleDateString()` with no validation. If either field was missing, `null`, or malformed in the API response, the literal text "Invalid Date" rendered next to thread authors and replies.

Changes made:
- Added a shared `formatThreadDate()` helper that checks for a falsy value and validates the parsed date via `Number.isNaN(d.getTime())` before formatting
- Falls back to `"Unknown date"` instead of rendering `"Invalid Date"` when the value can't be parsed
- Replaced both inline `new Date(...).toLocaleDateString()` call sites (thread header, reply list) with the shared helper
- Zero new TypeScript errors introduced

Fixes #2511

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings