### PR TITLE
fix: prevent missed Socket.IO subscriptions in RealTimeDashboard

### DIFF
--- a/admin-dashboard/src/pages/RealTimeDashboard.jsx
+++ b/admin-dashboard/src/pages/RealTimeDashboard.jsx
@@ -55,12 +55,18 @@ export default function RealTimeDashboard() {
   const [connected, setConnected] = useState(false);
 
   useEffect(() => {
-    socket.on('connect', () => {
+    const handleConnect = () => {
       setConnected(true);
       socket.emit('analytics:subscribe', 'all');
       socket.emit('analytics:request:metrics', 'all');
       socket.emit('analytics:request:trends', { eventId: 'all', timeWindow: '7 days' });
-    });
+    };
+
+    if (socket.connected) {
+      handleConnect();
+    }
+
+    socket.on('connect', handleConnect);
 
     socket.on('disconnect', () => setConnected(false));
 


### PR DESCRIPTION
## Description

### Summary

This PR fixes a race condition in `RealTimeDashboard` where the Socket.IO client could connect before the component registers its `connect` listener.

### Problem

If the socket is already connected before the component mounts, the `connect` event has already fired, so the dashboard never emits the analytics subscription events.

### Solution

* Added a reusable `handleConnect` function.
* Immediately invoke `handleConnect()` when `socket.connected` is already `true`.
* Register the same handler for future `connect` events to support reconnects.

### Related Issue

Closes #2849

## Type of Change

* [x] Bug fix

## Testing

* [x] Verified subscriptions are emitted when the socket is already connected.
* [x] Verified subscriptions continue to work after reconnects.

## Checklist

* [x] My code follows the project style.
* [x] I have tested my changes.
* [x] This PR addresses the linked issue.
