### PR TITLE
Fix useSearch hook to return apiError

### DIFF
--- a/website/src/hooks/useSearch.js
+++ b/website/src/hooks/useSearch.js
@@ -1,0 +1,1 @@
+return { query, setQuery, filter, setFilter, results, loading, clearSearch, apiError };


### PR DESCRIPTION
## What was broken
The `useSearch` hook did not return the `apiError` state, resulting in silent search failures.
## What changed
The `useSearch` hook now returns the `apiError` state.
## How to test
Test the `useSearch` hook by intentionally causing a search failure and verifying that the `apiError` state is returned and displayed to the user.

---
_Opened by autonomous agent. Human review required before merge._