### PR TITLE
feat: add announcements backend API

### DIFF
--- a/server-java/src/main/java/org/nexasphere/controller/AnnouncementsController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/AnnouncementsController.java
@@ -1,0 +1,100 @@
+package org.nexasphere.controller;
+
+import jakarta.validation.Valid;
+import org.nexasphere.model.entity.AnnouncementEntity;
+import org.nexasphere.repository.AnnouncementRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.lang.NonNull;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@RestController
+public class AnnouncementsController {
+
+
+private final AnnouncementRepository repo;
+
+public AnnouncementsController(AnnouncementRepository repo) {
+    this.repo = repo;
+}
+
+@GetMapping("/api/admin/announcements")
+public Map<String, Object> getAll() {
+    List<AnnouncementEntity> announcements =
+            repo.findAllByOrderByCreatedAtDesc();
+
+    return Map.of(
+            "announcements", announcements,
+            "total", announcements.size()
+    );
+}
+
+@PostMapping("/api/admin/announcements")
+public ResponseEntity<AnnouncementEntity> create(
+        @Valid @RequestBody AnnouncementEntity announcement) {
+
+    announcement.setId(null);
+
+    return ResponseEntity
+            .status(HttpStatus.CREATED)
+            .body(repo.save(announcement));
+}
+
+@PutMapping("/api/admin/announcements/{id}")
+public ResponseEntity<AnnouncementEntity> update(
+        @PathVariable @NonNull String id,
+        @Valid @RequestBody AnnouncementEntity announcement) {
+
+    return repo.findById(id).map(existing -> {
+
+        if (announcement.getTitle() != null) {
+            existing.setTitle(announcement.getTitle());
+        }
+
+        if (announcement.getContent() != null) {
+            existing.setContent(announcement.getContent());
+        }
+
+        if (announcement.getPriority() != null) {
+            existing.setPriority(announcement.getPriority());
+        }
+
+        if (announcement.getExpiresAt() != null) {
+            existing.setExpiresAt(announcement.getExpiresAt());
+        }
+
+        AnnouncementEntity saved =
+                Objects.requireNonNull(repo.save(existing));
+
+        return ResponseEntity.ok(saved);
+
+    }).orElseGet(() -> ResponseEntity.notFound().build());
+}
+
+@DeleteMapping("/api/admin/announcements/{id}")
+public ResponseEntity<Void> delete(
+        @PathVariable @NonNull String id) {
+
+    if (!repo.existsById(id)) {
+        return ResponseEntity.notFound().build();
+    }
+
+    repo.deleteById(id);
+    return ResponseEntity.noContent().build();
+}
+
+@GetMapping("/api/announcements/active")
+public List<AnnouncementEntity> getActive() {
+
+    return repo.findByExpiresAtAfterOrderByCreatedAtDesc(
+            LocalDateTime.now()
+    );
+}
+
+
+}

--- a/server-java/src/main/java/org/nexasphere/model/entity/AnnouncementEntity.java
+++ b/server-java/src/main/java/org/nexasphere/model/entity/AnnouncementEntity.java
@@ -1,0 +1,66 @@
+package org.nexasphere.model.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "announcements")
+@Data
+@NoArgsConstructor
+public class AnnouncementEntity {
+
+@Id
+private String id;
+
+@NotBlank
+@Size(max = 200)
+private String title;
+
+@NotBlank
+@Size(max = 5000)
+private String content;
+
+@Pattern(regexp = "low|normal|high|urgent")
+private String priority = "normal";
+
+private LocalDateTime expiresAt;
+
+@CreationTimestamp
+private LocalDateTime createdAt;
+
+@UpdateTimestamp
+private LocalDateTime updatedAt;
+
+@PrePersist
+public void generateId() {
+    if (this.id == null || this.id.isEmpty()) {
+        this.id = slugify(this.title);
+    }
+}
+
+private String slugify(String text) {
+    if (text == null) {
+        return "announcement-" + System.currentTimeMillis();
+    }
+
+    String slug = text.toLowerCase()
+            .replaceAll("[^a-z0-9]+", "-")
+            .replaceAll("^-|-$", "");
+
+    return slug.isEmpty()
+            ? "announcement-" + System.currentTimeMillis()
+            : slug;
+}
+
+}

--- a/server-java/src/main/java/org/nexasphere/repository/AnnouncementRepository.java
+++ b/server-java/src/main/java/org/nexasphere/repository/AnnouncementRepository.java
@@ -1,0 +1,18 @@
+package org.nexasphere.repository;
+
+import org.nexasphere.model.entity.AnnouncementEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface AnnouncementRepository extends JpaRepository<AnnouncementEntity, String> {
+
+List<AnnouncementEntity> findAllByOrderByCreatedAtDesc();
+
+List<AnnouncementEntity> findByExpiresAtAfterOrderByCreatedAtDesc(
+        LocalDateTime now
+);
+
+
+}


### PR DESCRIPTION
# Summary

Implemented backend support for announcements management by adding a new Announcement entity, repository, and REST controller. This enables persistent CRUD operations for announcements and provides a public API for retrieving active announcements.

## Related Issue

Fixes #1981

## Type of Change

- [x] Feature
- [ ] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

### Backend

- Added `AnnouncementEntity` for announcement data persistence
- Added `AnnouncementRepository` using Spring Data JPA
- Added `AnnouncementsController` with CRUD endpoints
- Added public endpoint for active announcements

### API Endpoints

#### Admin Endpoints

- `GET /api/admin/announcements`
- `POST /api/admin/announcements`
- `PUT /api/admin/announcements/{id}`
- `DELETE /api/admin/announcements/{id}`

#### Public Endpoint

- `GET /api/announcements/active`

## Technical Details

### Backend

- Spring Boot REST Controller implementation
- JPA Repository integration
- Validation using Jakarta Validation annotations
- Automatic slug-based ID generation using `@PrePersist`

### Database

Added `announcements` table with:

- id
- title
- content
- priority
- expiresAt
- createdAt
- updatedAt

## Testing

### Manual Testing

- [x] Created announcements through API
- [x] Updated announcements through API
- [x] Deleted announcements through API
- [x] Retrieved active announcements

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Ready for review

## Notes

Some existing CI failures are related to project environment dependencies and are not introduced by this change.