### PR TITLE
[Bug] Missing authentication on POST /api/dashboard/xp — anyone can award XP to any user

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -32,7 +32,7 @@ const router = Router();
 
 // Public
 router.get('/api/dashboard/leaderboard', gamificationController.getLeaderboard);
-router.post('/api/dashboard/xp', gamificationController.awardXP);
+router.post('/api/dashboard/xp', adminAuthMiddleware.requireAdmin, gamificationController.awardXP);
 router.post(
   '/api/assistant/recommend',
   upload.single('file'),

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -32,7 +32,7 @@ const router = Router();
 
 // Public
 router.get('/api/dashboard/leaderboard', gamificationController.getLeaderboard);
-router.post('/api/dashboard/xp', adminAuthMiddleware.requireAdmin, gamificationController.awardXP);
+router.post('/api/dashboard/xp', protectedActionRateLimiter, adminAuthMiddleware.requireAdmin, gamificationController.awardXP);
 router.post(
   '/api/assistant/recommend',
   upload.single('file'),


### PR DESCRIPTION
## Summary

Fixes #2697 — Unauthenticated XP awarding endpoint.

`POST /api/dashboard/xp` has zero authentication or authorization, allowing any unauthenticated client to arbitrarily award XP to any user.

## Description

The route at `server/routes/api.js:35` was missing auth middleware. Unlike other admin routes which use `adminAuthMiddleware.requireAdmin`, this endpoint was fully public.

## Changes Implemented

Added `adminAuthMiddleware.requireAdmin` middleware to the route:
```js
// Before
router.post('/api/dashboard/xp', gamificationController.awardXP);
// After
router.post('/api/dashboard/xp', adminAuthMiddleware.requireAdmin, gamificationController.awardXP);
```

## Type of Change

- [x] Bug Fix
- [x] Security Enhancement

## Testing

### Manual Testing

- [x] Verified unauthenticated requests are rejected with 401

## Checklist

- [x] Code follows project standards
- [x] Ready for review