### PR TITLE
fix(server): import isIP from net to fix ReferenceError in isInternalUrl

### DIFF
--- a/server/storage/supabaseClient.js
+++ b/server/storage/supabaseClient.js
@@ -1,5 +1,6 @@
 import { CircuitBreaker, circuitBreakerRegistry } from '../utils/circuitBreaker.js';
 import { tracedFetch } from '../config/appContext.js';
+import { isIP } from 'net';
 
 export const SUPABASE_URL = process.env.SUPABASE_URL || '';
 export const SUPABASE_SERVICE_KEY =


### PR DESCRIPTION
## Description

Adds missing `isIP` import from Node.js `net` module to fix ReferenceError in `isInternalUrl()` function.

## Related Issue

Fixes #2619

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `import { isIP } from net` to `server/storage/supabaseClient.js`

## Technical Details

### Backend

`server/storage/supabaseClient.js:25` calls `isIP(hostname)` inside `isInternalUrl()`, but `isIP` was never imported. This causes a ReferenceError whenever `isInternalUrl()` is invoked. `isIP` is a standard export from Node.js built-in `net` module.

## Testing

### Manual Testing

- [x] `isInternalUrl()` no longer throws ReferenceError

## Security Review

No security impact — uses Node.js built-in `net.isIP()` for network classification.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing