### PR TITLE
fix: validate timestamps before formatting in StatusPage.jsx

### DIFF
--- a/website/src/pages/StatusPage.jsx
+++ b/website/src/pages/StatusPage.jsx
@@ -1,4 +1,19 @@
 import React, { useEffect, useState } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatStatusDate(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleString();
+}
+function formatStatusTime(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleTimeString();
+}
 import { getApiBase } from '../utils/runtimeConfig';
 import { motion } from 'framer-motion';
 import { Activity, ShieldAlert, CheckCircle, Clock, ArrowLeft } from 'lucide-react';
@@ -163,9 +178,8 @@ export default function StatusPage() {
                     </span>
                   </div>
                   <div className="text-xs text-gray-500 mb-3">
-                    Start: {new Date(incident.startedAt).toLocaleString()}
-                    {incident.resolvedAt &&
-                      ` | End: ${new Date(incident.resolvedAt).toLocaleString()}`}
+                    Start: {formatStatusDate(incident.startedAt)}
+                    {incident.resolvedAt && ` | End: ${formatStatusDate(incident.resolvedAt)}`}
                   </div>
                   <div className="space-y-2 mt-2">
                     {incident.updates.map((update, idx) => (
@@ -174,7 +188,7 @@ export default function StatusPage() {
                         className="text-sm text-gray-400"
                       >
                         <span className="text-xs text-gray-600 block">
-                          {new Date(update.timestamp).toLocaleTimeString()}
+                          {formatStatusTime(update.timestamp)}
                         </span>
                         {update.message}
                       </div>


### PR DESCRIPTION
## Description
`StatusPage.jsx` passed `incident.startedAt`, `incident.resolvedAt`, and `update.timestamp` directly into `new Date(...).toLocaleString()`/`toLocaleTimeString()` with no validation. If any of these fields were `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered to users on the public Status page.

Changes made:
- Added shared `formatStatusDate()` and `formatStatusTime()` helpers that check for a falsy value and validate the parsed date via `Number.isNaN(d.getTime())` before formatting
- Fall back to `"Unknown"` instead of rendering `"Invalid Date"` when the value can't be parsed
- Replaced all three unguarded inline date formatting call sites with the shared helpers
- Note: `new Date().toLocaleTimeString()` on line 81 (the "Last checked" timestamp) uses no arguments and is always valid — left unchanged
- Zero new TypeScript errors introduced

Fixes #2510

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings