### PR TITLE
fix: clear intervalRef before setting new interval in SystemHealthPage.jsx

### DIFF
--- a/website/src/pages/monitoring/SystemHealthPage.jsx
+++ b/website/src/pages/monitoring/SystemHealthPage.jsx
@@ -180,11 +180,21 @@ export default function SystemHealthPage() {
   }, [fetchData]);
 
   useEffect(() => {
+    // Clear any existing interval before setting a new one — prevents
+    // duplicate concurrent intervals if the effect re-runs (e.g. when
+    // refreshInterval or fetchData changes) before the previous cleanup fires.
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
     if (autoRefresh) {
       intervalRef.current = setInterval(fetchData, refreshInterval);
     }
     return () => {
-      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
     };
   }, [autoRefresh, refreshInterval, fetchData]);
 


### PR DESCRIPTION
## Description
The auto-refresh `useEffect` in `SystemHealthPage.jsx` set `intervalRef.current` to the new interval ID without first clearing the previous value. If the effect re-ran (e.g. when `refreshInterval` or `fetchData` changed) and the cleanup had already fired, `intervalRef.current` still held the old stale ID — the next cleanup call would pass this stale ID to `clearInterval` instead of the currently active one. Additionally, when `autoRefresh` was `false`, the cleanup cleared the interval but never reset `intervalRef.current` to `null`, leaving a dangling stale ID in the ref.

Changes made:
- Added an explicit `clearInterval` + `null` reset at the top of the effect before scheduling a new interval, preventing duplicate concurrent intervals if the effect re-runs
- Reset `intervalRef.current = null` in both the early clear and the cleanup return, so the ref always reflects the currently active interval or `null`
- Zero new TypeScript errors introduced

Fixes #2828

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings