### PR TITLE
[GSSoC'26] fix: add generation counter to prevent AbortController race

### DIFF
--- a/website/src/components/portfolio/PortfolioBuilder.jsx
+++ b/website/src/components/portfolio/PortfolioBuilder.jsx
@@ -84,15 +84,15 @@ export default function PortfolioBuilder() {
   }));
 
   const loadControllerRef = useRef(null);
+  const loadGenRef = useRef(0);
 
   const handleLoadConfig = async () => {
     if (!username || username.length < 3) return;
     setErrorMsg('');
     setSuccessMsg('');
 
-    if (loadControllerRef.current) {
-      loadControllerRef.current.abort();
-    }
+    const gen = ++loadGenRef.current;
+    loadControllerRef.current?.abort();
     const controller = new AbortController();
     loadControllerRef.current = controller;
 
@@ -100,6 +100,7 @@ export default function PortfolioBuilder() {
       const base = getApiBase();
       const url = base ? `${base}/api/portfolio/${username}` : `/api/portfolio/${username}`;
       const data = await apiClient(url, { signal: controller.signal });
+      if (gen !== loadGenRef.current) return;
       if (data) {
         setTitle(data.title || '');
         setBio(data.bio || '');
@@ -125,6 +126,7 @@ export default function PortfolioBuilder() {
       }
     } catch (err) {
       if (err.name === 'AbortError') return;
+      if (gen !== loadGenRef.current) return;
       if (err.status === 404) {
         return;
       }


### PR DESCRIPTION
## Description

Use generation counter to discard stale responses after abort, preventing partial state from overwriting newer data.

## Fixes

#3071

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have read the [CONTRIBUTING.md]
- [x] My code follows the project's style guidelines
- [x] I have tested my changes locally
- [x] This PR does not introduce breaking changes