### PR TITLE
[Bug] ReferenceError in /account-recovery routes: studentAuthService not imported in server/routes/api.js

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -22,6 +22,7 @@ import { auditLogRepository } from '../repositories/auditLogRepository.js';
 
 import * as recommendationsController from '../controllers/recommendationsController.js';
 import * as gamificationController from '../controllers/gamificationController.js';
+import { studentAuthService } from '../services/studentAuthService.js';
 import multer from 'multer';
 
 const upload = multer({


### PR DESCRIPTION
## Summary

Fixes #2700 — ReferenceError on /account-recovery routes.

`server/routes/api.js` references `studentAuthService` at lines 63 and 76 but never imports it.

## Changes Implemented

Added missing import to `server/routes/api.js`:
```js
import { studentAuthService } from '../services/studentAuthService.js';
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified import resolves correctly

## Checklist

- [x] Code follows project standards
- [x] Ready for review