### PR TITLE
[Bug] ReferenceError on successful admin login: matchedUser is undefined in adminAuthMiddleware.js

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -372,6 +372,7 @@ async function login(req, res) {
 
     await clearLoginAttempts(ip);
 
+    const matchedUser = adminUsers.find((user) => safeEqual(user.username, u)) || adminUsers[0];
     const role = matchedUser.role || 'SuperAdmin';
     const scopes = getScopesForRole(role);
     const securityAccount = await getOrCreateAdminSecurityAccount(u, matchedUser.email || u);


### PR DESCRIPTION
## Summary

Fixes #2695 — ReferenceError after successful credential validation.

After credentials are validated, the code references `matchedUser.role` and `matchedUser.email` but `matchedUser` was never assigned.

## Description

Added a `matchedUser` lookup from the `adminUsers` array after credential validation succeeds, so the role and email can be extracted for session creation.

## Changes Implemented

Added to `adminAuthMiddleware.js`:
```js
const matchedUser = adminUsers.find((user) => safeEqual(user.username, u)) || adminUsers[0];
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified matchedUser is found after successful login

## Checklist

- [x] Code follows project standards
- [x] Ready for review