### PR TITLE
[GSSoC'26] fix: cancel stale global search requests

### DIFF
--- a/website/src/__tests__/useGlobalSearch.test.jsx
+++ b/website/src/__tests__/useGlobalSearch.test.jsx
@@ -1,0 +1,79 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import useGlobalSearch from '../hooks/useGlobalSearch';
+
+const createSearchResponse = (results) => ({
+  json: () =>
+    Promise.resolve({
+      results,
+      facets: {},
+      suggestions: [],
+    }),
+});
+
+const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('useGlobalSearch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('keeps a slower stale response from overwriting a newer search response', async () => {
+    let resolveFirstSearch;
+    let resolveSecondSearch;
+
+    const firstSearch = new Promise((resolve) => {
+      resolveFirstSearch = resolve;
+    });
+    const secondSearch = new Promise((resolve) => {
+      resolveSecondSearch = resolve;
+    });
+
+    const fetchMock = vi
+      .spyOn(globalThis, 'fetch')
+      .mockReturnValueOnce(firstSearch)
+      .mockReturnValueOnce(secondSearch);
+
+    const { result } = renderHook(() => useGlobalSearch());
+
+    act(() => {
+      result.current.setQuery('old');
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    act(() => {
+      result.current.setQuery('new');
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+
+    await act(async () => {
+      resolveSecondSearch(createSearchResponse([{ id: 'new-result' }]));
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([{ id: 'new-result' }]);
+    });
+
+    await act(async () => {
+      resolveFirstSearch(createSearchResponse([{ id: 'old-result' }]));
+      await flushPromises();
+    });
+
+    await waitFor(() => {
+      expect(result.current.results).toEqual([{ id: 'new-result' }]);
+    });
+  });
+});

--- a/website/src/hooks/useGlobalSearch.js
+++ b/website/src/hooks/useGlobalSearch.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { STORAGE_KEYS } from '../utils/storageKeys.js';
 
 /**
@@ -23,6 +23,8 @@ export const useGlobalSearch = () => {
   const [facets, setFacets] = useState({});
   const [activeFilters, setActiveFilters] = useState({});
   const [suggestions, setSuggestions] = useState([]);
+  const activeRequestRef = useRef(null);
+  const requestIdRef = useRef(0);
 
   // Safe lazy initializer protecting against malformed JSON crashes
   const [recentSearches, setRecentSearches] = useState(() => {
@@ -41,12 +43,20 @@ export const useGlobalSearch = () => {
   const fetchResults = useMemo(
     () =>
       debounce(async (searchQuery, filters) => {
+        activeRequestRef.current?.abort();
+
         if (searchQuery.length < 2) {
           setResults([]);
           setSuggestions([]);
+          setFacets({});
+          setLoading(false);
           return;
         }
 
+        const requestId = requestIdRef.current + 1;
+        requestIdRef.current = requestId;
+        const controller = new AbortController();
+        activeRequestRef.current = controller;
         setLoading(true);
         try {
           // Build query string with facets
@@ -55,29 +65,46 @@ export const useGlobalSearch = () => {
             ...filters,
           }).toString();
 
-          const response = await fetch(`/api/search?${filterParams}`);
+          const response = await fetch(`/api/search?${filterParams}`, {
+            signal: controller.signal,
+          });
           const data = await response.json();
+          if (requestId !== requestIdRef.current || controller.signal.aborted) {
+            return;
+          }
 
-          setResults(data.results);
-          setFacets(data.facets);
+          const nextResults = Array.isArray(data.results) ? data.results : [];
+          setResults(nextResults);
+          setFacets(data.facets || {});
           if (data.suggestions) setSuggestions([data.suggestions]);
 
           // Update recent searches if results found
-          if (data.results.length > 0) {
+          if (nextResults.length > 0) {
             updateRecentSearches(searchQuery);
           }
         } catch (error) {
+          if (error?.name === 'AbortError') return;
           console.error('Search API Error:', error);
         } finally {
-          setLoading(false);
+          if (requestId === requestIdRef.current) {
+            activeRequestRef.current = null;
+            setLoading(false);
+          }
         }
       }, 300),
     []
   );
 
   useEffect(() => {
+    activeRequestRef.current?.abort();
     fetchResults(query, activeFilters);
   }, [query, activeFilters, fetchResults]);
+
+  useEffect(() => {
+    return () => {
+      activeRequestRef.current?.abort();
+    };
+  }, []);
 
   // Combined tracking tracking mechanism with functional updates and protection
   const updateRecentSearches = (q) => {


### PR DESCRIPTION
## Description
Adds AbortController-based request cancellation to `useGlobalSearch` so stale responses from previous searches don't overwrite newer results. Each debounced request gets a unique ID; stale completions are discarded.

Fixes #3021

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `npx vitest run website/src/__tests__/useGlobalSearch.test.jsx`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue