### PR TITLE
[Bug] EncryptionManager generates random ENCRYPTION_KEY on every restart causing permanent data loss of all encrypted data

### DIFF
--- a/server/utils/encryptionManager.js
+++ b/server/utils/encryptionManager.js
@@ -1,8 +1,10 @@
 import crypto from 'crypto';
 
 const ALGORITHM = 'aes-256-cbc';
-let ENCRYPTION_KEY =
-  process.env.ENCRYPTION_KEY || crypto.randomBytes(32).toString('hex').slice(0, 32);
+if (!process.env.ENCRYPTION_KEY) {
+  throw new Error('FATAL: ENCRYPTION_KEY environment variable is not set.');
+}
+let ENCRYPTION_KEY = process.env.ENCRYPTION_KEY;
 
 let auditLogs = [];
 


### PR DESCRIPTION
## Summary

Fixes #2699 — Permanent data loss of all encrypted data on server restart.

## Description

`encryptionManager.js` defaults `ENCRYPTION_KEY` to `crypto.randomBytes(32)` when `process.env.ENCRYPTION_KEY` is not set. This generates a new random key on every server restart, making ALL previously encrypted data permanently undecryptable.

## Changes Implemented

Replaced the silent random key fallback with a startup validation that throws a clear error:
```js
if (!process.env.ENCRYPTION_KEY) {
  throw new Error('FATAL: ENCRYPTION_KEY environment variable is not set.');
}
let ENCRYPTION_KEY = process.env.ENCRYPTION_KEY;
```

## Type of Change

- [x] Bug Fix
- [x] Security Enhancement

## Testing

### Manual Testing

- [x] Verified missing key throws at startup instead of silently generating ephemeral key

## Checklist

- [x] Code follows project standards
- [x] Ready for review