### PR TITLE
[Bug] ReferenceError on admin login: ADMIN_USERNAME and ADMIN_PASSWORD not in scope in adminAuthMiddleware.js

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -37,6 +37,9 @@ function safeEqual(a, b) {
   return crypto.timingSafeEqual(hashA, hashB);
 }
 
+const ADMIN_USERNAME = requiredEnv('ADMIN_USERNAME');
+const ADMIN_PASSWORD = requiredStrongPassword('ADMIN_PASSWORD');
+
 let adminUsers = [];
 try {
   if (process.env.ADMIN_USERS_JSON) {


### PR DESCRIPTION
## Summary

Fixes #2694 — ReferenceError on every admin login attempt.

`ADMIN_USERNAME` and `ADMIN_PASSWORD` are referenced as bare identifiers in the `login()` function but were never defined as module-level variables.

## Description

Added `const ADMIN_USERNAME = requiredEnv('ADMIN_USERNAME')` and `const ADMIN_PASSWORD = requiredStrongPassword('ADMIN_PASSWORD')` as module-level constants before the `adminUsers` initialization block, making them accessible to the `login()` function.

## Changes Implemented

Added module-level constants to `adminAuthMiddleware.js`:
```js
const ADMIN_USERNAME = requiredEnv('ADMIN_USERNAME');
const ADMIN_PASSWORD = requiredStrongPassword('ADMIN_PASSWORD');
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified variables are in scope for `login()`

## Checklist

- [x] Code follows project standards
- [x] Ready for review