### PR TITLE
[Bug] NameError in Python portfolio service: httpx not imported in server-python/services/portfolio_service.py

### DIFF
--- a/server-python/services/portfolio_service.py
+++ b/server-python/services/portfolio_service.py
@@ -1,5 +1,6 @@
 import re
 import logging
+import httpx
 from typing import Any, Dict
 
 GITHUB_USERNAME_PATTERN = re.compile(r'^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$')


### PR DESCRIPTION
## Summary

Fixes #2703 — `NameError: name 'httpx' is not defined` when syncing GitHub/LeetCode portfolio metrics.

## Description

`portfolio_service.py` uses `httpx.AsyncClient`, `httpx.HTTPStatusError`, and `httpx.RequestError` but never imports `httpx`. The library is declared in `requirements.txt` but the import was missing.

## Changes Implemented

Added missing import:
```python
import httpx
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified httpx resolves correctly (listed in requirements.txt)

## Checklist

- [x] Code follows project standards
- [x] Ready for review