### PR TITLE
fix: derive upload extension from validated mimetype to prevent stored XSS (#2932)

### DIFF
--- a/server/middleware/uploadMiddleware.js
+++ b/server/middleware/uploadMiddleware.js
@@ -10,11 +10,29 @@ try {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
 } catch (_) {}
 
+const EXT_BY_MIME = {
+  'application/pdf': '.pdf',
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'application/zip': '.zip',
+  'application/x-zip-compressed': '.zip',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document': '.docx',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation': '.pptx',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': '.xlsx',
+  'text/plain': '.txt',
+  'text/markdown': '.md',
+  'application/json': '.json',
+};
+
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),
   filename: (_req, file, cb) => {
     const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1e9);
-    const ext = path.extname(file.originalname) || '';
+    // Derive the extension from the validated mimetype, never the untrusted
+    // filename, so an attacker can't store executable content as .html/.js/.svg.
+    const ext = EXT_BY_MIME[file.mimetype] || '.bin';
     cb(null, `${uniqueSuffix}${ext}`);
   },
 });


### PR DESCRIPTION
# Summary

The file upload middleware derived the on-disk extension from the untrusted original filename, so an attacker could store executable content (`.html`, `.js`, `.svg`) that is then served from `/uploads` and runs in the site's origin (stored XSS). This derives the stored extension from the validated mimetype instead.

## Description

In `server/middleware/uploadMiddleware.js`, the multer `filename` callback used `path.extname(file.originalname)` for the stored extension. Combined with `text/plain` / `text/markdown` / `application/json` having empty signature arrays in `MAGIC_BYTES` (so `validateMagicBytes` returns `true` without checking content), an attacker could upload a file with `mimetype: text/plain` and `filename: payload.html`: it passes `fileFilter` and the magic-byte check, and is written to disk as `.html`. Served statically from `/uploads`, it renders as `text/html` in the app's origin. A companion `.js` uploaded the same way is permitted by `script-src 'self'`, defeating the CSP for this vector.

This maps each accepted mimetype to a fixed, safe extension (`EXT_BY_MIME`) and uses it in the `filename` callback instead of the untrusted filename:

```js
const ext = EXT_BY_MIME[file.mimetype] || '.bin';
```

So an upload declared as `text/plain` is stored as `.txt` regardless of the original filename, and can no longer be served as executable HTML/JS. Types that aren't in the map fall back to `.bin`. The other unvalidated text types (`text/markdown`, `application/json`) now get `.md` / `.json`, which also don't execute.

The issue notes that fix (1) alone (this change) closes the reported vector, which is what this PR does.

## Related Issue

Fixes #2932

## Type of Change
- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Added an `EXT_BY_MIME` map (accepted mimetype to safe extension) in `server/middleware/uploadMiddleware.js`.
- Changed the multer `filename` callback to derive the stored extension from `file.mimetype` via that map, instead of `path.extname(file.originalname)`.

## Technical Details

### Backend

The stored filename is now `<uniqueSuffix><safeExt>` where `safeExt` comes from the validated mimetype. No change to `fileFilter`, `validateMagicBytes`, or the upload routes.

### Frontend / Database / API / Infrastructure

n/a

## Screenshots

### Before / After

n/a (backend middleware change)

## Testing

### Unit Tests
- [ ]

### Integration Tests
- [ ]

### E2E Tests
- [ ]

### Manual Testing
- [x] Verified the mapping: a `text/plain` upload (the injection vector) is stored as `.txt` rather than `.html`/`.js`, legitimate types keep correct extensions, and unknown types fall back to `.bin`.

## Security Review

Closes the stored-XSS vector described in the issue: attacker-controlled content can no longer be written to disk with an executable extension, so it can't be served as `text/html` or loaded as a same-origin script from `/uploads`.

Note on defense-in-depth: the issue also recommends serving `/uploads` with `Content-Disposition: attachment` and a neutral content type (fix 3). I kept this PR to the single middleware change since fix (1) alone closes the reported vector. The static mount in `server/index.js` currently has some merge-conflict residue around it (bare branch-name lines and duplicated CSP directives), so I did not want to touch that file as part of a security fix. Happy to follow up on the forced-download headers separately if you'd like, ideally once that residue is cleaned up.

## Accessibility Review

n/a

## Performance Impact

None.

## Breaking Changes
- [x] No Breaking Changes
- [ ] Breaking Changes Documented

Note: stored files now use an extension derived from the mimetype rather than the original filename. Since uploads are referenced by their stored URL (`/uploads/<suffix><ext>`) returned by the upload endpoint, this does not affect how files are retrieved.

## Deployment Notes

None.

## Rollback Plan

Revert this commit; it restores the previous filename behavior.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [ ] CI/CD passing
- [ ] Ready for review