### PR TITLE
fix: add attachOldState to admin users PUT route to capture previous role and permissions in audit log

### DIFF
--- a/server/repositories/usersRepository.js
+++ b/server/repositories/usersRepository.js
@@ -51,6 +51,16 @@ export const usersRepository = {
     });
   },
 
+  async getUserById(id) {
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        'SELECT id, username, display_name, email, admin_roles, created_at FROM users WHERE id = $1',
+        [id]
+      );
+      return rows[0] || null;
+    });
+  },
+
   async updateUser(id, updates) {
     return withDb(async (client) => {
       const fields = [];

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -5,6 +5,7 @@ import { adminAuthMiddleware } from '../middleware/adminAuthMiddleware.js';
 import * as coreTeamController from '../controllers/coreTeamController.js';
 import * as eventRegistrationController from '../controllers/eventRegistrationController.js';
 import * as usersController from '../controllers/usersController.js';
+import { usersRepository } from '../repositories/usersRepository.js';
 import * as attendanceController from '../controllers/attendanceController.js';
 import * as eventAnalyticsController from '../controllers/eventAnalyticsController.js';
 import { adminAuditMiddleware, attachOldState } from '../middleware/adminAuditMiddleware.js';
@@ -124,6 +125,7 @@ router.post(
 router.put(
   '/api/admin/users/:id',
   adminAuthMiddleware.requireAdmin,
+  attachOldState((req) => usersRepository.getUserById(req.params.id)),
   adminAuditMiddleware,
   usersController.adminUpdateUser
 );


### PR DESCRIPTION
<!-- missing before-state in audit log -->

# Summary
`PUT /api/admin/users/:id` was using `adminAuditMiddleware` without `attachOldState`, meaning the audit log recorded the new user state but had no record of previous role or permissions — a critical security auditing blind spot. Added `getUserById` to `usersRepository` and wired it into `attachOldState` before `adminAuditMiddleware`.

## Related Issue
Closes #2415

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added `getUserById` method to `server/repositories/usersRepository.js`
- Added `import { usersRepository }` to `server/routes/api.js`
- Added `attachOldState((req) => usersRepository.getUserById(req.params.id))` before `adminAuditMiddleware` on `PUT /api/admin/users/:id`

## Technical Details
### Backend
- `server/repositories/usersRepository.js` — added `getUserById` method
- `server/routes/api.js` — wired `attachOldState` to capture user before-state on update

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review