### PR TITLE
fix: replace key={i} with stable composite key for alert items in SystemHealthPage.jsx

### DIFF
--- a/website/src/pages/monitoring/SystemHealthPage.jsx
+++ b/website/src/pages/monitoring/SystemHealthPage.jsx
@@ -255,8 +255,8 @@ export default function SystemHealthPage() {
 
         {alerts && alerts.length > 0 && (
           <div style={{ marginBottom: '24px' }}>
-            {alerts.map((alert, i) => (
-              <div key={i} style={alertStyle(alert.severity)}>
+            {alerts.map((alert) => (
+              <div key={`${alert.severity}-${alert.message}`} style={alertStyle(alert.severity)}>
                 <span style={{ fontSize: '16px' }}>
                   {alert.severity === 'critical' ? '🔴' : '🟡'}
                 </span>


### PR DESCRIPTION
## Description
`SystemHealthPage.jsx` rendered alert items with `key={i}` (array index). When an alert was dismissed or a new one was added via the auto-refresh cycle, React reused alert `<div>` elements at the same index position rather than tracking by alert identity — items at shifted indices could render stale severity badges or messages from the previous render.

Changes made:
- Replaced `key={i}` with `` key={`${alert.severity}-${alert.message}`} `` using a composite of severity and message as a stable identifier
- Removed the now-unused `i` parameter from the `.map()` callback
- Note: CPU `perCore` items at line 345 use `key={i}` correctly since core index IS the stable identity (Core 0, Core 1, etc.) — left unchanged
- Zero new TypeScript errors introduced

Fixes #2820

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings