### PR TITLE
feat: add missing aria label to blogcard.

### DIFF
--- a/website/src/shared/BlogCard.jsx
+++ b/website/src/shared/BlogCard.jsx
@@ -32,7 +32,7 @@ export default function BlogCard({ post, onClick }) {
               <DynamicIcon name="MessageCircle" size={14} /> {commentCount}
             </span>
           </div>
-          <button className="read-more-btn">
+          <button className="read-more-btn" aria-label={`Read more: ${title}`}>
             <DynamicIcon name="ArrowRight" size={16} />
           </button>
         </div>


### PR DESCRIPTION
## Summary

This PR improves the accessibility of the `BlogCard` component by adding a descriptive `aria-label` to the "Read More" button. The label dynamically includes the blog title, allowing screen readers to clearly announce the purpose of the button without changing the UI.

Fixes #2726

---

## Description

### Changes
- Added a dynamic `aria-label` to the "Read More" button.
- The label now reads: `Read more about <blog title>`.
- Improved accessibility for screen reader users.
- No visual or functional changes to the component.

---

## Checklist

- [x] Linked the related issue
- [x] Added accessibility improvement
- [x] No visual changes
- [x] Tested locally
- [x] Existing functionality remains unchanged
- [x] No breaking changes