### PR TITLE
fix: prefix frontendUrl to OAuth error redirects to prevent 404 on auth failure

### DIFF
--- a/server/controllers/studentAuthController.js
+++ b/server/controllers/studentAuthController.js
@@ -9,10 +9,11 @@ export const googleAuth = passport.authenticate('google', {
 
 export const googleCallback = (req, res, next) => {
   passport.authenticate('google', { session: false }, (err, data, info) => {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
     if (err) return next(err);
     if (!data) {
       return res.redirect(
-        `/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`
+        `${frontendUrl}/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`
       );
     }
     res.cookie('ns_student_token', data.token, {
@@ -21,7 +22,6 @@ export const googleCallback = (req, res, next) => {
       sameSite: 'lax',
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
-    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
     return res.redirect(`${frontendUrl}/dashboard`);
   })(req, res, next);
 };
@@ -33,10 +33,11 @@ export const githubAuth = passport.authenticate('github', {
 
 export const githubCallback = (req, res, next) => {
   passport.authenticate('github', { session: false }, (err, data, info) => {
+    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
     if (err) return next(err);
     if (!data) {
       return res.redirect(
-        `/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`
+        `${frontendUrl}/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`
       );
     }
     res.cookie('ns_student_token', data.token, {
@@ -45,7 +46,6 @@ export const githubCallback = (req, res, next) => {
       sameSite: 'lax',
       maxAge: 7 * 24 * 60 * 60 * 1000,
     });
-    const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
     return res.redirect(`${frontendUrl}/dashboard`);
   })(req, res, next);
 };


### PR DESCRIPTION
# Summary
OAuth error callbacks in `googleCallback` and `githubCallback` were redirecting
failed auth attempts to `/login?error=...` — a relative path that resolved to
the backend server (port 8080), causing a 404. Moved `frontendUrl` declaration
above the error check so both success and error paths redirect to the correct
frontend URL.

## Related Issue
Closes #2408

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Moved `frontendUrl` declaration to the top of the `passport.authenticate` callback in both `googleCallback` and `githubCallback`
- Prefixed `${frontendUrl}` to the error redirect path in both callbacks

## Technical Details

### Frontend
N/A

### Backend
**File:** `server/controllers/studentAuthController.js`

Before (lines 14, 38):
```js
return res.redirect(`/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`);
```
After:
```js
const frontendUrl = process.env.FRONTEND_URL || 'http://localhost:5175';
return res.redirect(`${frontendUrl}/login?error=${encodeURIComponent(info?.message || 'Authentication failed')}`);
```

### Database
N/A

### API
N/A

### Infrastructure
N/A

## Screenshots

### Before
Error redirect hits `http://backend-server:8080/login` → 404

### After
Error redirect hits `http://localhost:5175/login?error=...` → correct frontend login page

## Testing

### Unit Tests
- [ ] N/A

### Integration Tests
- [ ] N/A

### E2E Tests
- [ ] N/A

### Manual Testing
- [x] Triggered OAuth auth failure manually — confirmed redirect now lands on frontend `/login` page with error query param

## Security Review
No security impact. Error message is already sanitized via `encodeURIComponent` before being passed as a query param.

## Accessibility Review
N/A

## Performance Impact
None.

## Breaking Changes
- [x] No Breaking Changes

## Deployment Notes
Ensure `FRONTEND_URL` env variable is correctly set in production. Defaults to `http://localhost:5175` if not set.

## Rollback Plan
Revert this commit. No DB or infra changes involved.

## Checklist
- [x] Code follows project standards
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [x] Ready for review