### PR TITLE
fix(server): import notification services to fix ReferenceError in notification endpoints

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,6 +36,9 @@ import { performanceMonitor } from './middleware/performanceMonitor.js';
 import { enhancedTracingMiddleware } from './middleware/enhancedTracingMiddleware.js';
 import { errorHandler, notFoundHandler } from './middleware/errorHandler.js';
 import { notificationAnalyticsRepository } from './repositories/notificationAnalyticsRepository.js';
+import { notificationPreferencesRepository } from './repositories/notificationPreferencesRepository.js';
+import notificationsService from './services/notificationsService.js';
+import { studentAuthService } from './services/studentAuthService.js';
 import { initializeSentry, addSentryErrorHandler } from './utils/sentry.js';
 import {
   apiRateLimiter,


### PR DESCRIPTION
## Description

Adds three missing imports for services and repositories used by the notification-related endpoints in server/index.js.

## Related Issue

Fixes #2616

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added import for `studentAuthService` from `./services/studentAuthService.js`
- Added import for `notificationsService` from `./services/notificationsService.js`
- Added import for `notificationPreferencesRepository` from `./repositories/notificationPreferencesRepository.js`

## Technical Details

### Backend

Three notification-related endpoints defined directly in server/index.js used unimported services:
- `GET /api/notifications` calls `studentAuthService.verifyToken()` (line 1394) and `notificationsService.getNotifications()` (line 1425)
- `GET /api/notifications/preferences` calls `notificationPreferencesRepository.list()` (line 1436)
- `PUT /api/notifications/preferences` calls `notificationPreferencesRepository.set()` (line 1448)
- `PUT /api/notifications/preferences/bulk` calls `notificationPreferencesRepository.setBulk()` (line 1471)

All produced ReferenceError at runtime. Fixed by adding the missing imports.

## Testing

### Manual Testing

- [x] Notification endpoints no longer throw ReferenceError

## Security Review

No security impact — imports reference existing validated service modules.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing