### PR TITLE
fix: remove duplicate matchedUser declaration in adminAuthMiddleware (#2848)

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -405,7 +405,6 @@ async function login(req, res) {
 
     await clearLoginAttempts(ip);
 
-    const matchedUser = adminUsers.find((user) => safeEqual(user.username, u)) || adminUsers[0];
     const role = matchedUser.role || 'SuperAdmin';
     const scopes = getScopesForRole(role);
     const securityAccount = await getOrCreateAdminSecurityAccount(u, matchedUser.email || u);


### PR DESCRIPTION
# Description

`const matchedUser` was declared twice in the same scope inside `login()` in `server/middleware/adminAuthMiddleware.js` (lines 393 and 408), which is a SyntaxError at parse time. Since this file is imported by `server/index.js` and the admin route modules, the parse failure crashed the server at startup. This PR removes the duplicate declaration, keeping the constant-time username/password check and dropping the unsafe `|| adminUsers[0]` fallback.

# Summary
 
`const matchedUser` was declared twice in the same scope inside `login()` in `server/middleware/adminAuthMiddleware.js` (lines 393 and 408), which is a SyntaxError at parse time. Since this file is imported by `server/index.js` and the admin route modules, the parse failure crashed the server at startup. This removes the duplicate declaration.
 
## Related Issue
 
Fixes #2848
 
## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration
## Changes Implemented
 
The two `matchedUser` declarations were leftover from a merge: the first (line 393) does a constant-time hash comparison of both username and password, the second (line 408) re-finds the user with `safeEqual` on the username only and falls back to `adminUsers[0]`. I kept the first timing-safe both-field check and removed the duplicate second one. The rest of `login()` reuses the `matchedUser` from the first block, and `u` is still in scope for the downstream calls, so nothing else changes.
 
Dropping the `|| adminUsers[0]` fallback is also safer, since it would otherwise resolve to the first admin user when no match was found.
 
## Technical Details
 
### Frontend
 
n/a
 
### Backend
 
Removed one duplicate `const matchedUser` line in `server/middleware/adminAuthMiddleware.js`. No behavior change beyond eliminating the parse error and the unsafe fallback.
 
### Database
 
n/a
 
### API
 
n/a
 
### Infrastructure
 
n/a
 
## Screenshots
 
### Before
 
n/a
 
### After
 
n/a
 
## Testing
 
### Unit Tests
- [x] `node --test test/adminAuth.test.js` passes (12/12). Before the fix the suite could not load the module because of the parse error.
### Integration Tests
- [ ]
### E2E Tests
- [ ]
### Manual Testing
- [x] `node --check server/middleware/adminAuthMiddleware.js` parses cleanly (no SyntaxError).
## Security Review
 
The retained check is the constant-time comparison of both username and password (`crypto.timingSafeEqual` on SHA-256 hashes). Removing the second declaration also removes the `|| adminUsers[0]` fallback, which could otherwise grant the first admin user on a non-match.
 
## Accessibility Review
 
n/a
 
## Performance Impact
 
None.
 
## Breaking Changes
- [x] No Breaking Changes
- [ ] Breaking Changes Documented
## Deployment Notes
 
None.
 
## Rollback Plan
 
Revert this commit; it is a single-line change.
 
## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [ ] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [ ] CI/CD passing
- [ ] Ready for review