### PR TITLE
fix(website): define timeoutsRef in RippleBtn to fix ReferenceError on click

### DIFF
--- a/website/src/pages/home/HeroSection.jsx
+++ b/website/src/pages/home/HeroSection.jsx
@@ -6,6 +6,7 @@ import { IconArrowRight, IconSpark, DynamicIcon } from '../../shared/Icons';
 /* â”€â”€ Ripple Button â”€â”€ */
 function RippleBtn({ cls, children, href, onClick }) {
   const ref = useRef(null);
+  const timeoutsRef = useRef([]);
   const go = (e) => {
     const b = ref.current;
     if (!b) return;
@@ -19,6 +20,9 @@ function RippleBtn({ cls, children, href, onClick }) {
     timeoutsRef.current.push(t);
     onClick && onClick(e);
   };
+  useEffect(() => {
+    return () => timeoutsRef.current.forEach(clearTimeout);
+  }, []);
   if (href)
     return (
       <a


### PR DESCRIPTION
## Description

Fixes ReferenceError in RippleBtn component where `timeoutsRef` was used but never defined.

## Related Issue

Fixes #2625

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added `const timeoutsRef = useRef([])` in RippleBtn component
- Added cleanup `useEffect` to clear timeout IDs on unmount

## Technical Details

### Frontend

`website/src/pages/home/HeroSection.jsx:19` called `timeoutsRef.current.push(t)` inside the ripple click handler, but `timeoutsRef` was never defined (only `ref` existed). Every click caused `ReferenceError: timeoutsRef is not defined`. Adding `useRef([])` fixes the error and the cleanup `useEffect` prevents timeout leaks.

## Testing

### Manual Testing

- [x] Ripple buttons no longer throw ReferenceError on click
- [x] Timeouts are properly cleaned up on unmount

## Security Review

No security impact.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] CI/CD passing