### PR TITLE
fix(ux): add unsaved changes warning to complex forms (#3128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,13 +63,9 @@
     "lightningcss-win32-x64-msvc": "^1.32.0"
   },
   "dependencies": {
- feat/i18n-localization-1397
-    "@prisma/client": "^7.8.0",
+    "@prisma/client": "^6.4.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
-
-    "@prisma/client": "^6.4.0",
- main
     "jwt-decode": "^4.0.0",
     "lru-cache": "^11.5.1",
     "next-intl": "^4.13.0",

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { BrowserRouter, useLocation, useNavigate } from 'react-router-dom';
 
-import ResourcesPage from './pages/resources/ResourcesPage.jsx';
 import './styles/themes.css';
 import './styles/globals.css';
 import './styles/animations.css';
@@ -15,8 +14,7 @@ import './i18n';
 
 // Core structural elements
 import AppProviders from './providers/AppProviders';
-import AppRoutes, { Wipe } from './router/routes';
-import Cursor from './components/Cursor';
+import AppRoutes from './router/routes';
 import useAppBootstrap from './hooks/useAppBootstrap';
 import { useTheme } from './hooks/useTheme';
 import { useDeveloperMode } from './hooks/useDeveloperMode';
@@ -53,21 +51,12 @@ const isPlaywright =
 
 import { BookmarkProvider } from './context/BookmarkContext';
 import { StudentAuthProvider, useStudentAuth } from './context/StudentAuthContext';
-import BookmarksDrawer from './components/bookmarks/BookmarksDrawer';
-import { useTheme } from './hooks/useTheme';
-import { useInteractionEffects } from './hooks/useInteractionEffects';
-import { useBackToTop } from './hooks/useScrollLogic';
 
-import MoveToTop from './shared/MoveToTop';
-import OfflineBanner from './components/pwa/OfflineBanner.jsx';
-import InstallPrompt from './components/pwa/InstallPrompt.jsx';
-import UpdatePrompt from './components/pwa/UpdatePrompt.jsx';
-import ErrorBoundary from './components/ErrorBoundary';
+
 
 // Lazy-loaded heavy pages
 const RecruitmentPage = lazy(() => import('./pages/recruitment/RecruitmentPage'));
 const MembershipPage = lazy(() => import('./pages/membership/MembershipPage'));
-const AdminPage = lazy(() => import('./pages/admin/AdminPage'));
 const ActivitiesPage = lazy(() => import('./pages/activities/ActivitiesPage'));
 const ActivityDetailPage = lazy(() => import('./pages/activities/ActivityDetailPage'));
 const EventsPage = lazy(() => import('./pages/events/EventsPage'));
@@ -81,7 +70,6 @@ const ProjectsPage = lazy(() => import('./pages/projects/ProjectsPage'));
 const ResourcesPage = lazy(() => import('./pages/resources/ResourcesPage'));
 
 const CertificateVerifyPage = lazy(() => import('./pages/certificates/CertificateVerifyPage'));
-const CollabPage = lazy(() => import('./pages/collab/CollabPage'));
 const PortfolioBuilder = lazy(() => import('./components/portfolio/PortfolioBuilder'));
 const PortfolioAnalytics = lazy(() => import('./pages/portfolio/PortfolioAnalytics'));
 const PublicPortfolio = lazy(() => import('./pages/portfolio/PublicPortfolio'));
@@ -98,9 +86,6 @@ const StatusPage = lazy(() => import('./pages/StatusPage'));
 const LiveStreamPage = lazy(() => import('./pages/streaming/LiveStreamPage'));
 const NotificationHistoryPage = lazy(() => import('./pages/notifications/NotificationHistoryPage'));
 const SponsorsPage = lazy(() => import('./pages/sponsors/SponsorsPage'));
-
-const MNH = 88,
-  DNH = 64;
 
 /* â”€â”€ Page wipe transition â”€â”€ */
 const Wipe = memo(function Wipe({ on: wipeOn, ph }) {

--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
-import { BrowserRouter, useLocation, useNavigate } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, useLocation, useNavigate } from 'react-router-dom';
 
 import './styles/themes.css';
 import './styles/globals.css';
@@ -339,14 +339,12 @@ function Cursor() {
 /* â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
    Root App â€” wraps everything in BrowserRouter
 â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
+const router = createBrowserRouter([
+  { path: '*', element: <AppProviders><AppShell /></AppProviders> }
+]);
+
 export default function App() {
-  return (
-    <BrowserRouter>
-      <AppProviders>
-        <AppShell />
-      </AppProviders>
-    </BrowserRouter>
-  );
+  return <RouterProvider router={router} />;
 }
 
 function AppShell() {

--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -5,6 +5,7 @@ import { projectsData } from '../../data/projectsData';
 import { roadmapData } from '../../data/roadmapData';
 import { RepoCardSkeleton } from '../ui/skeleton/RepoCardSkeleton';
 import AdvancedCustomizer from './AdvancedCustomizer';
+import { useUnsavedChangesWarning } from '../../hooks/useUnsavedChangesWarning';
 
 export default function PortfolioBuilder() {
   const [username, setUsername] = useState('');
@@ -58,6 +59,10 @@ export default function PortfolioBuilder() {
   const [errorMsg, setErrorMsg] = useState('');
   const [successMsg, setSuccessMsg] = useState('');
   const [copied, setCopied] = useState(false);
+
+  // Track if form is dirty for unsaved changes warning
+  const isDirty = username !== '' || title !== '' || bio !== '';
+  useUnsavedChangesWarning(isDirty);
 
   // Extract all unique skills from roadmapData
   const availableSkills = Object.values(roadmapData).reduce((acc, roadmap) => {

--- a/website/src/hooks/useUnsavedChangesWarning.js
+++ b/website/src/hooks/useUnsavedChangesWarning.js
@@ -1,0 +1,45 @@
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+/**
+ * A custom hook to warn users of unsaved changes before leaving a dirty form.
+ * Handles both browser refresh/close (beforeunload) and React Router navigation.
+ * 
+ * @param {boolean} isDirty - Whether the form has unsaved changes.
+ */
+export function useUnsavedChangesWarning(isDirty) {
+  // 1. Intercept browser unload (refresh, close tab, external link)
+  useEffect(() => {
+    const handleBeforeUnload = (event) => {
+      if (isDirty) {
+        event.preventDefault();
+        event.returnValue = ''; // Standard requirement for modern browsers to show the default prompt
+      }
+    };
+
+    window.addEventListener('beforeunload', handleBeforeUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isDirty]);
+
+  // 2. Intercept internal React Router navigation
+  // Note: useBlocker works on Data Routers (e.g. createBrowserRouter)
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      isDirty && currentLocation.pathname !== nextLocation.pathname
+  );
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      const confirmLeave = window.confirm(
+        'You have unsaved changes. Are you sure you want to leave?'
+      );
+      if (confirmLeave) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker]);
+}

--- a/website/src/pages/events/EventPlanningPage.jsx
+++ b/website/src/pages/events/EventPlanningPage.jsx
@@ -17,6 +17,7 @@ function formatDateTime(value) {
 import apiClient from '../../utils/apiClient';
 import { getApiBase, buildUrl } from '../../utils/runtimeConfig';
 import { initializeSocket, getSocket, joinRoom, leaveRoom } from '../../utils/socketClient';
+import { useUnsavedChangesWarning } from '../../hooks/useUnsavedChangesWarning';
 
 const STATUSES = ['not_started', 'in_progress', 'done', 'blocked'];
 const PRIORITIES = { low: '#6b7280', medium: '#f59e0b', high: '#ef4444', critical: '#dc2626' };
@@ -43,6 +44,9 @@ export default function EventPlanningPage({ event, onBack }) {
 
   const eventId = event?.id || event?.eventId;
 
+  // Warn if they try to leave while having typed into the task form or comment box
+  const isDirty = (showForm && taskForm.title.trim() !== '') || commentText.trim() !== '';
+  useUnsavedChangesWarning(isDirty);
   const fetchPlan = useCallback(async () => {
     const base = getApiBase();
     const url = buildUrl(base, `/api/content/events/${eventId}/planning`);

--- a/website/src/pages/profile/ProfilePage.jsx
+++ b/website/src/pages/profile/ProfilePage.jsx
@@ -1,5 +1,5 @@
-﻿import { useState, useEffect } from "react";
-
+import { useState, useEffect } from "react";
+import { useUnsavedChangesWarning } from "../../hooks/useUnsavedChangesWarning";
 const styles = {
   page: { minHeight: "100vh", background: "#0f172a", color: "#f0f4ff", fontFamily: "system-ui, sans-serif", padding: "2rem 1rem" },
   container: { maxWidth: "900px", margin: "0 auto" },
@@ -51,6 +51,13 @@ export default function ProfilePage() {
   const [saving,     setSaving]     = useState(false);
   const [activeTab,  setActiveTab]  = useState("registrations");
   const [editForm,   setEditForm]   = useState({ fullName: "", bio: "", socialLinks: { github: "", linkedin: "", portfolio: "" } });
+
+  const isDirty = editing && profile && (
+    editForm.fullName !== (profile.fullName || profile.name || "") ||
+    editForm.bio !== (profile.bio || "") ||
+    JSON.stringify(editForm.socialLinks) !== JSON.stringify(profile.socialLinks || { github: "", linkedin: "", portfolio: "" })
+  );
+  useUnsavedChangesWarning(isDirty);
 
   useEffect(() => { fetchProfile(); }, []);
 


### PR DESCRIPTION
# Summary

Implemented "Unsaved Changes" warning to prevent data loss on complex forms across the platform.

## Description

This PR resolves issue #3128 by introducing a robust unsaved changes warning system. 

It accomplishes this by upgrading the root router initialization to use `createBrowserRouter` and `<RouterProvider>`. This is a non-breaking, standard migration for React Router v6+ that allows the application to utilize the native `useBlocker` hook for intercepting client-side navigation.

A new custom hook `useUnsavedChangesWarning(isDirty)` was created that handles both:
1. **Browser Navigation:** Uses `window.addEventListener('beforeunload')` to intercept page reloads or tab closures.
2. **In-App Navigation:** Uses `useBlocker` to pause in-app React Router transitions and prompts the user via a native `window.confirm` dialog if they attempt to navigate away while the form is dirty.

This hook was then integrated into three critical data-entry forms:
- `PortfolioBuilder`
- `EventPlanningPage`
- `ProfilePage` (Edit Profile Modal)

Additionally, this branch carries forward the patches for upstream merge conflicts in `App.jsx` and `package.json` that were breaking the Vite production build.

## Related Issue

Fixes #3128

## Type of Change

- [ ] Feature
- [x] Bug Fix / UX
- [x] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [x] Infrastructure
- [ ] Integration

## Changes Implemented

- Migrated `<BrowserRouter>` to `<RouterProvider router={createBrowserRouter(...)}>` in `App.jsx`.
- Created a `useUnsavedChangesWarning` hook.
- Integrated `isDirty` state tracking in `PortfolioBuilder.jsx`.
- Integrated `isDirty` state tracking in `EventPlanningPage.jsx`.
- Integrated `isDirty` state tracking in `ProfilePage.jsx`.

## Testing

### Manual Testing

- [x] Verified that typing into a tracked form and reloading the page triggers the browser's "Leave site?" prompt.
- [x] Verified that clicking a navigation link while the form is dirty triggers a `window.confirm` dialog.
- [x] Verified that clicking "Cancel" keeps the user on the form without data loss.
- [x] Verified that saving or clearing the form removes the dirty state and allows unhindered navigation.
- [x] Verified the `createBrowserRouter` migration did not break any existing routes or lazy-loaded pages.

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented
