### PR TITLE
fix: log fetch errors instead of silently swallowing them in SponsorshipMarketplacePage.jsx

### DIFF
--- a/website/src/pages/monetization/SponsorshipMarketplacePage.jsx
+++ b/website/src/pages/monetization/SponsorshipMarketplacePage.jsx
@@ -35,7 +35,11 @@ export default function SponsorshipMarketplacePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setCompanies(d.companies || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SponsorshipMarketplacePage] Failed to fetch companies:', err.message);
+        }
+      }
   }, []);
 
   const fetchPackages = useCallback(async () => {
@@ -44,7 +48,11 @@ export default function SponsorshipMarketplacePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setPackages(d.packages || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SponsorshipMarketplacePage] Failed to fetch packages:', err.message);
+        }
+      }
   }, []);
 
   const fetchProposals = useCallback(async () => {
@@ -53,7 +61,11 @@ export default function SponsorshipMarketplacePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setProposals(d.proposals || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SponsorshipMarketplacePage] Failed to fetch proposals:', err.message);
+        }
+      }
   }, []);
 
   const fetchAgreements = useCallback(async () => {
@@ -62,7 +74,11 @@ export default function SponsorshipMarketplacePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setAgreements(d.agreements || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SponsorshipMarketplacePage] Failed to fetch agreements:', err.message);
+        }
+      }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Description
`SponsorshipMarketplacePage.jsx`'s `fetchCompanies`, `fetchPackages`, `fetchProposals`, and `fetchAgreements` each had bare `try { ... } catch {}` blocks that completely discarded errors. If any of these requests failed, the failure was silently swallowed — no error state, no console output, nothing. Same pattern already fixed in `SkillExchangePage.jsx` (#2515).

Changes made:
- Added `import.meta.env.DEV`-guarded `console.error` calls to all four catch blocks, each with a `[SponsorshipMarketplacePage]` prefix and `err.message` for traceability
- Zero new TypeScript errors introduced

Fixes #2509

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings