### PR TITLE
https://github.com/Ayushh-Sharmaa/NexaSphere/compare/main...KaparthyReddy:NexaSphere:fix/calendar-view-day-column-keys

### DIFF
--- a/website/src/components/events/CalendarView.jsx
+++ b/website/src/components/events/CalendarView.jsx
@@ -239,7 +239,7 @@ export default function CalendarView({ events: initialEvents, onEventClick, isAd
         {daysToRender.map((date, idx) => {
           const keyPrefix = `${date.getFullYear()}-${date.getMonth()}-${date.getDate()}`;
           return (
-            <div key={idx} className="day-column">
+            <div key={keyPrefix} className="day-column">
               <div className="time-slot-header">
                 {isDayView ? '' : daysOfWeek[idx]} {date.getDate()}
               </div>


### PR DESCRIPTION
## Description
`CalendarView.jsx` rendered day columns with `key={idx}` (array index) despite a stable `keyPrefix` date string (`YYYY-M-D`) already being computed on the very next line. When navigating between weeks or switching between day/week view, React reused column components at the same index position rather than tracking by date identity — columns could render stale event data from the previous view at the same index.

Changes made:
- Replaced `key={idx}` with `key={keyPrefix}` using the already-computed `YYYY-M-D` date string as a stable identifier — no new variables or logic needed since `keyPrefix` was already there
- Zero new TypeScript errors introduced

Fixes #2822

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings