### PR TITLE
fix: validate timestamps before formatting in EventPlanningPage.jsx

### DIFF
--- a/website/src/pages/events/EventPlanningPage.jsx
+++ b/website/src/pages/events/EventPlanningPage.jsx
@@ -1,4 +1,19 @@
 import { useState, useEffect, useCallback } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatDate(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleDateString();
+}
+function formatDateTime(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleString();
+}
 import apiClient from '../../utils/apiClient';
 import { getApiBase, buildUrl } from '../../utils/runtimeConfig';
 import { initializeSocket, getSocket, joinRoom, leaveRoom } from '../../utils/socketClient';
@@ -282,7 +297,7 @@ export default function EventPlanningPage({ event, onBack }) {
                 )}
                 {task.deadline && (
                   <div style={{ fontSize: 11, color: 'var(--t3)' }}>
-                    Due: {new Date(task.deadline).toLocaleDateString()}
+                    Due: {formatDate(task.deadline)}
                   </div>
                 )}
                 <div style={{ display: 'flex', gap: 4, marginTop: 8 }}>
@@ -375,7 +390,7 @@ export default function EventPlanningPage({ event, onBack }) {
                     )}
                     {task.deadline && (
                       <span>
-                        Deadline: <strong>{new Date(task.deadline).toLocaleDateString()}</strong>
+                        Deadline: <strong>{formatDate(task.deadline)}</strong>
                       </span>
                     )}
                   </div>
@@ -392,7 +407,7 @@ export default function EventPlanningPage({ event, onBack }) {
                       >
                         <strong>{c.author || 'Anonymous'}</strong>: {c.content}
                         <div style={{ fontSize: 11, color: 'var(--t3)' }}>
-                          {new Date(c.createdAt).toLocaleString()}
+                          {formatDateTime(c.createdAt)}
                         </div>
                       </div>
                     ))}
@@ -482,7 +497,7 @@ export default function EventPlanningPage({ event, onBack }) {
                   >
                     <strong>{log.user}</strong> {log.details}
                     <div style={{ color: 'var(--t3)', fontSize: 11 }}>
-                      {new Date(log.timestamp).toLocaleString()}
+                      {formatDateTime(log.timestamp)}
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Description
`EventPlanningPage.jsx` passed API-supplied timestamps directly into `new Date(...).toLocaleDateString()`/`toLocaleString()` at four call sites with no validation. If any of these fields were `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered to users in task cards, task detail view, comments list, and activity log.

Changes made:
- Added shared `formatDate()` and `formatDateTime()` helpers that check for a falsy value and validate via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown"` otherwise
- Replaced all four unguarded inline call sites (lines 285, 378, 395, 485) with the shared helpers
- `new Date().toISOString()` at line 90 uses no arguments and is always valid — left unchanged
- Zero new TypeScript errors introduced

Fixes #2818

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings