### PR TITLE
[GSSoC'26] fix: bind res.json wrapper to preserve this context

### DIFF
--- a/server/middleware/rbacMiddleware.js
+++ b/server/middleware/rbacMiddleware.js
@@ -71,7 +71,7 @@ export function auditPermissionCheck(req, res, next) {
     return next();
   }
 
-  const originalJson = res.json;
+  const originalJson = res.json.bind(res);
   res.json = function (body) {
     if (res.statusCode === 403) {
       const auditLog = {


### PR DESCRIPTION
## Description
Properly binds `originalJson` with `.bind(res)` in `auditPermissionCheck` to preserve the correct `this` context when calling the underlying Express `res.json` method.

Fixes #3074

## Type of Change
- [x] Bug Fix

## Checklist
- [x] I have linked the related issue
- [x] This PR addresses only one issue