### PR TITLE
[GSSoC'26] fix: require socket frontend origin in production

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -41,10 +41,18 @@ function parseBearer(authHeader) {
  * Initialize Socket.IO
  * @param {Object} httpServer - HTTP server instance
  */
+export function resolveSocketCorsOrigin(env = process.env) {
+  if (env.FRONTEND_URL) return env.FRONTEND_URL;
+  if (env.NODE_ENV === 'production') {
+    throw new Error('FRONTEND_URL must be set in production for Socket.IO CORS');
+  }
+  return 'http://localhost:5173';
+}
+
 export function initializeSocketIO(httpServer) {
   io = new Server(httpServer, {
     cors: {
-      origin: process.env.FRONTEND_URL || 'http://localhost:5173',
+      origin: resolveSocketCorsOrigin(),
       credentials: true,
     },
     reconnection: true,

--- a/server/test/socketConfig.test.js
+++ b/server/test/socketConfig.test.js
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { resolveSocketCorsOrigin } from '../config/socket.js';
+
+test('resolveSocketCorsOrigin uses explicit FRONTEND_URL', () => {
+  const origin = resolveSocketCorsOrigin({
+    FRONTEND_URL: 'https://nexasphere.example',
+    NODE_ENV: 'production',
+  });
+
+  assert.equal(origin, 'https://nexasphere.example');
+});
+
+test('resolveSocketCorsOrigin keeps localhost fallback outside production', () => {
+  const origin = resolveSocketCorsOrigin({ NODE_ENV: 'development' });
+
+  assert.equal(origin, 'http://localhost:5173');
+});
+
+test('resolveSocketCorsOrigin rejects missing FRONTEND_URL in production', () => {
+  assert.throws(
+    () => resolveSocketCorsOrigin({ NODE_ENV: 'production' }),
+    /FRONTEND_URL must be set in production/
+  );
+});


### PR DESCRIPTION
## Description
Prevents the Socket.IO server from silently allowing the localhost frontend origin in production when `FRONTEND_URL` is missing. Development still keeps the existing localhost fallback, and explicit `FRONTEND_URL` values continue to be used.

Fixes #3020

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test test/socketConfig.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue
