### PR TITLE
fix(server): import calculateRiskScore from threatDetection to fix ReferenceError

### DIFF
--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -2,6 +2,7 @@ import rateLimit from 'express-rate-limit';
 import logger from '../utils/logger.js';
 import { createRateLimitStore } from '../services/rateLimitService.js';
 import { apiSecurityManager } from "../utils/apiSecurityManager.js";
+import { calculateRiskScore } from '../utils/threatDetection.js';
 
 const suspiciousIPs = new Map();
 


### PR DESCRIPTION
## Description

Adds missing `calculateRiskScore` import from threatDetection utility to fix ReferenceError in rate limiter.

## Related Issue

Fixes #2620

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `import { calculateRiskScore } from ../utils/threatDetection.js` to `server/middleware/rateLimiter.js`

## Technical Details

### Backend

`server/middleware/rateLimiter.js:78` calls `calculateRiskScore(req)` inside the rate-limit middleware, but the function was never imported. `calculateRiskScore` is a named export from `../utils/threatDetection.js`. This causes a ReferenceError on every rate-limited request.

## Testing

### Manual Testing

- [x] Rate limit middleware no longer throws ReferenceError

## Security Review

No security impact — imports existing validated utility function.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing