### PR TITLE
fix(server): import slackController to fix ReferenceError in 7 Slack routes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -88,6 +88,7 @@ import scheduledTasksRouter from './routes/scheduledTasks.js';
 import financialsRouter from './routes/financials.js';
 import { schedulerService } from './services/schedulerService.js';
 import feedbackRouter from './routes/feedbackRoutes.js';
+import * as slackController from './controllers/slackController.js';
 
 validateLimiters();
 


### PR DESCRIPTION
## Description

Adds missing import for slackController to resolve ReferenceError when registering 7 Slack integration routes.

## Related Issue

Fixes #2614

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `import * as slackController from './controllers/slackController.js'` to server/index.js

## Technical Details

### Backend

`server/index.js:1157-1166` registers 7 Slack endpoints using `slackController.*` methods but the controller was never imported. This caused `ReferenceError: slackController is not defined` at module evaluation time.

## Screenshots

N/A

## Testing

### Manual Testing

- [x] Server starts without ReferenceError for slackController
- [x] Slack endpoint registrations succeed

## Security Review

No security impact — imports an existing validated controller module.

## Accessibility Review

N/A

## Performance Impact

None.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing