### PR TITLE
[GSSoC'26] fix: handle cache read failures

### DIFF
--- a/server/middleware/cacheMiddleware.js
+++ b/server/middleware/cacheMiddleware.js
@@ -3,7 +3,12 @@ import { cacheService } from '../services/cacheService.js';
 export function cacheResponse(duration = 3600) {
   return async (req, res, next) => {
     const cacheKey = cacheService.buildKey('response', req.originalUrl || req.url);
-    const cached = await cacheService.get(cacheKey);
+    let cached = null;
+    try {
+      cached = await cacheService.get(cacheKey);
+    } catch (error) {
+      console.warn('Cache read failed, continuing without cached response:', error.message);
+    }
 
     if (cached) {
       res.setHeader('X-Cache', 'HIT');

--- a/server/test/cacheMiddleware.test.js
+++ b/server/test/cacheMiddleware.test.js
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { cacheResponse } from '../middleware/cacheMiddleware.js';
+import { cacheService } from '../services/cacheService.js';
+
+test('cacheResponse continues when cache read fails', async () => {
+  const originalGet = cacheService.get;
+  cacheService.get = async () => {
+    throw new Error('redis down');
+  };
+
+  try {
+    let nextCalled = false;
+    const middleware = cacheResponse(60);
+    const req = { originalUrl: '/api/events' };
+    const res = {
+      statusCode: 200,
+      setHeader() {},
+      json() {},
+    };
+
+    await assert.doesNotReject(
+      () => middleware(req, res, () => {
+        nextCalled = true;
+      })
+    );
+
+    assert.equal(nextCalled, true);
+  } finally {
+    cacheService.get = originalGet;
+  }
+});


### PR DESCRIPTION
## Description
Prevents `cacheResponse` from rejecting the request pipeline when `cacheService.get()` fails, such as during Redis outages. The middleware now logs the cache read failure and continues to the route handler without cached data.

Fixes #3035

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test test/cacheMiddleware.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue
