### PR TITLE
fix: guard against state updates after unmount in ExplorePage.jsx

### DIFF
--- a/website/src/pages/explore/ExplorePage.jsx
+++ b/website/src/pages/explore/ExplorePage.jsx
@@ -33,6 +33,12 @@ export default function ExplorePage({ onBack, eventsData }) {
   const [activeTab, setActiveTab] = useState('discover');
 
   useEffect(() => {
+    // apiClient creates its own internal AbortController per call (for its
+    // request timeout) and does not currently accept an external signal, so
+    // in-flight requests here cannot be cancelled directly. Guard against
+    // state updates firing after unmount with an `alive` flag instead,
+    // consistent with the pattern already used in TeamPage.jsx.
+    let alive = true;
     const fetchData = async () => {
       const base = getApiBase();
       setLoading(true);
@@ -43,18 +49,23 @@ export default function ExplorePage({ onBack, eventsData }) {
           base ? apiClient(`${base}/api/content/team`).catch(() => null) : null,
         ]);
 
+        if (!alive) return;
         if (trendingRes?.trending) setTrending(trendingRes.trending);
         if (recsRes?.recommendations) setRecommendations(recsRes.recommendations);
         if (teamRes?.members) setMembers(teamRes.members);
       } catch (err) {
+        if (!alive) return;
         if (import.meta.env.DEV) {
           console.warn('[ExplorePage] Failed to fetch explore data:', err.message);
         }
         setFetchError('Failed to load content. Please try again.');
       }
-      setLoading(false);
+      if (alive) setLoading(false);
     };
     fetchData();
+    return () => {
+      alive = false;
+    };
   }, []);
 
   const filteredEvents = useMemo(() => {


### PR DESCRIPTION
## Description
This issue covers multiple pages with the same root pattern. This PR scopes the fix to `ExplorePage.jsx` as a concrete, representative fix.

`ExplorePage` fetched trending/recommendations/team data via `Promise.all` on mount with no cancellation or unmount guard. If the component unmounted before the requests resolved, `setTrending`/`setRecommendations`/`setMembers`/`setFetchError`/`setLoading` all still fired on an unmounted component.

I investigated using a proper `AbortController` passed into `apiClient`, but found that `apiClient` creates its own internal `AbortController` per call (used for its 10s request timeout) and spreads `{ ...fetchOptions, signal: controller.signal }` unconditionally — meaning any external `signal` passed via `options` would currently be silently overwritten. Passing an external `AbortController` through `apiClient` isn't actually possible without modifying that shared utility, which felt too high-risk/broad-blast-radius for this PR given how widely `apiClient` is used across the app.

Instead, applied the narrower `alive` ref-guard pattern already established elsewhere in the codebase (see `TeamPage.jsx`):

Changes made:
- `fetchData` now checks an `alive` flag before each state update
- The effect's cleanup function sets `alive = false` on unmount
- Zero new TypeScript errors introduced

The same `alive`-guard approach can be applied to other affected pages in follow-up PRs, or `apiClient` could be extended to accept an external signal in a separate, dedicated PR.

Fixes #2506

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings