### PR TITLE
[Bug] TypeError in HeroSection.jsx: timeoutsRef is undefined — RippleBtn click crashes

### DIFF
--- a/website/src/pages/home/HeroSection.jsx
+++ b/website/src/pages/home/HeroSection.jsx
@@ -6,6 +6,12 @@ import { IconArrowRight, IconSpark, DynamicIcon } from '../../shared/Icons';
 /* â”€â”€ Ripple Button â”€â”€ */
 function RippleBtn({ cls, children, href, onClick }) {
   const ref = useRef(null);
+  const timeoutsRef = useRef([]);
+
+  useEffect(() => {
+    return () => timeoutsRef.current.forEach(clearTimeout);
+  }, []);
+
   const go = (e) => {
     const b = ref.current;
     if (!b) return;


### PR DESCRIPTION
## Summary

Fixes #2625 — Every ripple button click in HeroSection throws ReferenceError.

## Description

`RippleBtn` component pushes timeout IDs to `timeoutsRef.current` but `timeoutsRef` was never defined with `useRef`. Only `ref` was created (for the DOM element).

## Changes Implemented

Added missing ref and cleanup effect to `RippleBtn`:
```js
const timeoutsRef = useRef([]);

useEffect(() => {
  return () => timeoutsRef.current.forEach(clearTimeout);
}, []);
```

## Type of Change

- [x] Bug Fix

## Testing

### Manual Testing

- [x] Verified ripple buttons work without ReferenceError

## Checklist

- [x] Code follows project standards
- [x] Ready for review