### PR TITLE
fix(website): import useStudentAuth to fix dashboard ReferenceError

### DIFF
--- a/website/src/pages/dashboard/DashboardPage.jsx
+++ b/website/src/pages/dashboard/DashboardPage.jsx
@@ -5,6 +5,7 @@ import Leaderboard from '../../components/dashboard/Leaderboard';
 import AiMentor from '../../components/dashboard/AiMentor';
 import { buildUrl, getAiApiBase, getApiBase } from '../../utils/runtimeConfig';
 import { useTheme } from '../../hooks/useTheme';
+import { useStudentAuth } from '../../context/StudentAuthContext';
 
 function DashboardCardSkeleton({ count = 3 }) {
   return (


### PR DESCRIPTION
## Description

Adds missing `useStudentAuth` import to fix ReferenceError crash on Dashboard page.

## Related Issue

Fixes #2623

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `import { useStudentAuth } from '../../context/StudentAuthContext'` to `DashboardPage.jsx`

## Technical Details

### Frontend

`website/src/pages/dashboard/DashboardPage.jsx:47` calls `useStudentAuth()` but the hook was never imported. This causes `ReferenceError: useStudentAuth is not defined` when navigating to `/dashboard`, resulting in a white screen crash.

## Testing

### Manual Testing

- [x] Dashboard page renders without ReferenceError

## Security Review

No security impact — imports existing validated context hook.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing