### PR TITLE
[GSSoC'26] fix: guard identifyUser call in socket connect

### DIFF
--- a/website/src/utils/socketClient.js
+++ b/website/src/utils/socketClient.js
@@ -62,7 +62,9 @@ export function initializeSocket(serverUrl = getSocketServerUrl()) {
     socket.on('connect', () => {
       console.log('Socket connected:', socket.id);
 
-      identifyUser();
+      if (typeof identifyUser === 'function') {
+        identifyUser();
+      }
     });
 
     socket.on('disconnect', (reason) => {


### PR DESCRIPTION
## Description
Adds `typeof identifyUser === 'function'` guard before calling `identifyUser()` in the socket connect handler to prevent `ReferenceError` when the function is unavailable.

Fixes #3024

## Type of Change
- [x] Bug Fix

## Testing
- [x] `git diff --check`

## Checklist
- [x] I have tested my changes
- [x] I have linked the related issue
- [x] This PR addresses only one issue