### PR TITLE
[Bug] envValidator.js only validates 2 of 10+ required environment variables — silent startup with deferred crashes

### DIFF
--- a/server/utils/envValidator.js
+++ b/server/utils/envValidator.js
@@ -1,5 +1,12 @@
 export function validateEnvironment() {
-  const required = ['CORS_ORIGIN', 'ADMIN_EVENT_PASSWORD'];
+  const required = [
+    'CORS_ORIGIN',
+    'ADMIN_EVENT_PASSWORD',
+    'JWT_SECRET',
+    'ENCRYPTION_KEY',
+    'SUPABASE_URL',
+    'SUPABASE_SERVICE_ROLE_KEY',
+  ];
 
   const missing = required.filter((key) => !process.env[key]);
 


### PR DESCRIPTION
## Summary

Fixes #2704 — Silent startup with deferred crashes when critical env vars are missing.

## Description

`envValidator.js` only validated 2 env vars (`CORS_ORIGIN`, `ADMIN_EVENT_PASSWORD`). Critical vars like `JWT_SECRET`, `ENCRYPTION_KEY`, `SUPABASE_URL`, and `SUPABASE_SERVICE_ROLE_KEY` were not checked, causing crashes later when features first accessed them.

## Changes Implemented

Expanded validation to include all unconditionally required env vars:
```js
const required = [
  'CORS_ORIGIN',
  'ADMIN_EVENT_PASSWORD',
  'JWT_SECRET',
  'ENCRYPTION_KEY',
  'SUPABASE_URL',
  'SUPABASE_SERVICE_ROLE_KEY',
];
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified missing vars are caught at startup

## Checklist

- [x] Code follows project standards
- [x] Ready for review