### PR TITLE
[GSSoC'26] fix: ignore quoted SQL boolean literals in injection guard

### DIFF
--- a/server/middleware/sqlInjectionGuard.js
+++ b/server/middleware/sqlInjectionGuard.js
@@ -1,16 +1,61 @@
+const BOOLEAN_OPERATOR_PATTERN = /(\b(OR|AND)\b\s+\d+\s*[=<>])/i;
+
 const SQL_INJECTION_PATTERNS = [
-  /(\b(OR|AND)\b\s+\d+\s*[=<>])/i,
   /([';])\s*(--|#|\/\*)/,
   /(\b(LOAD_FILE|INTO_OUTFILE|INTO_DUMPFILE|BENCHMARK|SLEEP|WAITFOR)\b)/i,
   /(\bINFORMATION_SCHEMA\b)/i,
 ];
 
+function maskQuotedLiterals(value) {
+  let masked = '';
+
+  for (let i = 0; i < value.length; i += 1) {
+    const quote = value[i];
+
+    if (quote !== "'" && quote !== '"' && quote !== '`') {
+      masked += quote;
+      continue;
+    }
+
+    let end = -1;
+    for (let j = i + 1; j < value.length; j += 1) {
+      if (value[j] === '\\') {
+        j += 1;
+        continue;
+      }
+
+      if (value[j] === quote && value[j + 1] === quote) {
+        j += 1;
+        continue;
+      }
+
+      if (value[j] === quote) {
+        end = j;
+        break;
+      }
+    }
+
+    if (end === -1) {
+      masked += quote;
+      continue;
+    }
+
+    masked += ' '.repeat(end - i + 1);
+    i = end;
+  }
+
+  return masked;
+}
+
 function hasSqliPattern(value) {
   if (typeof value === 'string') {
-    return SQL_INJECTION_PATTERNS.some(pattern => pattern.test(value));
+    return (
+      BOOLEAN_OPERATOR_PATTERN.test(maskQuotedLiterals(value)) ||
+      SQL_INJECTION_PATTERNS.some((pattern) => pattern.test(value))
+    );
   }
   if (typeof value === 'object' && value !== null) {
-    return Object.values(value).some(v => hasSqliPattern(v));
+    return Object.values(value).some((v) => hasSqliPattern(v));
   }
   return false;
 }
@@ -34,7 +79,9 @@ export function sqlInjectionGuard(req, res, next) {
   }
 
   if (suspicious.length > 0) {
-    console.warn(`[SQLI-GUARD] Blocked request from ${req.ip} - suspicious patterns in: ${suspicious.join(', ')}`);
+    console.warn(
+      `[SQLI-GUARD] Blocked request from ${req.ip} - suspicious patterns in: ${suspicious.join(', ')}`
+    );
     return res.status(400).json({ error: 'Request contains invalid patterns' });
   }
 

--- a/server/test/sqlInjectionGuard.test.js
+++ b/server/test/sqlInjectionGuard.test.js
@@ -43,9 +43,30 @@ test('sqlInjectionGuard allows legitimate free-text content', async (t) => {
   }
 });
 
+test('sqlInjectionGuard allows boolean words inside quoted SQL string literals', async (t) => {
+  const quotedLiteralInputs = [
+    "status = 'draft OR published'",
+    "department = 'research AND development'",
+    "title = 'AI OR 1=1 workshop'",
+  ];
+
+  for (const input of quotedLiteralInputs) {
+    await t.test(`allows quoted literal: ${input}`, () => {
+      const { nextCalled, statusCode } = runGuard({ filter: input });
+      assert.equal(
+        nextCalled,
+        true,
+        'next() should be called when boolean words are inside quoted literals'
+      );
+      assert.equal(statusCode, null, 'no error status should be set');
+    });
+  }
+});
+
 test('sqlInjectionGuard still blocks real injection payloads', async (t) => {
   const maliciousInputs = [
-    "1 OR 1=1",
+    '1 OR 1=1',
+    "status = 'draft' OR 1=1",
     "'; DROP TABLE users; --",
     "SELECT * FROM users WHERE 1=1; WAITFOR DELAY '0:0:5'",
     'UNION SELECT * FROM INFORMATION_SCHEMA.TABLES',


### PR DESCRIPTION
## Description
Refines `sqlInjectionGuard.js` regex to only block unquoted SQL boolean operators (`OR`, `AND`) rather than all occurrences, preventing false positives on legitimate content containing these words in quoted strings.

Fixes #3037

## Type of Change
- [x] Bug Fix
- [ ] Feature
- [ ] Security
- [ ] Infrastructure

## Testing
- [x] `node --test server/test/sqlInjectionGuard.test.js`
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue