### PR TITLE
[GSSoC'26] fix: prune stale tier rate buckets

### DIFF
--- a/server/middleware/tierRateLimiter.js
+++ b/server/middleware/tierRateLimiter.js
@@ -5,6 +5,7 @@ import { _getRedisClient } from '../services/rateLimitService.js';
 const memoryBuckets = new Map(); // key -> { tokens, lastUpdated }
 const memoryViolations = new Map(); // key -> { count, expiresAt }
 const memoryBlocked = new Map(); // key -> expiresAt
+const MEMORY_BUCKET_TTL_MS = 60 * 60 * 1000;
 
 // Base rate limiting configurations per tier
 const CONFIG = {
@@ -53,13 +54,15 @@ function resolveEndpointConfig(path, tier) {
 /**
  * Clean up expired memory entries to prevent memory leaks
  */
-function pruneMemoryStores() {
-  const now = Date.now();
+export function pruneMemoryStores(now = Date.now()) {
   for (const [key, val] of memoryViolations.entries()) {
     if (now > val.expiresAt) memoryViolations.delete(key);
   }
   for (const [key, expiresAt] of memoryBlocked.entries()) {
     if (now > expiresAt) memoryBlocked.delete(key);
+  }
+  for (const [key, bucket] of memoryBuckets.entries()) {
+    if (now - bucket.lastUpdated > MEMORY_BUCKET_TTL_MS) memoryBuckets.delete(key);
   }
 }
 

--- a/server/test/tierRateLimiter.test.js
+++ b/server/test/tierRateLimiter.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { tierRateLimiter } from '../middleware/tierRateLimiter.js';
+import { pruneMemoryStores, tierRateLimiter } from '../middleware/tierRateLimiter.js';
 
 test('Tier-Based Rate Limiting & Backoff Middleware Tests', async (t) => {
   await t.test('1. Guest rate limit checks (IP-based keying & headers)', async () => {
@@ -88,7 +88,44 @@ test('Tier-Based Rate Limiting & Backoff Middleware Tests', async (t) => {
     assert.equal(headers['X-RateLimit-Remaining'], '9');
   });
 
-  await t.test('3. Exponential Backoff Block checks', async () => {
+  await t.test('3. Prunes stale in-memory token buckets', async () => {
+    const middleware = tierRateLimiter({ capacity: 2, refillRate: 0, baseCooldown: 2 });
+    const req = { ip: '203.0.113.25', adminSession: null, user: null };
+
+    const createRes = () => ({
+      headers: {},
+      setHeader(name, val) {
+        this.headers[name] = val.toString();
+      },
+      status(code) {
+        this.statusCode = code;
+        return this;
+      },
+      json(data) {
+        this.jsonData = data;
+        return this;
+      },
+    });
+
+    let nextCalled = false;
+    await middleware(req, createRes(), () => {
+      nextCalled = true;
+    });
+    assert.equal(nextCalled, true);
+
+    pruneMemoryStores(Date.now() + 61 * 60 * 1000);
+
+    const res = createRes();
+    nextCalled = false;
+    await middleware(req, res, () => {
+      nextCalled = true;
+    });
+
+    assert.equal(nextCalled, true);
+    assert.equal(res.headers['X-RateLimit-Remaining'], '1');
+  });
+
+  await t.test('4. Exponential Backoff Block checks', async () => {
     const middleware = tierRateLimiter({ capacity: 1, refillRate: 0.1, baseCooldown: 2 });
     const req = { ip: '10.0.0.99', adminSession: null, user: null };
 


### PR DESCRIPTION
## Description
Extends tier rate limiter memory cleanup to remove stale token bucket entries, preventing unbounded growth for inactive clients. The prune helper now accepts a timestamp for deterministic testing.

Fixes #3025

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test test/tierRateLimiter.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue
