### PR TITLE
fix: local wrapAsync in forumController masks Zod validation errors as 500

### DIFF
--- a/server/controllers/forumController.js
+++ b/server/controllers/forumController.js
@@ -9,11 +9,7 @@ import {
 } from '../schemas/forumSchema.js';
 
 function wrapAsync(fn) {
-  return (req, res) =>
-    Promise.resolve(fn(req, res)).catch((e) => {
-      console.error('[forumController]', e);
-      return res.status(500).json({ error: e.message || 'Internal server error' });
-    });
+  return (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);
 }
 
 export const listCategories = wrapAsync(async (req, res) => {


### PR DESCRIPTION
# Summary
Local `wrapAsync` in `forumController.js` was catching all errors and hardcoding 500. Zod validation errors (e.g. missing `title` field) were swallowed instead of returning 400. Fixed by delegating to `next(err)` so global middleware handles it correctly.

## Related Issue
Fixes #2406

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Replaced local `wrapAsync` body with `catch(next)` to delegate error handling to global middleware

## Technical Details

### Backend
**File:** `server/controllers/forumController.js`

Before:
```js
function wrapAsync(fn) {
  return (req, res) =>
    Promise.resolve(fn(req, res)).catch((e) => {
      console.error('[forumController]', e);
      return res.status(500).json({ error: e.message || 'Internal server error' });
    });
}
```
After:
```js
function wrapAsync(fn) {
  return (req, res, next) =>
    Promise.resolve(fn(req, res, next)).catch(next);
}
```

### Frontend
N/A
### Database
N/A
### API
N/A
### Infrastructure
N/A

## Screenshots
### Before
`POST /api/forum/threads` with missing `title` → 500 Internal Server Error
### After
`POST /api/forum/threads` with missing `title` → 400 Bad Request

## Testing
### Manual Testing
- [x] Sent `POST /api/forum/threads` with missing `title` — confirmed 400 response

## Security Review
No impact.

## Accessibility Review
N/A

## Performance Impact
None.

## Breaking Changes
- [x] No Breaking Changes

## Deployment Notes
None.

## Rollback Plan
Revert this commit. No DB or infra changes.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review