### PR TITLE
fix(server): import startWebhookRetryProcessor to fix ReferenceError at VERCEL boot

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -76,6 +76,7 @@ import { loadPersistedPushSubscriptions } from './routes/notifications.js';
 import * as mentorshipController from './controllers/mentorshipController.js';
 import { xssSanitizer } from './middleware/xssSanitizer.js';
 import { tierRateLimiter } from './middleware/tierRateLimiter.js';
+import { startWebhookRetryProcessor } from './services/webhookRetryProcessor.js';
 import { csrfProtection } from './middleware/csrfMiddleware.js';
 import compression from 'compression';
 import syncRouter from './routes/sync.js';


### PR DESCRIPTION
## Description

Adds missing `startWebhookRetryProcessor` import to fix ReferenceError on Vercel deployment path.

## Related Issue

Fixes #2618

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added import for `startWebhookRetryProcessor` from `./services/webhookRetryProcessor.js`

## Technical Details

### Backend

`server/index.js:1667` calls `startWebhookRetryProcessor()` inside the listen callback (VERCEL path), but the function was never imported from `./services/webhookRetryProcessor.js`. This causes `ReferenceError: startWebhookRetryProcessor is not defined` immediately after the server starts listening on Vercel deployments.

## Testing

### Manual Testing

- [x] Server no longer crashes on VERCEL deployment path

## Security Review

No security impact — imports existing validated service module.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing