### PR TITLE
fix: clean up pending animationend listeners on unmount in TeamSection.jsx

### DIFF
--- a/website/src/pages/team/TeamSection.jsx
+++ b/website/src/pages/team/TeamSection.jsx
@@ -172,6 +172,20 @@ export default function TeamSection({ onApply }) {
   }, []);
 
   useEffect(() => {
+    // Tracks animationend listeners added dynamically below so they can be
+    // explicitly removed on unmount — { once: true } only cleans up after
+    // the event actually fires, but if the component unmounts mid-animation
+    // the listener is still attached and would mutate a detached DOM node's
+    // style when it eventually fires.
+    const pendingListeners = [];
+    const addRevealListener = (target) => {
+      const handler = () => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      };
+      target.addEventListener('animationend', handler, { once: true });
+      pendingListeners.push({ target, handler });
+    };
     const elements = document.querySelectorAll(
       '#section-team .pop-flip, #section-team .pop-in, #section-team .pop-word'
     );
@@ -180,14 +194,7 @@ export default function TeamSection({ onApply }) {
         entries.forEach((e) => {
           if (e.isIntersecting && !e.target.classList.contains('fired')) {
             e.target.classList.add('fired');
-            e.target.addEventListener(
-              'animationend',
-              () => {
-                e.target.style.opacity = '1';
-                e.target.style.transform = 'none';
-              },
-              { once: true }
-            );
+            addRevealListener(e.target);
             obs.unobserve(e.target);
           }
         });
@@ -200,20 +207,16 @@ export default function TeamSection({ onApply }) {
         const rect = el.getBoundingClientRect();
         if (rect.top < window.innerHeight + 100 && !el.classList.contains('fired')) {
           el.classList.add('fired');
-          el.addEventListener(
-            'animationend',
-            () => {
-              el.style.opacity = '1';
-              el.style.transform = 'none';
-            },
-            { once: true }
-          );
+          addRevealListener(el);
         }
       });
     }, 120);
     return () => {
       obs.disconnect();
       clearTimeout(fallback);
+      pendingListeners.forEach(({ target, handler }) => {
+        target.removeEventListener('animationend', handler);
+      });
     };
   }, []);
 


### PR DESCRIPTION
## Description
`TeamSection.jsx`'s `IntersectionObserver` callback and its `setTimeout` fallback both added `animationend` listeners with `{ once: true }` that were never tracked for removal — the same leak pattern already fixed in `AboutSection.jsx` (#2503). If the component unmounted while an element's CSS animation was still in flight, the listener remained attached and later mutated a detached DOM node's `style` when it eventually fired.

Note: this issue was originally framed as "TeamPage.jsx and TeamSection.jsx duplicate fetches on shared state," but that premise didn't hold — the two components render on mutually exclusive routes (home page vs `/team`) and are never mounted simultaneously, so there's no actual duplicate fetching. While investigating, this real and distinct `animationend` cleanup bug was found in the same file and the issue was repurposed to track it instead.

Changes made:
- Extracted a shared `addRevealListener()` helper used by both the `IntersectionObserver` path and the `setTimeout` fallback path
- Tracks `{ target, handler }` pairs in a `pendingListeners` array
- Cleanup function now removes any still-pending listeners alongside the existing `obs.disconnect()` and `clearTimeout(fallback)`
- The existing fallback `setTimeout` was already correctly cleared — only the `animationend` listeners themselves were leaking
- Zero new TypeScript errors introduced

Fixes #2504

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings