### PR TITLE
fix: replace key={i} with key={f} for feature list items in SubscriptionPage.jsx

### DIFF
--- a/website/src/pages/subscription/SubscriptionPage.jsx
+++ b/website/src/pages/subscription/SubscriptionPage.jsx
@@ -219,8 +219,8 @@ export default function SubscriptionPage({ onBack }) {
                 )}
               </div>
               <ul style={styles.featureList}>
-                {tier.features.map((f, i) => (
-                  <li key={i} style={styles.featureItem}>
+                {tier.features.map((f) => (
+                  <li key={f} style={styles.featureItem}>
                     <span style={{ color: '#22c55e' }}>✓</span> {f}
                   </li>
                 ))}


### PR DESCRIPTION
## Description
`SubscriptionPage.jsx` rendered subscription tier feature list items with `key={i}` (array index). When switching between tiers with different feature lists, React reused `<li>` elements at the same index position rather than tracking by feature identity — items at shifted positions could render stale feature text from the previous tier.

Changes made:
- Replaced `key={i}` with `key={f}` using the feature string itself as a stable identifier, since feature strings are unique within a tier
- Removed the now-unused `i` parameter from the `.map()` callback
- Zero new TypeScript errors introduced

Fixes #2817

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings