### PR TITLE
https://github.com/Ayushh-Sharmaa/NexaSphere/compare/main...KaparthyReddy:NexaSphere:fix/team-member-modal-share-fallback

### DIFF
--- a/website/src/components/ShareHub/ShareHub.jsx
+++ b/website/src/components/ShareHub/ShareHub.jsx
@@ -45,7 +45,14 @@ export default function ShareHub({ isOpen, onClose, data }) {
 
   function handleNativeShare() {
     if (navigator.share) {
-      navigator.share({ title: shareTitle, url: shareUrl }).catch(() => {});
+      navigator.share({ title: shareTitle, url: shareUrl }).catch((err) => {
+        // User cancelled (AbortError) — no feedback needed.
+        // Any other failure (e.g. share target unavailable) falls back to
+        // copying the URL to clipboard so the user can still share manually.
+        if (err?.name !== 'AbortError' && navigator.clipboard) {
+          navigator.clipboard.writeText(shareUrl).catch(() => {});
+        }
+      });
     }
   }
 


### PR DESCRIPTION
## Description
`ShareHub.jsx`'s `handleNativeShare` called `navigator.share().catch(() => {})` with an empty catch block. If the native share sheet failed for any reason other than the user cancelling, the error was silently discarded with no fallback — the user had no way to share the link.

Changes made:
- `AbortError` (user explicitly cancelled the share sheet) is now explicitly ignored — no action needed in that case
- Any other failure now falls back to `navigator.clipboard.writeText(shareUrl)` so the user can still copy the URL and share manually
- Zero new TypeScript errors introduced

Fixes #2829

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings