### PR TITLE
feat(activities): add difficulty level filter chips (#1491)

### DIFF
--- a/website/src/data/activities/index.js
+++ b/website/src/data/activities/index.js
@@ -28,6 +28,7 @@ export const activities = [
   {
     ...hackathon,
     id: 1,
+    difficultyLevel: 'intermediate',
     chips: ['Team Event', 'Coding', 'Innovation', 'Prizes'],
     features: [
       '24–48 hour team sprints',
@@ -39,6 +40,7 @@ export const activities = [
   {
     ...codathon,
     id: 2,
+    difficultyLevel: 'advanced',
     chips: ['Competitive', 'Algorithms', 'DSA', 'Leaderboard'],
     features: [
       'Multi-round elimination format',
@@ -50,6 +52,7 @@ export const activities = [
   {
     ...ideathon,
     id: 3,
+    difficultyLevel: 'beginner',
     chips: ['No-Code', 'Creativity', 'Pitching', 'Strategy'],
     features: [
       'Open to all branches',
@@ -61,6 +64,7 @@ export const activities = [
   {
     ...promptathon,
     id: 4,
+    difficultyLevel: 'beginner',
     chips: ['Prompt Engineering', 'AI Tools', 'Creative Thinking', 'Problem Solving'],
     features: [
       'Multi-round prompt battles',
@@ -72,6 +76,7 @@ export const activities = [
   {
     ...workshop,
     id: 5,
+    difficultyLevel: 'beginner',
     chips: ['New Technologies', 'Practical Skills', 'Tool Mastery', 'Applied Learning'],
     features: [
       'Live coding sessions',
@@ -83,6 +88,7 @@ export const activities = [
   {
     ...insightSession,
     id: 6,
+    difficultyLevel: 'beginner',
     chips: ['Career', 'Industry Trends', 'Panels', 'Networking'],
     features: [
       'Expert & alumni speakers',
@@ -94,6 +100,7 @@ export const activities = [
   {
     ...openSourceDay,
     id: 7,
+    difficultyLevel: 'beginner',
     chips: ['Git', 'Open Source', 'Code Review', 'Documentation'],
     features: [
       'First-PR guidance',
@@ -105,6 +112,7 @@ export const activities = [
   {
     ...techDebate,
     id: 8,
+    difficultyLevel: 'intermediate',
     chips: ['Public Speaking', 'Critical Thinking', 'Tech Topics', 'Audience Vote'],
     features: [
       'Structured Oxford-style format',
@@ -113,4 +121,10 @@ export const activities = [
       'Audience participation & vote',
     ],
   },
+];
+
+export const difficultyLevels = [
+  { value: 'beginner', label: 'Beginner' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
 ];

--- a/website/src/pages/activities/ActivitiesPage.jsx
+++ b/website/src/pages/activities/ActivitiesPage.jsx
@@ -1,5 +1,5 @@
-import { useEffect, useRef } from 'react';
-import { activities } from '../../data/activities';
+import { useEffect, useRef, useState, useMemo } from 'react';
+import { activities, difficultyLevels } from '../../data/activities';
 import { BannerOrbs } from '../../shared/MotionLayer';
 import Footer from '../../shared/Footer';
 import { DynamicIcon } from '../../shared/Icons';
@@ -98,6 +98,23 @@ const activityDetails = {
   },
 };
 
+const difficultyColors = {
+  beginner: '#4CAF50',
+  intermediate: '#FF9800',
+  advanced: '#F44336',
+};
+
+const difficultyBadgeStyles = Object.fromEntries(
+  Object.entries(difficultyColors).map(([level, color]) => [
+    level,
+    { background: `${color}18`, color, border: `1px solid ${color}35` },
+  ])
+);
+
+function difficultyLabel(level) {
+  return difficultyLevels.find((d) => d.value === level)?.label || level;
+}
+
 function ActivityCard({ a, idx, onNavigate }) {
   const ref = useRef(null);
   const details = activityDetails[a.title] || {};
@@ -179,6 +196,25 @@ function ActivityCard({ a, idx, onNavigate }) {
       >
         {a.title}
       </div>
+      {a.difficultyLevel && (
+        <span
+          className={`ns-difficulty-badge ns-difficulty-${a.difficultyLevel}`}
+          style={{
+            display: 'inline-block',
+            fontSize: '.62rem',
+            fontWeight: 700,
+            padding: '3px 10px',
+            borderRadius: '20px',
+            marginBottom: '12px',
+            textTransform: 'uppercase',
+            letterSpacing: '.05em',
+            fontFamily: "'Space Mono', monospace",
+            ...difficultyBadgeStyles[a.difficultyLevel],
+          }}
+        >
+          {difficultyLabel(a.difficultyLevel)}
+        </span>
+      )}
       <p
         style={{
           fontSize: '.88rem',
@@ -303,6 +339,35 @@ function ActivityCard({ a, idx, onNavigate }) {
 }
 
 export default function ActivitiesPage({ onNavigate, onBack }) {
+  const [selectedDifficulties, setSelectedDifficulties] = useState(() => {
+    const params = new URLSearchParams(window.location.search);
+    const raw = params.get('difficulty');
+    return raw ? raw.split(',').filter(Boolean) : [];
+  });
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    if (selectedDifficulties.length > 0) {
+      params.set('difficulty', selectedDifficulties.join(','));
+    } else {
+      params.delete('difficulty');
+    }
+    const query = params.toString();
+    const newUrl = window.location.pathname + (query ? `?${query}` : '') + window.location.hash;
+    window.history.replaceState({}, '', newUrl);
+  }, [selectedDifficulties]);
+
+  const toggleDifficulty = (value) => {
+    setSelectedDifficulties((prev) =>
+      prev.includes(value) ? prev.filter((v) => v !== value) : [...prev, value]
+    );
+  };
+
+  const filteredActivities = useMemo(() => {
+    if (selectedDifficulties.length === 0) return activities;
+    return activities.filter((a) => selectedDifficulties.includes(a.difficultyLevel));
+  }, [selectedDifficulties]);
+
   useEffect(() => {
     window.scrollTo({ top: 0 });
     const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
@@ -414,12 +479,88 @@ export default function ActivitiesPage({ onNavigate, onBack }) {
       <div className="container">
         <div
           style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '10px',
+            marginBottom: '28px',
+            alignItems: 'center',
+          }}
+        >
+          <span
+            style={{
+              fontSize: '.78rem',
+              color: 'var(--t2)',
+              fontWeight: 600,
+              marginRight: '4px',
+            }}
+          >
+            Filter by difficulty:
+          </span>
+          {difficultyLevels.map((d) => {
+            const active = selectedDifficulties.includes(d.value);
+            const color = difficultyColors[d.value] || 'var(--c1)';
+            return (
+              <button
+                key={d.value}
+                onClick={() => toggleDifficulty(d.value)}
+                aria-pressed={active}
+                style={{
+                  padding: '7px 16px',
+                  borderRadius: '50px',
+                  fontSize: '.8rem',
+                  fontWeight: 600,
+                  border: `1px solid ${active ? color : 'var(--bdr)'}`,
+                  background: active ? `${color}20` : 'var(--card)',
+                  color: active ? color : 'var(--t2)',
+                  cursor: 'pointer',
+                  transition: 'all .15s',
+                  fontFamily: "'Rajdhani', sans-serif",
+                }}
+              >
+                {d.label}
+              </button>
+            );
+          })}
+          {selectedDifficulties.length > 0 && (
+            <button
+              onClick={() => setSelectedDifficulties([])}
+              style={{
+                padding: '7px 14px',
+                borderRadius: '50px',
+                fontSize: '.78rem',
+                border: '1px solid var(--bdr)',
+                background: 'transparent',
+                color: 'var(--t2)',
+                cursor: 'pointer',
+                fontFamily: "'Rajdhani', sans-serif",
+              }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {filteredActivities.length === 0 && (
+          <p
+            style={{
+              textAlign: 'center',
+              color: 'var(--t2)',
+              padding: '40px 0',
+              fontSize: '.95rem',
+            }}
+          >
+            No activities match the selected difficulty filters.
+          </p>
+        )}
+
+        <div
+          style={{
             display: 'grid',
             gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))',
             gap: '24px',
           }}
         >
-          {activities.map((a, i) => (
+          {filteredActivities.map((a, i) => (
             <ActivityCard key={a.id} a={a} idx={i} onNavigate={onNavigate} />
           ))}
         </div>


### PR DESCRIPTION
Closes #1491

## Description
Fixes #1491 — adds difficulty level filtering to the Activities page.

Adds `difficultyLevel` field to all 8 activities (`data/activities/index.js`) and a `difficultyLevels` export (beginner/intermediate/advanced), mirroring the existing pattern in `resourcesData.js`.

On `ActivitiesPage.jsx`:
- Difficulty badge shown on each activity card
- Toggleable filter chips supporting multiple simultaneous selections (not a single-select dropdown, per the issue's "Multiple filters can be combined" requirement)
- Filter state persists in the URL via `?difficulty=level1,level2` using `URLSearchParams` + `window.history.replaceState`, matching the pattern used in `components/dashboard/SlackSettings.jsx`
- "Clear filters" button and empty-state message when no activities match

### ⚠️ Note on AC #1
"Add difficulty field to activity creation form (admin)" is **not implemented** — no admin activity-creation flow exists anywhere in the codebase (confirmed via search of `components/admin`). Activities are static entries in `data/activities/index.js`, not admin-created content. Flagging this rather than silently skipping it — happy to build an admin form separately if wanted, but that's a much larger, distinct feature.

## Related Issue
Fixes #1491

## Type of Change
- [ ] Feature
- [x] UI/UX Improvement
- [ ] Bug Fix
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
See Summary above.

## Technical Details
### Frontend
`src/data/activities/index.js` and `src/pages/activities/ActivitiesPage.jsx` only. No backend, database, or API changes.

### Backend
N/A

### Database
N/A

### API
N/A

### Infrastructure
N/A

## Screenshots
### Before
No filtering existed on the Activities page — all 8 activities shown unfiltered.

### After
Filter chips render below the page header ("Filter by difficulty: Beginner / Intermediate / Advanced"). Selecting a chip highlights it and filters the grid; badges appear on each card; URL updates to `?difficulty=...` and persists on refresh.

## Testing
### Unit Tests
- [ ] N/A, no test suite exists for this page currently

### Integration Tests
- [ ] N/A

### E2E Tests
- [ ] N/A

### Manual Testing
- [x] Verified locally end-to-end: chips toggle correctly, multiple filters combine, badges render on matching cards, URL syncs and persists on page refresh, empty-state message shows when no activities match, "Clear filters" resets both state and URL.

## Security Review
No security surface — client-side filtering of static local data only.

## Accessibility Review
Chips use `aria-pressed` to reflect active/inactive state for screen readers.

## Performance Impact
Negligible — filtering runs via `useMemo` over 8 static items.

## Breaking Changes
- [x] No Breaking Changes

## Deployment Notes
None.

## Rollback Plan
Revert this commit; no data migrations or external dependencies involved.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated — N/A, no existing test coverage for this page
- [ ] Documentation updated — N/A
- [x] Security reviewed
- [x] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing — pending PR checks
- [x] Ready for review