### PR TITLE
fix: remove duplicate read-only imports and routes

### DIFF
--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -24,12 +24,6 @@ import {
   createIncidentLog,
 } from '../routes/readOnlyMode.js';
 import {
-  activateReadOnlyMode,
-  deactivateReadOnlyMode,
-  getReadOnlyStatus,
-  createIncidentLog,
-} from '../utils/readOnlyMode.js';
-import {
   getServiceStatus,
   getIncidentTimeline,
   getMaintenanceSchedule,
@@ -119,22 +113,6 @@ router.get('/api/admin/database-recovery', adminAuth, (req, res) => {
 
 router.get('/api/admin/database-audit-log', adminAuth, (req, res) => {
   res.json(createRecoveryAuditLog());
-});
-
-router.get('/api/admin/read-only-status', adminAuth, (req, res) => {
-  res.json(getReadOnlyStatus());
-});
-
-router.post('/api/admin/read-only-enable', adminAuth, (req, res) => {
-  res.json(activateReadOnlyMode());
-});
-
-router.post('/api/admin/read-only-disable', adminAuth, (req, res) => {
-  res.json(deactivateReadOnlyMode());
-});
-
-router.get('/api/admin/read-only-log', adminAuth, (req, res) => {
-  res.json(createIncidentLog());
 });
 
 router.get('/api/admin/read-only-status', adminAuth, (req, res) => {


### PR DESCRIPTION
# Summary

Removed duplicate `readOnlyMode` imports and duplicate read-only route definitions from the backend admin routes to prevent duplicate declaration errors during server startup.

## Related Issue

Fixes #2271

## Type of Change

* [ ] Feature
* [x] Bug Fix
* [ ] UI/UX Improvement
* [ ] Performance Optimization
* [ ] Security Enhancement
* [ ] Refactoring
* [ ] Documentation
* [ ] Testing
* [ ] Infrastructure
* [ ] Integration

## Changes Implemented

* Removed the duplicate import of `activateReadOnlyMode`, `deactivateReadOnlyMode`, `getReadOnlyStatus`, and `createIncidentLog` from `../utils/readOnlyMode.js`.
* Removed duplicate read-only route definitions from `server/routes/admin.js`.
* Ensured only a single set of read-only endpoints remains.

## Technical Details

### Frontend

* No frontend changes.

### Backend

* Updated `server/routes/admin.js`.
* Removed duplicate imports and duplicate route handlers.

### Database

* No database changes.

### API

* No API changes.
* Existing endpoints remain unchanged.

### Infrastructure

* No infrastructure changes.

## Screenshots

### Before

N/A

### After

N/A

## Testing

### Unit Tests

* [ ] Not applicable

### Integration Tests

* [ ] Not run

### E2E Tests

* [ ] Not run

### Manual Testing

* [x] Verified duplicate imports and duplicate route definitions were removed.

## Security Review

No security impact.

## Accessibility Review

Not applicable.

## Performance Impact

No performance impact.

## Breaking Changes

* [x] No Breaking Changes
* [ ] Breaking Changes Documented

## Deployment Notes

No special deployment steps required.

## Rollback Plan

Revert this commit if necessary.

## Checklist

* [x] Code follows project standards
* [ ] Tests added or updated
* [ ] Documentation updated
* [x] Security reviewed
* [ ] Accessibility reviewed
* [x] Performance validated
* [ ] CI/CD passing
* [x] Ready for review
