### PR TITLE
fix: use Promise.allSettled and AbortController in UserDashboard.tsx

### DIFF
--- a/website/src/pages/dashboard/UserDashboard.tsx
+++ b/website/src/pages/dashboard/UserDashboard.tsx
@@ -156,12 +156,34 @@ export default function UserDashboard() {
       if (!r.ok) throw new Error(`Dashboard API error: ${r.status} ${r.statusText}`);
       return r.json();
     };
-    Promise.all([
-      fetch(`${base}/api/dashboard/profile/${userId}`).then(safeJson),
-      fetch(`${base}/api/dashboard/quests/${userId}`).then(safeJson),
-      fetch(`${base}/api/dashboard/leaderboard`).then(safeJson),
+    const controller = new AbortController();
+    Promise.allSettled([
+      fetch(`${base}/api/dashboard/profile/${userId}`, { signal: controller.signal }).then(
+        safeJson
+      ),
+      fetch(`${base}/api/dashboard/quests/${userId}`, { signal: controller.signal }).then(safeJson),
+      fetch(`${base}/api/dashboard/leaderboard`, { signal: controller.signal }).then(safeJson),
     ])
-      .then(([profile, quests, leaderboard]) => {
+      .then(([profileResult, questsResult, leaderboardResult]) => {
+        // Promise.allSettled means one failed endpoint no longer blanks the
+        // whole dashboard — each result is handled independently, falling
+        // back to mock data only for the piece that actually failed.
+        const profile = profileResult.status === 'fulfilled' ? profileResult.value : null;
+        const quests = questsResult.status === 'fulfilled' ? questsResult.value : null;
+        if (import.meta.env.DEV) {
+          if (profileResult.status === 'rejected') {
+            console.warn('[UserDashboard] Profile fetch failed:', profileResult.reason?.message);
+          }
+          if (questsResult.status === 'rejected') {
+            console.warn('[UserDashboard] Quests fetch failed:', questsResult.reason?.message);
+          }
+          if (leaderboardResult.status === 'rejected') {
+            console.warn(
+              '[UserDashboard] Leaderboard fetch failed:',
+              leaderboardResult.reason?.message
+            );
+          }
+        }
         // isDemo stays true — userId is still hardcoded as 'user_123'
 
         // Map profile → metrics
@@ -217,6 +239,7 @@ export default function UserDashboard() {
         setIsDemo(true);
       })
       .finally(() => setLoading(false));
+    return () => controller.abort();
   }, []);
 
   const weeklyData = [


### PR DESCRIPTION
## Description
Dashboard data fetching used `Promise.all` across three independent fetch calls (profile, quests, leaderboard) with no `AbortController`. Because `Promise.all` rejects as soon as any single promise rejects, a single failed endpoint (e.g. leaderboard) caused successfully-fetched profile and quest data to be discarded entirely, falling back to generic mock data for the whole dashboard.

Changes made:
- Replaced `Promise.all` with `Promise.allSettled` so each fetch result is handled independently — a single endpoint failure no longer blanks data that did successfully load from the other two
- Added an `AbortController`, passing `signal` to all three fetch calls
- Added an effect cleanup that aborts in-flight requests on unmount
- Added `import.meta.env.DEV`-guarded `console.warn` logging per rejected promise for development traceability
- Note: pre-existing TypeScript errors at lines 200 and 209–213 (badge mapping types) are unrelated to this change and untouched by this diff

Fixes #2512

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings