### PR TITLE
fix: replace key={idx} with key={match.projectId} in ProjectRecommendations.jsx

### DIFF
--- a/website/src/components/recommendations/ProjectRecommendations.jsx
+++ b/website/src/components/recommendations/ProjectRecommendations.jsx
@@ -118,7 +118,9 @@ export default function ProjectRecommendations({ onBack }) {
           <div className="recommendations-grid">
             {recommendations.map((match, idx) => {
               const matchedProject = projectsData.find((p) => p.id === match.projectId);
-              return <RecommendationCard key={idx} project={matchedProject} match={match} />;
+              return (
+                <RecommendationCard key={match.projectId} project={matchedProject} match={match} />
+              );
             })}
           </div>
         </div>


### PR DESCRIPTION
## Description
`ProjectRecommendations.jsx` used `key={idx}` (array index) for `RecommendationCard` components. Each card renders matched project data via `projectsData.find(p => p.id === match.projectId)`. When the recommendations list changed (filtered, sorted, or refreshed), React reused card components at the same index position rather than tracking by project identity — components at shifted indices could render stale project data from the previous render.

Changes made:
- Replaced `key={idx}` with `key={match.projectId}` so React correctly tracks each card by its stable project identifier, independent of its position in the list
- Zero new TypeScript errors introduced

Fixes #2825

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings