### PR TITLE
[GSSoC'26] fix: guard tier rate limiter defaults

### DIFF
--- a/server/middleware/tierRateLimiter.js
+++ b/server/middleware/tierRateLimiter.js
@@ -50,6 +50,12 @@ function resolveEndpointConfig(path, tier) {
   return matched ? ENDPOINT_LIMITS[matched][tier] : {};
 }
 
+export function resolveRateLimitConfig(path, tier, options = {}) {
+  const baseConfig = CONFIG[tier] || CONFIG.guest;
+  const endpointCfg = resolveEndpointConfig(path, tier) || {};
+  return { ...baseConfig, ...options, ...endpointCfg };
+}
+
 /**
  * Clean up expired memory entries to prevent memory leaks
  */
@@ -91,8 +97,7 @@ export function tierRateLimiter(options = {}) {
       tier = 'guest';
     }
 
-    const endpointCfg = resolveEndpointConfig(req.path, tier);
-    const { capacity, refillRate, baseCooldown } = { ...CONFIG[tier], ...options, ...endpointCfg };
+    const { capacity, refillRate, baseCooldown } = resolveRateLimitConfig(req.path, tier, options);
     const rateLimitKey = `tier-rate-limit:${identifier}`;
     const violationsKey = `tier-rate-limit-violations:${identifier}`;
     const blockedKey = `tier-rate-limit-blocked:${identifier}`;

--- a/server/test/tierRateLimiter.test.js
+++ b/server/test/tierRateLimiter.test.js
@@ -1,8 +1,18 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { tierRateLimiter } from '../middleware/tierRateLimiter.js';
+import { resolveRateLimitConfig, tierRateLimiter } from '../middleware/tierRateLimiter.js';
 
 test('Tier-Based Rate Limiting & Backoff Middleware Tests', async (t) => {
+  await t.test('0. Unknown tiers fall back to guest defaults', () => {
+    const config = resolveRateLimitConfig('/api/unknown', 'premium');
+
+    assert.deepEqual(config, {
+      capacity: 20,
+      refillRate: 0.5,
+      baseCooldown: 10,
+    });
+  });
+
   await t.test('1. Guest rate limit checks (IP-based keying & headers)', async () => {
     const middleware = tierRateLimiter({ capacity: 5, refillRate: 0.1 });
     const req = { ip: '192.168.1.50', adminSession: null, user: null };


### PR DESCRIPTION
## Description
Fixes unknown tier handling in `tierRateLimiter.js` by falling back to the guest rate-limit defaults when a tier is not present in the base config. This prevents `TypeError` from spreading an undefined config while preserving endpoint-specific overrides.

Fixes #3100

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test test/tierRateLimiter.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue
