### PR TITLE
[GSSoC'26] fix: record required RBAC permission

### DIFF
--- a/server/middleware/rbacMiddleware.js
+++ b/server/middleware/rbacMiddleware.js
@@ -13,6 +13,7 @@ export function requirePermission(requiredPermissions, options = {}) {
     : [requiredPermissions];
 
   return async (req, res, next) => {
+    req.requiredPermission = permissions;
     if (!req.adminSession) {
       return res.status(401).json({ error: 'Unauthorized: No session found' });
     }

--- a/server/test/rbacMiddleware.test.js
+++ b/server/test/rbacMiddleware.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { requirePermission } from '../middleware/rbacMiddleware.js';
+
+test('requirePermission audit log includes the denied permission', async () => {
+  const middleware = requirePermission('events:write');
+  const req = {
+    adminSession: {
+      adminId: 'admin-1',
+      metadata: { role: 'viewer', permissions: [] },
+    },
+    ip: '127.0.0.1',
+  };
+  const res = {
+    statusCode: 200,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload) {
+      this.payload = payload;
+      return this;
+    },
+  };
+
+  await middleware(req, res, () => {});
+
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(req.requiredPermission, ['events:write']);
+});


### PR DESCRIPTION
## Description
Stores the required permission on the request inside `requirePermission()` so downstream RBAC audit logging can report the actual denied permission instead of `undefined`.

Fixes #3023

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test test/rbacMiddleware.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue
