### PR TITLE
fix: improve image accessibility in ShareHub

### DIFF
--- a/website/src/components/ShareHub/ShareHub.jsx
+++ b/website/src/components/ShareHub/ShareHub.jsx
@@ -73,7 +73,13 @@ export default function ShareHub({ isOpen, onClose, data }) {
         </div>
 
         <div className="sharehub-preview">
-          {data.image && <img src={data.image} alt="" className="sharehub-preview-img" />}
+          {data.image && (
+            <img
+              src={data.image}
+              alt={`Preview image for ${data.title}`}
+              className="sharehub-preview-img"
+            />
+          )}
           <div>
             <p className="sharehub-preview-title">{data.title}</p>
             {data.subtitle && <p className="sharehub-preview-sub">{data.subtitle}</p>}


### PR DESCRIPTION
# Description

This PR improves the accessibility of the `ShareHub` component by fixing the preview image's accessibility attributes.

The image previously used an empty `alt=""` attribute without `aria-hidden="true"`, which could lead to a poor experience for screen reader users. This PR updates the image to follow accessibility best practices by ensuring it either:

* Uses `aria-hidden="true"` if the image is decorative, or
* Provides meaningful alternative text if the image is informative.

No visual or functional changes were introduced.

---

## Related Issue

Closes #2842

---

## Type of Change

* [x] Bug Fix
 *[ ] Feature
 *[ ] Documentation
 *[ ] Refactoring
 *[ ] UI/UX Improvement

---

## Changes Implemented

* Updated the image accessibility attributes in `ShareHub.jsx`.
* Improved screen reader compatibility.
* Preserved the existing UI and functionality.

---

## Checklist

 *[x] Code follows the project's coding standards.
 *[x] Only the required file(s) were modified.
 *[x] No unrelated changes were introduced.
 *[x] No visual changes were made.
 *[x] Accessibility best practices were followed.
 *[x] Lint/build checks pass locally.
 *[x] Ready for review.
