### PR TITLE
fix: add explicit radix to parseInt calls in AdvancedCustomizer.jsx

### DIFF
--- a/website/src/components/portfolio/AdvancedCustomizer.jsx
+++ b/website/src/components/portfolio/AdvancedCustomizer.jsx
@@ -239,7 +239,7 @@ const AdvancedCustomizer = ({ currentConfig, onUpdate }) => {
                     value={currentConfig.spacing?.radius || 12}
                     onChange={(e) =>
                       updateConfig({
-                        spacing: { ...currentConfig.spacing, radius: parseInt(e.target.value) },
+                        spacing: { ...currentConfig.spacing, radius: parseInt(e.target.value, 10) },
                       })
                     }
                   />
@@ -267,7 +267,10 @@ const AdvancedCustomizer = ({ currentConfig, onUpdate }) => {
                     value={currentConfig.spacing?.padding || 28}
                     onChange={(e) =>
                       updateConfig({
-                        spacing: { ...currentConfig.spacing, padding: parseInt(e.target.value) },
+                        spacing: {
+                          ...currentConfig.spacing,
+                          padding: parseInt(e.target.value, 10),
+                        },
                       })
                     }
                   />


### PR DESCRIPTION
## Description
`AdvancedCustomizer.jsx` lines 242 and 270 called `parseInt(e.target.value)` without a radix to parse border radius and padding values from range inputs. Without an explicit radix, `parseInt` may behave unexpectedly with strings starting with `"0"`. MDN recommends always specifying the radix.

Changes made:
- Changed both `parseInt(e.target.value)` calls to `parseInt(e.target.value, 10)` with an explicit radix, consistent with all other `parseInt` calls in the codebase
- Zero new TypeScript errors introduced

Fixes #2826

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings