### PR TITLE
[Bug] ReferenceError at boot: slackIntegrationService.init() called but slackIntegrationService not imported in server/index.js

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -45,6 +45,7 @@ import { notificationAnalyticsRepository } from './repositories/notificationAnal
 import { notificationPreferencesRepository } from './repositories/notificationPreferencesRepository.js';
 import notificationsService from './services/notificationsService.js';
 import { studentAuthService } from './services/studentAuthService.js';
+import { slackIntegrationService } from './services/slackIntegrationService.js';
 import { initializeSentry, addSentryErrorHandler } from './utils/sentry.js';
 import {
   apiRateLimiter,


### PR DESCRIPTION
## Summary

Fixes #2693 — Server crashes at boot with ReferenceError.

## Description

`server/index.js` calls `slackIntegrationService.init()` at lines 1674 and 1688 but never imports the module. The module exists at `./services/slackIntegrationService.js` with a named export `slackIntegrationService`.

## Changes Implemented

Added missing import to `server/index.js`:
```js
import { slackIntegrationService } from './services/slackIntegrationService.js';
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified import resolves correctly

## Checklist

- [x] Code follows project standards
- [x] Ready for review