### PR TITLE
[Bug] Build failure: useAdvancedSearch.js imports lodash/debounce but lodash is not a dependency

### DIFF
--- a/website/src/hooks/useAdvancedSearch.js
+++ b/website/src/hooks/useAdvancedSearch.js
@@ -1,5 +1,14 @@
 import { useState, useEffect, useMemo } from 'react';
-import debounce from 'lodash/debounce';
+
+function debounce(fn, ms) {
+  let timer;
+  const debounced = (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), ms);
+  };
+  debounced.cancel = () => clearTimeout(timer);
+  return debounced;
+}
 
 /**
  * Hook for managing advanced search state and API interaction
@@ -62,6 +71,7 @@ export const useAdvancedSearch = () => {
 
   useEffect(() => {
     fetchResults(query, activeFilters);
+    return () => fetchResults.cancel();
   }, [query, activeFilters, fetchResults]);
 
   // Combined tracking tracking mechanism with functional updates and protection


### PR DESCRIPTION
## Summary

Fixes #2626 — Build failure from missing lodash dependency.

## Description

`useAdvancedSearch.js` imports `debounce` from `lodash/debounce` but lodash is not listed in `website/package.json`. This causes a module resolution failure at build time.

## Changes Implemented

Replaced the lodash import with a native debounce implementation inside the hook file:
```js
function debounce(fn, ms) {
  let timer;
  const debounced = (...args) => {
    clearTimeout(timer);
    timer = setTimeout(() => fn(...args), ms);
  };
  debounced.cancel = () => clearTimeout(timer);
  return debounced;
}
```

Also added cleanup via `fetchResults.cancel()` on useEffect teardown.

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified debounce works without lodash dependency

## Checklist

- [x] Code follows project standards
- [x] Ready for review