### PR TITLE
fix(server): import SUPABASE_URL and SUPABASE_SERVICE_KEY from supabaseClient

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -62,7 +62,7 @@ import * as activityEventsController from './controllers/activityEventsControlle
 import * as streamController from './controllers/streamController.js';
 import * as coreTeamController from './controllers/coreTeamController.js';
 import { coreTeamService } from './services/coreTeamService.js';
-import { HAS_SUPABASE } from './storage/supabaseClient.js';
+import { HAS_SUPABASE, SUPABASE_URL, SUPABASE_SERVICE_KEY } from './storage/supabaseClient.js';
 import cookieParser from 'cookie-parser';
 import session from 'express-session';
 import RedisStore from 'connect-redis';


### PR DESCRIPTION
## Description

Adds missing `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` imports to resolve ReferenceError when Supabase operations execute.

## Related Issue

Fixes #2615

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Updated import on line 65 to destructure `SUPABASE_URL` and `SUPABASE_SERVICE_KEY` alongside `HAS_SUPABASE` from `./storage/supabaseClient.js`

## Technical Details

### Backend

`server/index.js:65` only imported `HAS_SUPABASE` from `supabaseClient.js`, but `supabaseRequest()` (line 551) and `supabasePaginatedRequest()` (line 590) reference `SUPABASE_URL` and `SUPABASE_SERVICE_KEY`. These are exported from `supabaseClient.js` but were never imported, causing ReferenceError at runtime.

## Testing

### Manual Testing

- [x] Supabase functions no longer throw ReferenceError for these variables

## Security Review

No security impact — these are configuration variables already used by the code.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing