### PR TITLE
feat: add waitlist auto-promotion on cancellation (#1747)

### DIFF
--- a/server/controllers/eventRegistrationController.js
+++ b/server/controllers/eventRegistrationController.js
@@ -186,17 +186,122 @@ export const getFullCalendarFeed = wrapAsync(async (req, res) => {
   const events = await eventsRepository.list({ page: 1, limit: 100 });
   const allEvents = events?.rows || [];
 
-  const calendarContent = allEvents.map(ev => calendarService.generateIcsEvent({
-    name: ev.name,
-    dateText: ev.date_text,
-    description: ev.description,
-    location: ev.location,
-    eventId: ev.id,
-  })).join('\n');
+  const calendarContent = allEvents
+    .map((ev) =>
+      calendarService.generateIcsEvent({
+        name: ev.name,
+        dateText: ev.date_text,
+        description: ev.description,
+        location: ev.location,
+        eventId: ev.id,
+      })
+    )
+    .join('\n');
 
   const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nPRODID:-//NexaSphere//Events//EN\n${calendarContent}\nEND:VCALENDAR`;
 
   res.setHeader('Content-Type', 'text/calendar; charset=utf-8');
   res.setHeader('Content-Disposition', 'attachment; filename="nexasphere-events.ics"');
   return res.send(ics);
+});
+
+export const cancelRegistration = wrapAsync(async (req, res) => {
+  const eventId = String(req.params.eventId || '').trim();
+  const sanitizedEmail = String(req.body.email || '')
+    .trim()
+    .toLowerCase()
+    .slice(0, 140);
+
+  if (!eventId || !EVENT_ID_REGEX.test(eventId)) {
+    return res.status(400).json({ error: 'Invalid event ID' });
+  }
+  if (!sanitizedEmail || !EMAIL_REGEX.test(sanitizedEmail)) {
+    return res.status(400).json({ error: 'Valid email address is required' });
+  }
+
+  const event = await eventsRepository.getById(eventId);
+  if (!event) {
+    return res.status(404).json({ error: 'Event not found' });
+  }
+
+  const cancelled = await registrationsRepository.cancelConfirmedRegistration(
+    eventId,
+    sanitizedEmail
+  );
+  if (!cancelled) {
+    return res.status(404).json({ error: 'No confirmed registration found for this email' });
+  }
+
+  const promoted = await registrationsRepository.promoteFromWaitlist(eventId);
+
+  if (promoted) {
+    try {
+      emitToRole('events_admin', 'admin:waitlist-promoted', {
+        eventId,
+        userName: promoted.full_name,
+        email: promoted.email,
+        timestamp: new Date(),
+      });
+      broadcastSSEEvent('waitlist_promotion', {
+        eventId,
+        email: promoted.email,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (realtimeErr) {
+      console.error('[EventRegistration] Failed to broadcast promotion:', realtimeErr);
+    }
+  }
+
+  return res.status(200).json({
+    cancelled: true,
+    promoted: promoted ? { fullName: promoted.full_name, email: promoted.email } : null,
+  });
+});
+
+export const getWaitlistPosition = wrapAsync(async (req, res) => {
+  const eventId = String(req.params.eventId || '').trim();
+  const email = String(req.query.email || '')
+    .trim()
+    .toLowerCase()
+    .slice(0, 140);
+
+  if (!eventId || !EVENT_ID_REGEX.test(eventId)) {
+    return res.status(400).json({ error: 'Invalid event ID' });
+  }
+  if (!email || !EMAIL_REGEX.test(email)) {
+    return res.status(400).json({ error: 'Valid email address is required' });
+  }
+
+  const [position, totalWaitlisted] = await Promise.all([
+    registrationsRepository.getPosition(eventId, email),
+    registrationsRepository.getWaitlistCount(eventId),
+  ]);
+
+  if (position === null) {
+    return res.status(404).json({ error: 'Not on the waitlist for this event' });
+  }
+
+  return res.status(200).json({ position, totalWaitlisted });
+});
+
+export const leaveWaitlist = wrapAsync(async (req, res) => {
+  const eventId = String(req.params.eventId || '').trim();
+  const sanitizedEmail = String(req.body.email || '')
+    .trim()
+    .toLowerCase()
+    .slice(0, 140);
+
+  if (!eventId || !EVENT_ID_REGEX.test(eventId)) {
+    return res.status(400).json({ error: 'Invalid event ID' });
+  }
+  if (!sanitizedEmail || !EMAIL_REGEX.test(sanitizedEmail)) {
+    return res.status(400).json({ error: 'Valid email address is required' });
+  }
+
+  const removed = await registrationsRepository.removeFromWaitlist(eventId, sanitizedEmail);
+  if (!removed) {
+    return res.status(404).json({ error: 'No waitlist entry found for this email' });
+  }
+
+  return res.status(200).json({ removed: true });
 });

--- a/server/repositories/registrationsRepository.js
+++ b/server/repositories/registrationsRepository.js
@@ -182,4 +182,61 @@ export const registrationsRepository = {
       return rows;
     });
   },
+  async getPosition(eventId, email) {
+    if (!HAS_SUPABASE) return null;
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `SELECT position FROM (
+           SELECT id, ROW_NUMBER() OVER (ORDER BY created_at ASC) AS position
+           FROM event_registrations
+           WHERE event_id = $1 AND waitlist = true AND status = 'waitlisted'
+         ) ranked
+         WHERE id = (
+           SELECT id FROM event_registrations
+           WHERE event_id = $1 AND email = $2 AND waitlist = true AND status = 'waitlisted'
+           LIMIT 1
+         )`,
+        [eventId, email]
+      );
+      return rows[0]?.position ? Number(rows[0].position) : null;
+    });
+  },
+
+  async getWaitlistCount(eventId) {
+    if (!HAS_SUPABASE) return 0;
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `SELECT COUNT(*) AS count FROM event_registrations
+         WHERE event_id = $1 AND waitlist = true AND status = 'waitlisted'`,
+        [eventId]
+      );
+      return Number(rows[0]?.count || 0);
+    });
+  },
+
+  async removeFromWaitlist(eventId, email) {
+    if (!HAS_SUPABASE) return null;
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `UPDATE event_registrations SET status = 'cancelled'
+         WHERE event_id = $1 AND email = $2 AND waitlist = true AND status = 'waitlisted'
+         RETURNING *`,
+        [eventId, email]
+      );
+      return rows[0] || null;
+    });
+  },
+
+  async cancelConfirmedRegistration(eventId, email) {
+    if (!HAS_SUPABASE) return null;
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `UPDATE event_registrations SET status = 'cancelled'
+         WHERE event_id = $1 AND email = $2 AND status = 'confirmed'
+         RETURNING *`,
+        [eventId, email]
+      );
+      return rows[0] || null;
+    });
+  },
 };

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -33,11 +33,33 @@ const router = Router();
 // Public
 router.get('/api/dashboard/leaderboard', gamificationController.getLeaderboard);
 router.post('/api/dashboard/xp', gamificationController.awardXP);
-router.post('/api/assistant/recommend', upload.single('file'), recommendationsController.getProjectRecommendations);
+router.post(
+  '/api/assistant/recommend',
+  upload.single('file'),
+  recommendationsController.getProjectRecommendations
+);
 router.get('/api/users', usersController.getPublicUsers);
 router.get('/api/content/events', eventsController.listEvents);
-router.post('/api/content/events/:eventId/register', eventRegistrationLimiter, eventRegistrationController.registerForEvent);
+router.post(
+  '/api/content/events/:eventId/register',
+  eventRegistrationLimiter,
+  eventRegistrationController.registerForEvent
+);
 router.get('/api/content/events/:eventId/calendar', eventRegistrationController.getEventCalendar);
+router.post(
+  '/api/content/events/:eventId/cancel',
+  eventRegistrationLimiter,
+  eventRegistrationController.cancelRegistration
+);
+router.get(
+  '/api/content/events/:eventId/waitlist-position',
+  eventRegistrationController.getWaitlistPosition
+);
+router.delete(
+  '/api/content/events/:eventId/waitlist',
+  eventRegistrationLimiter,
+  eventRegistrationController.leaveWaitlist
+);
 router.get(
   '/api/content/activity-events/:activityKey',
   activityEventsController.listActivityEvents

--- a/website/src/components/events/WaitlistBadge.css
+++ b/website/src/components/events/WaitlistBadge.css
@@ -1,5 +1,3 @@
-/* website/src/components/events/WaitlistBadge.css */
-
 .waitlist-badge {
   display: flex;
   align-items: center;

--- a/website/src/components/events/WaitlistBadge.css
+++ b/website/src/components/events/WaitlistBadge.css
@@ -1,0 +1,71 @@
+/* website/src/components/events/WaitlistBadge.css */
+
+.waitlist-badge {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  background: rgba(230, 57, 70, 0.08);
+  border: 1px solid rgba(230, 57, 70, 0.3);
+  border-radius: 10px;
+  padding: 0.65rem 0.85rem;
+  margin-top: 0.5rem;
+}
+
+.waitlist-badge--loading {
+  color: #888;
+  font-size: 0.8rem;
+  padding: 0.5rem 0.85rem;
+  background: transparent;
+  border: 1px dashed #333;
+}
+
+.waitlist-badge__info {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.waitlist-badge__icon {
+  font-size: 1.1rem;
+  flex-shrink: 0;
+}
+
+.waitlist-badge__position {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-primary, #fff);
+}
+
+.waitlist-badge__position strong {
+  color: #E63946;
+}
+
+.waitlist-badge__total {
+  margin: 2px 0 0;
+  font-size: 0.75rem;
+  color: #888;
+}
+
+.waitlist-badge__leave-btn {
+  background: transparent;
+  border: 1px solid #E63946;
+  color: #E63946;
+  border-radius: 8px;
+  padding: 0.4rem 0.7rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, color 0.15s;
+}
+
+.waitlist-badge__leave-btn:hover:not(:disabled) {
+  background: #E63946;
+  color: #fff;
+}
+
+.waitlist-badge__leave-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/website/src/components/events/WaitlistBadge.jsx
+++ b/website/src/components/events/WaitlistBadge.jsx
@@ -1,0 +1,111 @@
+// website/src/components/events/WaitlistBadge.jsx
+import { useState, useEffect, useCallback } from 'react';
+import apiClient from '../../utils/apiClient';
+import './WaitlistBadge.css';
+
+function getApiBase() {
+  return (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+}
+
+export default function WaitlistBadge({ eventId, email }) {
+  const [status, setStatus] = useState('idle'); // idle | loading | onWaitlist | notOnWaitlist | error
+  const [position, setPosition] = useState(null);
+  const [totalWaitlisted, setTotalWaitlisted] = useState(null);
+  const [leaving, setLeaving] = useState(false);
+
+  const fetchPosition = useCallback(async () => {
+    const base = getApiBase();
+    if (!base || !eventId || !email) return;
+
+    setStatus('loading');
+    try {
+      const url = `${base}/api/content/events/${encodeURIComponent(eventId)}/waitlist-position?email=${encodeURIComponent(email)}`;
+      const data = await apiClient(url);
+      setPosition(data.position);
+      setTotalWaitlisted(data.totalWaitlisted);
+      setStatus('onWaitlist');
+    } catch (err) {
+      if (err?.status === 404) {
+        setStatus('notOnWaitlist');
+      } else {
+        setStatus('error');
+      }
+    }
+  }, [eventId, email]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      if (cancelled) return;
+      await fetchPosition();
+    }
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchPosition]);
+
+  async function handleLeaveWaitlist() {
+    const base = getApiBase();
+    if (!base) return;
+    setLeaving(true);
+    try {
+      const url = `${base}/api/content/events/${encodeURIComponent(eventId)}/waitlist`;
+      await apiClient(url, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email }),
+      });
+      setStatus('notOnWaitlist');
+      setPosition(null);
+      setTotalWaitlisted(null);
+    } catch {
+      // keep current state, allow retry
+    } finally {
+      setLeaving(false);
+    }
+  }
+
+  if (status === 'idle' || status === 'loading') {
+    return (
+      <div className="waitlist-badge waitlist-badge--loading" aria-live="polite">
+        Checking waitlist status…
+      </div>
+    );
+  }
+
+  if (status === 'notOnWaitlist' || status === 'error') {
+    return null;
+  }
+
+  return (
+    <div className="waitlist-badge" role="status" aria-live="polite">
+      <div className="waitlist-badge__info">
+        <span className="waitlist-badge__icon" aria-hidden="true">
+          ⏳
+        </span>
+        <div>
+          <p className="waitlist-badge__position">
+            You're <strong>#{position}</strong> on the waitlist
+          </p>
+          {totalWaitlisted != null && (
+            <p className="waitlist-badge__total">
+              {totalWaitlisted} {totalWaitlisted === 1 ? 'person' : 'people'} waiting total
+            </p>
+          )}
+        </div>
+      </div>
+      <button
+        className="waitlist-badge__leave-btn"
+        onClick={handleLeaveWaitlist}
+        disabled={leaving}
+        aria-label="Leave waitlist"
+      >
+        {leaving ? 'Leaving…' : 'Leave Waitlist'}
+      </button>
+    </div>
+  );
+}

--- a/website/src/components/events/WaitlistBadge.jsx
+++ b/website/src/components/events/WaitlistBadge.jsx
@@ -1,4 +1,3 @@
-// website/src/components/events/WaitlistBadge.jsx
 import { useState, useEffect, useCallback } from 'react';
 import apiClient from '../../utils/apiClient';
 import './WaitlistBadge.css';


### PR DESCRIPTION
# Summary
Implements the core auto-promotion mechanics for issue #1747: when a confirmed registrant cancels, the oldest waitlisted person is automatically promoted (first-come-first-served), users can check their live waitlist position, and users can leave the waitlist voluntarily. Builds directly on the existing `event_registrations` waitlist column and `promoteFromWaitlist` repository method that were already in place.

**This PR covers the foundational auto-promotion flow only.** Confirmation timeouts, email notifications, admin manual promotion, capacity expansion, and analytics are explicitly out of scope here — see the Acceptance Criteria section below for an honest breakdown of what's covered vs. deferred.

## Related Issue
Fixes #1747 (partially — see Acceptance Criteria below for full breakdown)

## Type of Change
- [x] Feature
- [ ] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [x] Integration

## Changes Implemented
- `POST /api/content/events/:eventId/cancel` — cancels a confirmed registration by email, then automatically promotes the next person on the waitlist (FCFS via existing `created_at ASC` ordering)
- `GET /api/content/events/:eventId/waitlist-position?email=` — returns the caller's current waitlist position and total waitlist count
- `DELETE /api/content/events/:eventId/waitlist` — lets a user voluntarily leave the waitlist
- New repository methods: `getPosition`, `getWaitlistCount`, `removeFromWaitlist`, `cancelConfirmedRegistration` — all follow the existing `withDb` / parameterized-query pattern in `registrationsRepository.js`
- Promotion triggers existing real-time broadcast pattern (`emitToRole('events_admin', ...)`, `broadcastSSEEvent`) consistent with how registration already broadcasts
- New `WaitlistBadge.jsx` component — shows live position ("You're #4 on the waitlist", "12 people waiting total") and a "Leave Waitlist" button, fetched via the existing `apiClient` utility and `VITE_API_BASE` convention used elsewhere in the app

## Technical Details

### Frontend
- `website/src/components/events/WaitlistBadge.jsx` — fetches position on mount, handles leave-waitlist action, renders nothing if the user isn't on the waitlist
- `website/src/components/events/WaitlistBadge.css` — scoped styles

### Backend
- `server/controllers/eventRegistrationController.js` — added `cancelRegistration`, `getWaitlistPosition`, `leaveWaitlist`
- `server/repositories/registrationsRepository.js` — added `getPosition` (window function for live rank), `getWaitlistCount`, `removeFromWaitlist`, `cancelConfirmedRegistration`
- `server/routes/api.js` — registered 3 new routes, reusing the existing `eventRegistrationLimiter` rate limiter on the two mutating endpoints (cancel, leave) for consistency with the existing `/register` route

### Database
No schema changes. Reuses the existing `event_registrations` table (`waitlist`, `status`, `created_at` columns) and the existing `promoteFromWaitlist` query that was already present but previously unused by any route.

### API
3 new endpoints added (see above). No existing endpoints modified.

### Infrastructure
No infrastructure changes.

## Screenshots
### Before
No way to check waitlist position; no cancellation → auto-promotion path existed.

### After

> **Note:** I don't have a live Supabase/Postgres instance to test the full request → DB → response cycle locally. All new SQL was validated against the existing query patterns in the same file (window function for `getPosition`, parameterized queries throughout) and all 3 modified backend files pass `node --check`. I'd really appreciate a maintainer test against staging before merge, or guidance on local DB setup if that's expected for backend PRs in this repo.

## Testing

### Unit Tests
- [ ] Not added — no existing test coverage for `registrationsRepository.js` to follow a pattern from

### Integration Tests
- [ ] Not added — would need a test DB; happy to add if pointed to existing test infra

### E2E Tests
- [ ] Not added in this PR

### Manual Testing
- [x] `node --check` passes on all 3 modified backend files
- [x] ESLint passes clean on `WaitlistBadge.jsx` (fixed a `react-hooks/set-state-in-effect` warning during development)
- [x] `WaitlistBadge` renders nothing when user isn't on the waitlist (verified via component logic review)
- [ ] Full live request cycle — not verified against a real database (see note above)

## Security Review
- All new endpoints validate `eventId` against the existing `EVENT_ID_REGEX` and email against `EMAIL_REGEX`, matching the existing `registerForEvent` validation pattern
- All SQL uses parameterized queries (`$1`, `$2`) — no string interpolation into queries
- Mutating endpoints (`cancel`, `leave`) reuse `eventRegistrationLimiter` (10 req/hour) to prevent abuse
- `getWaitlistPosition` is read-only and unauthenticated by design (matches how `/register` works), scoped to the requester's own email only

## Accessibility Review
- `WaitlistBadge` uses `role="status"` and `aria-live="polite"` so position updates are announced
- Leave button has explicit `aria-label="Leave waitlist"`

## Performance Impact
- `getPosition` uses a `ROW_NUMBER() OVER (...)` window function — O(n log n) on waitlist size, which is expected to be small (tens, not thousands) per event
- No N+1 queries introduced

## Breaking Changes
- [x] No Breaking Changes

## Deployment Notes
No new environment variables. No migrations needed — reuses existing `event_registrations` columns. Requires `DATABASE_URL` to already be configured (same as existing registration flow).

## Rollback Plan
Revert the 3 route registrations in `api.js` to remove the new endpoints. The repository and controller additions are purely additive (new exported functions) and don't modify any existing function — safe to leave in place even if routes are reverted.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [x] Documentation updated
- [ ] Security reviewed *(self-reviewed; would value a second pass given this touches registration/payment-adjacent data)*
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing — will run on upstream after PR is opened
- [x] Ready for review