### PR TITLE
fix: replace key={idx} with key={chip} for match chips in RecommendationCard.jsx

### DIFF
--- a/website/src/components/recommendations/RecommendationCard.jsx
+++ b/website/src/components/recommendations/RecommendationCard.jsx
@@ -16,8 +16,8 @@ export default function RecommendationCard({ project, match }) {
 
         {/* Match Chips */}
         <div className="match-chips">
-          {match.matchChips.map((chip, idx) => (
-            <span key={idx} className="match-chip">
+          {match.matchChips.map((chip) => (
+            <span key={chip} className="match-chip">
               ✨ {chip}
             </span>
           ))}


### PR DESCRIPTION
## Description
`RecommendationCard.jsx` used `key={idx}` (array index) for match chip `<span>` elements. When the chip list changed between recommendation updates, React reused elements at the same index position rather than tracking by chip identity — chips at shifted positions could render stale labels from the previous list.

Changes made:
- Replaced `key={idx}` with `key={chip}` using the chip string itself as a stable identifier, since chip strings are unique within a match
- Removed the now-unused `idx` parameter from the `.map()` callback
- Zero new TypeScript errors introduced

Fixes #2823

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of my project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings