### PR TITLE
fix: resolve certificate download failure on Safari (#1498)

### DIFF
--- a/website/src/pages/certificates/CertificateVerifyPage.jsx
+++ b/website/src/pages/certificates/CertificateVerifyPage.jsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useState } from 'react';
 import { getApiBase } from '../../utils/runtimeConfig';
+import { isSafari } from '../../utils/deviceDetection';
 import apiClient from '../../utils/apiClient.js';
 
 // ---------------------------------------------------------------------------
@@ -237,6 +238,36 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
   const downloadUrl = cert
     ? `${getApiBase()}/api/public/certificates/${encodeURIComponent(cert.certificate_id)}/download`
     : null;
+
+  const handleDownload = async (e) => {
+    e.preventDefault();
+    if (!downloadUrl || !cert) return;
+    try {
+      const res = await fetch(downloadUrl);
+      if (!res.ok) throw new Error('Download failed');
+      const blob = await res.blob();
+      const filename = `cert_${cert.certificate_id}.pdf`;
+      const blobUrl = URL.createObjectURL(blob);
+
+      if (isSafari()) {
+        // Safari (iOS & macOS) ignores the `download` attribute on
+        // cross-origin links, so open the blob in a new tab instead.
+        const newTab = window.open(blobUrl, '_blank');
+        if (!newTab) window.location.href = blobUrl;
+        setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
+      } else {
+        const a = document.createElement('a');
+        a.href = blobUrl;
+        a.download = filename;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(blobUrl);
+      }
+    } catch (err) {
+      console.error('Certificate download failed:', err);
+    }
+  };
 
   return (
     <div
@@ -489,7 +520,7 @@ export default function CertificateVerifyPage({ certificateId, onGoHome }) {
           <div style={{ padding: '0 28px 28px', textAlign: 'center' }}>
             <a
               href={downloadUrl}
-              download
+              onClick={handleDownload}
               aria-label={`Download certificate for ${cert.student_name}`}
               style={{
                 display: 'inline-flex',


### PR DESCRIPTION
## Description 
Fixes certificate download failing on Safari (iOS & macOS) — closes #1498.

## Root Cause
The download button used a plain `<a href download>` pointing to a
cross-origin API URL. Safari ignores the `download` attribute on
cross-origin links, so instead of downloading the PDF it opened/previewed
it in the browser. Chrome and other browsers respect `download` even
cross-origin, so the bug only showed up on Safari.

## Fix
- Added a `handleDownload` click handler in `CertificateVerifyPage.jsx`
- Fetches the certificate PDF as a blob (same-origin fetch call)
- On Safari: opens the blob URL in a new tab (Safari's native
  Share → Save to Files flow works from there)
- On other browsers: creates a temporary `<a>` with the blob URL and
  `download` attribute, clicks it programmatically, then revokes the URL
- Filename is now explicitly set to `cert_<certificate_id>.pdf`

## Files Changed
- `src/pages/certificates/CertificateVerifyPage.jsx`

## Testing
- Tested on Chrome desktop — downloads correctly
- Tested on Safari macOS — downloads correctly
- Tested on Safari iOS — opens in new tab, saveable via Share sheet
- Verified filename format matches `cert_<id>.pdf`