### PR TITLE
[Bug] Zod schema marks CORS_ORIGIN as optional but server crashes if missing — misleading validation in server/config/env.js

### DIFF
--- a/server/config/env.js
+++ b/server/config/env.js
@@ -4,7 +4,7 @@ import { secretsManager } from '../services/secretsManager.js';
 const envSchema = z.object({
   PORT: z.coerce.number().default(8787),
   NODE_ENV: z.string().default('development'),
-  CORS_ORIGIN: z.string().optional(),
+  CORS_ORIGIN: z.string(),
   DATABASE_URL: z.string().optional(),
 });
 


### PR DESCRIPTION
## Summary

Fixes #2705 — Zod schema fails silently, then app crashes immediately after.

## Description

The Zod schema in `env.js` marks `CORS_ORIGIN` as `.optional()`, but `server/index.js` throws a fatal error if it's unset. The validation passes with no complaint, then the app crashes immediately — defeating early validation.

## Changes Implemented

Removed `.optional()` to match the actual runtime requirement:
```js
// Before
CORS_ORIGIN: z.string().optional(),
// After
CORS_ORIGIN: z.string(),
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified Zod now rejects missing CORS_ORIGIN with clear error

## Checklist

- [x] Code follows project standards
- [x] Ready for review