### PR TITLE
[GSSoC'26] fix: proxy portfolio GitHub repo fetches through backend

### DIFF
--- a/server/routes/portfolio.js
+++ b/server/routes/portfolio.js
@@ -13,6 +13,12 @@ import notificationsService from '../services/notificationsService.js';
 
 const router = Router();
 
+const GITHUB_USERNAME_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9]|-(?=[a-zA-Z0-9])){0,38}$/;
+
+function getGitHubToken() {
+  return String(process.env.GITHUB_TOKEN || process.env.GITHUB_API_TOKEN || '').trim();
+}
+
 // ── Passkey brute-force lockout ────────────────────────────────────────────
 // Tracks failed attempts per IP and per username with exponential backoff.
 // Hard cap on tracked entries prevents memory exhaustion under attack.
@@ -117,6 +123,76 @@ function clearPasskeyAttempts(username, ip) {
 }
 
 // ── Routes ─────────────────────────────────────────────────────────────────
+
+/**
+ * GET /api/portfolio/github-repos/:username — Server-side GitHub repository import.
+ * Keeps GitHub API credentials off the browser and avoids unauthenticated client calls.
+ */
+router.get('/portfolio/github-repos/:username', async (req, res) => {
+  const username = String(req.params.username || '').trim();
+  if (!GITHUB_USERNAME_PATTERN.test(username)) {
+    return res.status(400).json({
+      error: 'Invalid GitHub username format.',
+    });
+  }
+
+  const token = getGitHubToken();
+  if (!token) {
+    return res.status(503).json({
+      error: 'GitHub repository import is unavailable because the server token is not configured.',
+    });
+  }
+
+  const sort =
+    req.query.sort === 'created' || req.query.sort === 'pushed' ? req.query.sort : 'updated';
+  const perPage = Math.min(Math.max(Number.parseInt(req.query.per_page, 10) || 30, 1), 30);
+  const githubUrl = new URL(`https://api.github.com/users/${encodeURIComponent(username)}/repos`);
+  githubUrl.searchParams.set('sort', sort);
+  githubUrl.searchParams.set('per_page', String(perPage));
+
+  try {
+    const response = await fetch(githubUrl, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'NexaSphere-PortfolioBuilder',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+
+    if (response.status === 403 || response.status === 429) {
+      const resetHeader = response.headers.get('X-RateLimit-Reset');
+      const resetDate = resetHeader
+        ? new Date(Number.parseInt(resetHeader, 10) * 1000).toISOString()
+        : null;
+      return res.status(response.status).json({
+        error: 'GitHub rate limit reached. Please try again later.',
+        rateLimitReset: resetDate,
+      });
+    }
+
+    if (response.status === 404) {
+      return res.status(404).json({
+        error: `GitHub user "${username}" not found. Please check the username and try again.`,
+      });
+    }
+
+    if (!response.ok) {
+      return res.status(response.status).json({
+        error: `GitHub API error: ${response.status} ${response.statusText}`,
+      });
+    }
+
+    const repos = await response.json();
+    res.set('Cache-Control', 'private, max-age=60');
+    return res.json(repos);
+  } catch (err) {
+    console.error('Error fetching GitHub repositories:', err);
+    return res.status(502).json({
+      error: 'Failed to fetch repositories from GitHub.',
+    });
+  }
+});
 
 /**
  * GET /api/portfolio/:username — Public portfolio lookup.
@@ -266,7 +342,10 @@ router.put('/portfolio', protectedActionRateLimiter, async (req, res) => {
           projectName: lastProject.name,
         });
       } catch (socketErr) {
-        console.warn('[Portfolio] Could not emit project-approved notification:', socketErr.message);
+        console.warn(
+          '[Portfolio] Could not emit project-approved notification:',
+          socketErr.message
+        );
       }
     }
 

--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -5,6 +5,7 @@ import { projectsData } from '../../data/projectsData';
 import { roadmapData } from '../../data/roadmapData';
 import { RepoCardSkeleton } from '../ui/skeleton/RepoCardSkeleton';
 import AdvancedCustomizer from './AdvancedCustomizer';
+import { buildGithubReposUrl } from './githubReposConfig';
 
 export default function PortfolioBuilder() {
   const [username, setUsername] = useState('');
@@ -170,7 +171,7 @@ export default function PortfolioBuilder() {
       const base = getApiBase();
       const url = base ? `${base}/api/portfolio` : `/api/portfolio`;
 
-      const data = await apiClient(url, {
+      await apiClient(url, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -227,15 +228,17 @@ export default function PortfolioBuilder() {
     setIsFetchingGh(true);
     setGhError('');
     try {
-      const response = await fetch(
-        `https://api.github.com/users/${ghUsername.trim()}/repos?sort=updated&per_page=30`,
-        { signal: controller.signal }
-      );
+      const response = await fetch(buildGithubReposUrl(ghUsername), { signal: controller.signal });
 
       if (response.status === 403 || response.status === 429) {
-        const resetHeader = response.headers.get('X-RateLimit-Reset');
-        const resetTime = resetHeader
-          ? new Date(parseInt(resetHeader, 10) * 1000).toLocaleTimeString()
+        let errorDetail = {};
+        try {
+          errorDetail = await response.json();
+        } catch {
+          // Keep default rate-limit message below.
+        }
+        const resetTime = errorDetail.rateLimitReset
+          ? new Date(errorDetail.rateLimitReset).toLocaleTimeString()
           : 'soon';
         setGhError(
           `GitHub rate limit reached. Too many requests from this network. Please try again after ${resetTime}.`
@@ -251,7 +254,15 @@ export default function PortfolioBuilder() {
       }
 
       if (!response.ok) {
-        setGhError(`GitHub API error: ${response.status} ${response.statusText}`);
+        let errorDetail = {};
+        try {
+          errorDetail = await response.json();
+        } catch {
+          // Keep fallback message below.
+        }
+        setGhError(
+          errorDetail.error || `GitHub API error: ${response.status} ${response.statusText}`
+        );
         return;
       }
 

--- a/website/src/components/portfolio/PortfolioBuilder.test.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.test.jsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { buildGithubReposUrl } from './githubReposConfig';
+
+describe('PortfolioBuilder GitHub repository fetch config', () => {
+  it('builds a backend API URL instead of calling api.github.com from the browser', () => {
+    const url = buildGithubReposUrl('octocat', '');
+
+    expect(url).toBe('/api/portfolio/github-repos/octocat?sort=updated&per_page=30');
+    expect(url).not.toContain('api.github.com');
+  });
+
+  it('uses the configured API base when one is available', () => {
+    const url = buildGithubReposUrl('octo-cat', 'https://api.nexasphere.test');
+
+    expect(url).toBe(
+      'https://api.nexasphere.test/api/portfolio/github-repos/octo-cat?sort=updated&per_page=30'
+    );
+  });
+});

--- a/website/src/components/portfolio/githubReposConfig.js
+++ b/website/src/components/portfolio/githubReposConfig.js
@@ -1,0 +1,7 @@
+import { getApiBase } from '../../utils/runtimeConfig';
+
+export function buildGithubReposUrl(username, apiBase = getApiBase()) {
+  const encodedUsername = encodeURIComponent(String(username || '').trim());
+  const path = `/api/portfolio/github-repos/${encodedUsername}?sort=updated&per_page=30`;
+  return apiBase ? `${apiBase}${path}` : path;
+}


### PR DESCRIPTION
## Description
Replaces unauthenticated GitHub API calls in PortfolioBuilder with backend-proxied requests, avoiding the 60 req/hr IP rate limit. The backend routes use the server's GitHub token for authenticated API access.

Fixes #3030

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `npx vitest run website/src/components/portfolio/PortfolioBuilder.test.jsx`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue