### PR TITLE
fix: show error state when activity events loading fails

### DIFF
--- a/admin-dashboard/src/pages/ActivityEventsManager.jsx
+++ b/admin-dashboard/src/pages/ActivityEventsManager.jsx
@@ -25,14 +25,17 @@ export function ActivityEventsManager() {
   const [deleting, setDeleting] = useState(null);
   const [deleteTarget, setDeleteTarget] = useState(null);
   const [deleteError, setDeleteError] = useState('');
+  const [error, setError] = useState('');
 
   const loadEvents = useCallback(async (key) => {
     setLoading(true);
+    setError('');
     try {
       const data = await api.activityEvents.getAll(key);
       setEvents(data?.events ?? []);
-    } catch {
+    } catch (e) {
       setEvents([]);
+      setError(e.message || 'Failed to load activity events.');
     } finally {
       setLoading(false);
     }
@@ -105,7 +108,9 @@ export function ActivityEventsManager() {
 
       {loading && <Skeleton height={64} count={3} />}
 
-      {!loading && (
+      {error && <div className="page-error">{error}</div>}
+
+      {!loading && !error && (
         <div className="list">
           {events.length === 0 && (
             <div className="empty-state">No events for {selectedName} yet.</div>


### PR DESCRIPTION
# Summary

Displays a visible error message when loading activity events fails instead of silently replacing the events list with an empty array.

## Related Issue

Fixes #2851

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Added an `error` state to track API failures.
- Reset the error state before each request.
- Stored the API error message when loading fails.
- Rendered a visible error message instead of silently showing an empty list.
- Prevented the events list from rendering while an error is present.

## Technical Details

### Frontend

- Updated `admin-dashboard/src/pages/ActivityEventsManager.jsx`.
- Added UI error handling for failed activity event requests.

### Backend

- No changes.

### Database

- No changes.

### API

- No changes.

### Infrastructure

- No changes.

## Screenshots

### Before

API failures silently cleared the events list with no user feedback.

### After

A visible error message is displayed when loading activity events fails.

## Testing

### Unit Tests

- [ ] Not applicable

### Integration Tests

- [ ] Not applicable

### E2E Tests

- [ ] Not applicable

### Manual Testing

- [x] Simulated an API failure and verified that the error message is displayed.
- [x] Verified that the events list renders normally when the request succeeds.

## Security Review

No security impact.

## Accessibility Review

The error message is rendered in the UI and is accessible to users.

## Performance Impact

Negligible.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes

No special deployment steps required.

## Rollback Plan

Revert this commit if necessary.

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [x] Ready for review