### PR TITLE
fix(server): import slackRepository to fix ReferenceError at boot

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -69,6 +69,7 @@ import RedisStore from 'connect-redis';
 import Redis from 'ioredis';
 import passport from './config/studentOAuth.js';
 import { studentUsersRepository } from './repositories/studentUsersRepository.js';
+import { slackRepository } from './repositories/slackRepository.js';
 import * as studentAuthController from './controllers/studentAuthController.js';
 import * as forumController from './controllers/forumController.js';
 import { requireStudentAuth } from './middleware/studentAuthMiddleware.js';


### PR DESCRIPTION
## Description

Adds missing `slackRepository` import to resolve ReferenceError when `slackRepository.ensureSchema()` is called during server startup.

## Related Issue

Fixes #2617

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added import for `slackRepository` from `./repositories/slackRepository.js`

## Technical Details

### Backend

`server/index.js:1647` calls `slackRepository.ensureSchema()` during the init phase, but `slackRepository` was never imported. This causes a ReferenceError at boot immediately after the `studentUsersRepository.ensureSchema()` call.

## Testing

### Manual Testing

- [x] Server no longer crashes at boot with ReferenceError for slackRepository

## Security Review

No security impact — import references existing validated repository module.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing