### PR TITLE
fix(server): import liveQaService to fix ReferenceError in socket setup

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -8,6 +8,7 @@ import logger from '../utils/logger.js';
 import { getAdminSession } from '../repositories/adminSessionsRepository.js';
 import { resolveAdminPermissions, getRoomsForPermissions } from './eventPermissions.js';
 import { createAdapter } from '@socket.io/redis-adapter';
+import { liveQaService } from '../services/liveQaService.js';
 import { getRedisClient } from '../utils/redis.js';
 import { waitingRoomService } from '../services/waitingRoomService.js';
 


### PR DESCRIPTION
## Description

Adds missing `liveQaService` import to fix ReferenceError when setting up Socket.IO.

## Related Issue

Fixes #2622

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `import { liveQaService } from '../services/liveQaService.js'` to `server/config/socket.js`

## Technical Details

### Backend

`server/config/socket.js:92` calls `liveQaService.setIO(io)` during Socket.IO initialization, but `liveQaService` was never imported. This causes a ReferenceError at runtime when the WebSocket server initializes.

## Testing

### Manual Testing

- [x] Socket.IO initialization no longer throws ReferenceError for liveQaService

## Security Review

No security impact — imports existing validated service module.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing