### PR TITLE
fix(server): resolve boot crashes — supabaseRequest syntax, missing router/service imports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -88,6 +88,10 @@ import scheduledTasksRouter from './routes/scheduledTasks.js';
 import financialsRouter from './routes/financials.js';
 import { schedulerService } from './services/schedulerService.js';
 import feedbackRouter from './routes/feedbackRoutes.js';
+import complianceRouter from './routes/compliance.js';
+import healthDashboardRouter from './routes/healthDashboard.js';
+import { logEvent } from './controllers/analyticsController.js';
+import * as slackController from './controllers/slackController.js';
 
 validateLimiters();
 
@@ -354,7 +358,6 @@ if (!useStructuredHttpLog) {
 }
 
 // Mount route modules
-app.use('/api/form-submissions', formSubmissionsRouter);
 app.post('/api/analytics/track', logEvent);
 app.use('/api/monitoring', monitoringRouter);
 app.use('/api/health-dashboard', healthDashboardRouter);
@@ -542,7 +545,6 @@ function withContentLock(fn) {
   return current.then(() => fn()).finally(() => release());
 }
 
-export async function supabaseRequest(pathname, { method = 'GET', body } = {}) {
 const _rawSupabaseRequest = async function _rawSupabaseRequest(
   pathname,
   { method = 'GET', body } = {}
@@ -566,8 +568,7 @@ const _rawSupabaseRequest = async function _rawSupabaseRequest(
   const text = await res.text();
   return text ? JSON.parse(text) : [];
 };
-
-export const supabaseRequest = _rawSupabaseRequest;
+export { _rawSupabaseRequest as supabaseRequest };
 
 export const supabaseBreaker = circuitBreakerRegistry.register(
   'index-supabase',


### PR DESCRIPTION
## Summary

Fixes 3 server boot crashes caused by syntax errors and missing imports in `server/index.js`.

## Related Issues

Fixes #2612, #2613, #2614

## Type of Change

- [x] Bug Fix

## Changes Implemented

- **#2612**: Fixed `supabaseRequest` nested `export` inside function body — changed to module-level export
- **#2613**: Added missing imports for `complianceRouter`, `healthDashboardRouter`, `logEvent`; removed orphaned `formSubmissionsRouter` route registration (file does not exist)
- **#2614**: Added missing import for `slackController` used in 7 Slack integration routes

## Technical Details

### Backend

- `server/index.js`: 
  - Fixed wrapper function `export async function supabaseRequest(...)` that had nested `export const` inside its body
  - Added 4 imports for previously undefined controllers/routers
  - Removed `app.use('/api/form-submissions', formSubmissionsRouter)` since `routes/formSubmissions.js` does not exist

## Testing

### Manual Testing

- [x] Server starts without ReferenceError or SyntaxError
- [x] `complianceRouter`, `healthDashboardRouter`, `analytics/track`, `slackController` routes now properly registered

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing