### PR TITLE
fix: prevent missed Socket.IO subscriptions in RealTimeDashboard

### DIFF
--- a/admin-dashboard/src/pages/RealTimeDashboard.jsx
+++ b/admin-dashboard/src/pages/RealTimeDashboard.jsx
@@ -55,12 +55,18 @@ export default function RealTimeDashboard() {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    socket.on('connect', () => {
+    const handleConnect = () => {
       setConnected(true);
       socket.emit('analytics:subscribe', 'all');
       socket.emit('analytics:request:metrics', 'all');
       socket.emit('analytics:request:trends', { eventId: 'all', timeWindow: '7 days' });
-    });
+    };
+
+    if (socket.connected) {
+      handleConnect();
+    }
+
+    socket.on('connect', handleConnect);
 
     socket.on('disconnect', () => setConnected(false));
 


### PR DESCRIPTION
## Summary

The `RealTimeDashboard` could miss subscribing to real-time analytics if the Socket.IO connection was established before the component mounted.

This PR fixes the race condition by checking whether the socket is already connected and subscribing immediately, while still registering the normal `connect` event listener for future reconnections.

## Related Issue

Closes #2849

## Type of Change

* [ ] Feature
* [x] Bug Fix
* [ ] UI/UX Improvement
* [ ] Performance Optimization
* [ ] Security Enhancement
* [ ] Refactoring
* [ ] Documentation
* [ ] Testing
* [ ] Infrastructure
* [ ] Integration

## Changes Implemented

* Added a reusable `handleConnect` function for subscription logic.
* Immediately invokes `handleConnect()` when `socket.connected` is already `true`.
* Registers the same handler for future `connect` events.
* Preserves existing real-time analytics subscription behavior.

## Technical Details

**Frontend**

* `admin-dashboard/src/pages/RealTimeDashboard.jsx`

  * Fixed the Socket.IO connection race condition.
  * Ensured analytics subscriptions are established regardless of when the component mounts.

## Testing

* Verified subscriptions are sent when the socket is already connected before the component mounts.
* Verified subscriptions continue to work on subsequent reconnect events.

## Checklist

* [x] Code follows project standards.
* [x] Ready for review.
