### PR TITLE
fix: add explicit radix to parseInt in EventFeedbackForm.jsx

### DIFF
--- a/website/src/pages/EventFeedbackForm.jsx
+++ b/website/src/pages/EventFeedbackForm.jsx
@@ -61,7 +61,9 @@ const EventFeedbackForm = () => {
             min="1"
             max="5"
             value={formData.ratingOverall}
-            onChange={(e) => setFormData({ ...formData, ratingOverall: parseInt(e.target.value) })}
+            onChange={(e) =>
+              setFormData({ ...formData, ratingOverall: parseInt(e.target.value, 10) })
+            }
             className="w-full border-gray-300 rounded-md shadow-sm p-2 border"
             required
           />


### PR DESCRIPTION
## Description
`EventFeedbackForm.jsx` line 64 called `parseInt(e.target.value)` without a radix to parse the overall rating value from the input. Without an explicit radix, `parseInt` may behave unexpectedly with strings starting with `"0"`. MDN recommends always specifying the radix.

Changes made:
- Changed `parseInt(e.target.value)` to `parseInt(e.target.value, 10)` with an explicit radix, consistent with all other `parseInt` calls in the codebase
- Zero new TypeScript errors introduced

Fixes #2827

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings