### PR TITLE
fix(server): remove nested export in supabaseRequest to fix SyntaxError

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -542,7 +542,6 @@ function withContentLock(fn) {
   return current.then(() => fn()).finally(() => release());
 }
 
-export async function supabaseRequest(pathname, { method = 'GET', body } = {}) {
 const _rawSupabaseRequest = async function _rawSupabaseRequest(
   pathname,
   { method = 'GET', body } = {}
@@ -567,7 +566,7 @@ const _rawSupabaseRequest = async function _rawSupabaseRequest(
   return text ? JSON.parse(text) : [];
 };
 
-export const supabaseRequest = _rawSupabaseRequest;
+export { _rawSupabaseRequest as supabaseRequest };
 
 export const supabaseBreaker = circuitBreakerRegistry.register(
   'index-supabase',


### PR DESCRIPTION
## Description

Fixes SyntaxError in server/index.js where `export const` appeared inside a function body — illegal in ESM modules.

## Related Issue

Fixes #2612

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Removed outer `export async function supabaseRequest(...)` wrapper function
- `_rawSupabaseRequest` is now the sole implementation, exported at module top level
- Resolves `SyntaxError: export statements may only appear at top level`

## Technical Details

### Backend

`server/index.js:545-570` — The function declaration `export async function supabaseRequest()` opened a function body containing `export const supabaseRequest = _rawSupabaseRequest;`. In ESM, `export` is only valid at module top level. Fix: inline the implementation directly and export it properly.

## Screenshots

N/A

## Testing

### Manual Testing

- [x] `node server/index.js` no longer throws SyntaxError at module evaluation
- [x] `supabaseRequest` and `supabaseBreaker` exports remain available

## Security Review

No security impact — only fixes syntax structure.

## Accessibility Review

N/A — backend change only.

## Performance Impact

None.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing