### PR TITLE
feat: enhance rate limiting with per-endpoint config and rate limit headers (fixes #1618, #1607)

### DIFF
--- a/server/middleware/authRateLimiter.js
+++ b/server/middleware/authRateLimiter.js
@@ -44,7 +44,7 @@ export const authRateLimiter = rateLimit({
   windowMs: AUTH_WINDOW_MS,
   max: AUTH_MAX_ATTEMPTS,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('auth-limit:'),
   handler: createRateLimitHandler('Authentication'),
 });
@@ -57,7 +57,7 @@ export const protectedActionRateLimiter = rateLimit({
   windowMs: AUTH_WINDOW_MS,
   max: AUTH_MAX_ATTEMPTS,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('protected-action-limit:'),
   handler: createRateLimitHandler('Protected Action'),
 });
@@ -70,7 +70,7 @@ export const passwordResetRateLimiter = rateLimit({
   windowMs: RESET_WINDOW_MS,
   max: RESET_MAX_ATTEMPTS,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('password-reset-limit:'),
   handler: (req, res, _next, options) => {
     const ipAddress = req.ip;

--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -52,7 +52,7 @@ export const apiRateLimiter = rateLimit({
   windowMs: API_WINDOW_MS,
   max: API_MAX_REQUESTS,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:api:'),
   handler: (req, res, _next, options) => {
     logger.warn('Global API rate limit exceeded', {
@@ -96,7 +96,7 @@ export const formRateLimiter = rateLimit({
   windowMs: FORM_WINDOW_MS,
   max: FORM_MAX_REQUESTS,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:form:'),
   handler: (req, res, _next, options) => {
     logger.warn('Rate limit exceeded for public form API', {
@@ -117,7 +117,7 @@ export const authRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 10,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   handler: createLimiterHandler(
     "Authentication rate limit exceeded",
     "Too many login attempts, please try again after a minute."
@@ -129,7 +129,7 @@ export const notificationRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 60,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   handler: createLimiterHandler(
     "Notification mutation rate limit exceeded",
     "Too many notification requests, please try again later."
@@ -145,7 +145,7 @@ export const activityAuthRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:activity-auth:'),
   handler: (req, res, next, options) => {
     logger.warn('Activity-event auth rate limit exceeded', {
@@ -166,7 +166,7 @@ export const syncRateLimiter = rateLimit({
   windowMs: 60 * 1000,
   max: 10,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:sync:'),
   handler: (req, res, next, options) => {
     logger.warn('Sync batch rate limit exceeded', {
@@ -185,7 +185,7 @@ export const portfolioRateLimiter = rateLimit({
   windowMs: 15 * 60 * 1000,
   max: 10,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   handler: createLimiterHandler(
     "Portfolio update rate limit exceeded",
     "Too many portfolio update attempts from this IP, please try again after 15 minutes."
@@ -197,7 +197,7 @@ export const eventRegistrationLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
   max: 10,
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:event-reg:'),
   handler: (req, res, _next, options) => {
     logger.warn('Event registration rate limit exceeded', {
@@ -216,7 +216,7 @@ export const searchRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute
   max: 30, // 30 requests per minute
   standardHeaders: true,
-  legacyHeaders: false,
+  legacyHeaders: true,
   store: createRateLimitStore('rate-limit:search:'),
   handler: (req, res, next, options) => {
     logger.warn('Search rate limit exceeded', {

--- a/server/middleware/tierRateLimiter.js
+++ b/server/middleware/tierRateLimiter.js
@@ -6,7 +6,7 @@ const memoryBuckets = new Map(); // key -> { tokens, lastUpdated }
 const memoryViolations = new Map(); // key -> { count, expiresAt }
 const memoryBlocked = new Map(); // key -> expiresAt
 
-// Rate limiting configurations
+// Base rate limiting configurations per tier
 const CONFIG = {
   guest: {
     capacity: 20,
@@ -19,6 +19,36 @@ const CONFIG = {
     baseCooldown: 5, // seconds
   },
 };
+
+// Per-endpoint rate limit overrides (#1618)
+// More specific paths take precedence over less specific ones.
+// Auth endpoints are stricter; data endpoints are more lenient.
+const ENDPOINT_LIMITS = {
+  '/api/auth': {
+    guest: { capacity: 10, refillRate: 0.17, baseCooldown: 30 },
+    authenticated: { capacity: 30, refillRate: 0.5, baseCooldown: 15 },
+  },
+  '/api/portfolio': {
+    guest: { capacity: 15, refillRate: 0.5, baseCooldown: 20 },
+    authenticated: { capacity: 60, refillRate: 2.0, baseCooldown: 10 },
+  },
+  '/api/sync': {
+    guest: { capacity: 5, refillRate: 0.17, baseCooldown: 60 },
+    authenticated: { capacity: 20, refillRate: 1.0, baseCooldown: 20 },
+  },
+  '/api/activity': {
+    guest: { capacity: 10, refillRate: 0.33, baseCooldown: 30 },
+    authenticated: { capacity: 40, refillRate: 1.5, baseCooldown: 10 },
+  },
+};
+
+const ENDPOINT_PREFIXES = Object.keys(ENDPOINT_LIMITS)
+  .sort((a, b) => b.length - a.length);
+
+function resolveEndpointConfig(path, tier) {
+  const matched = ENDPOINT_PREFIXES.find((prefix) => path.startsWith(prefix));
+  return matched ? ENDPOINT_LIMITS[matched][tier] : {};
+}
 
 /**
  * Clean up expired memory entries to prevent memory leaks
@@ -61,7 +91,8 @@ export function tierRateLimiter(options = {}) {
       tier = 'guest';
     }
 
-    const { capacity, refillRate, baseCooldown } = { ...CONFIG[tier], ...options };
+    const endpointCfg = resolveEndpointConfig(req.path, tier);
+    const { capacity, refillRate, baseCooldown } = { ...CONFIG[tier], ...options, ...endpointCfg };
     const rateLimitKey = `tier-rate-limit:${identifier}`;
     const violationsKey = `tier-rate-limit-violations:${identifier}`;
     const blockedKey = `tier-rate-limit-blocked:${identifier}`;
@@ -73,6 +104,9 @@ export function tierRateLimiter(options = {}) {
         const blockedTtl = await redis.ttl(blockedKey);
         if (blockedTtl > 0) {
           res.setHeader('Retry-After', blockedTtl);
+          res.setHeader('X-RateLimit-Limit', capacity);
+          res.setHeader('X-RateLimit-Remaining', 0);
+          res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + blockedTtl);
           return res.status(429).json({
             error: 'Too many requests. Temporary cooldown active.',
             retryAfter: blockedTtl,
@@ -122,8 +156,10 @@ export function tierRateLimiter(options = {}) {
         );
 
         if (allowed === 1) {
+          const resetIn = Math.ceil((capacity - tokensLeft) / refillRate);
           res.setHeader('X-RateLimit-Limit', capacity);
           res.setHeader('X-RateLimit-Remaining', tokensLeft);
+          res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + resetIn);
           return next();
         }
 
@@ -140,6 +176,9 @@ export function tierRateLimiter(options = {}) {
         );
 
         res.setHeader('Retry-After', cooldownSec);
+        res.setHeader('X-RateLimit-Limit', capacity);
+        res.setHeader('X-RateLimit-Remaining', 0);
+        res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + cooldownSec);
         return res.status(429).json({
           error: 'Rate limit exceeded. Temporary cooldown active.',
           retryAfter: cooldownSec,
@@ -157,6 +196,9 @@ export function tierRateLimiter(options = {}) {
     if (blockExpiresAt && now < blockExpiresAt) {
       const remainingSec = Math.ceil((blockExpiresAt - now) / 1000);
       res.setHeader('Retry-After', remainingSec);
+      res.setHeader('X-RateLimit-Limit', capacity);
+      res.setHeader('X-RateLimit-Remaining', 0);
+      res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + remainingSec);
       return res.status(429).json({
         error: 'Too many requests. Temporary cooldown active.',
         retryAfter: remainingSec,
@@ -179,8 +221,11 @@ export function tierRateLimiter(options = {}) {
       bucket.tokens -= 1;
       memoryBuckets.set(rateLimitKey, bucket);
 
+      const remainingMem = Math.floor(bucket.tokens);
+      const resetMem = Math.ceil((capacity - remainingMem) / refillRate);
       res.setHeader('X-RateLimit-Limit', capacity);
-      res.setHeader('X-RateLimit-Remaining', Math.floor(bucket.tokens));
+      res.setHeader('X-RateLimit-Remaining', remainingMem);
+      res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + resetMem);
       return next();
     }
 
@@ -203,6 +248,9 @@ export function tierRateLimiter(options = {}) {
     );
 
     res.setHeader('Retry-After', cooldownSec);
+    res.setHeader('X-RateLimit-Limit', capacity);
+    res.setHeader('X-RateLimit-Remaining', 0);
+    res.setHeader('X-RateLimit-Reset', Math.ceil(Date.now() / 1000) + cooldownSec);
     return res.status(429).json({
       error: 'Rate limit exceeded. Temporary cooldown active.',
       retryAfter: cooldownSec,


### PR DESCRIPTION
## Description

Enhances rate limiting with per-endpoint configuration, user tier differentiation, and standard `X-RateLimit-*` response headers.

## Changes

### Per-Endpoint Limits (#1618)
- Added `ENDPOINT_LIMITS` config map in `tierRateLimiter.js` with per-path overrides for `/api/auth`, `/api/portfolio`, `/api/sync`, `/api/activity`
- Endpoint configs are merged on top of tier config (guest vs authenticated), so auth endpoints get tighter limits while data endpoints are more lenient
- Redis-backed token bucket counters remain the primary store, with in-memory fallback

### Rate Limit Headers (#1607)
- `rateLimiter.js` / `authRateLimiter.js`: Switched `legacyHeaders` to `true` so `express-rate-limit` now emits both `RateLimit-*` (RFC draft) and `X-RateLimit-*` (legacy) headers on every response
- `tierRateLimiter.js`: Added `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers to all response paths (success, 429-blocked, 429-rate-limited) for both Redis and memory modes

## Files Changed
- `server/middleware/rateLimiter.js` — enable legacy headers on 8 rate limiters
- `server/middleware/authRateLimiter.js` — enable legacy headers on 3 rate limiters  
- `server/middleware/tierRateLimiter.js` — add endpoint config map, resolve per-path limits, emit full X-RateLimit header set on all responses

Closes #1618
Closes #1607
