### PR TITLE
[Bug] ReferenceError in admin subscription routes: subscriptionsController not imported in server/routes/api.js

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -22,6 +22,7 @@ import { auditLogRepository } from '../repositories/auditLogRepository.js';
 
 import * as recommendationsController from '../controllers/recommendationsController.js';
 import * as gamificationController from '../controllers/gamificationController.js';
+import * as subscriptionsController from '../controllers/subscriptionsController.js';
 import multer from 'multer';
 
 const upload = multer({


### PR DESCRIPTION
## Summary

Fixes #2702 — ReferenceError on admin subscription routes.

`server/routes/api.js` references `subscriptionsController` at lines 210-232 but never imports it.

## Changes Implemented

Added missing import to `server/routes/api.js`:
```js
import * as subscriptionsController from '../controllers/subscriptionsController.js';
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified import resolves correctly

## Checklist

- [x] Code follows project standards
- [x] Ready for review