### PR TITLE
fix(website): expose apiError from useEventSearch hook to fix silent search failures

### DIFF
--- a/website/src/hooks/useEventSearch.js
+++ b/website/src/hooks/useEventSearch.js
@@ -169,5 +169,5 @@ export function useEventSearch(activities, events) {
     setApiError(null);
   }, []);
 
-  return { query, setQuery, filter, setFilter, results, loading, clearSearch };
+  return { query, setQuery, filter, setFilter, results, loading, apiError, clearSearch };
 }


### PR DESCRIPTION
## 📝 Description

This PR addresses a critical bug where search failures were failing silently from the user's perspective. Previously, when a user tried to search and the backend API failed (e.g., team member API returned an error), they were simply presented with an empty list of results without any feedback explaining what went wrong. 

## 🐛 Root Cause
The `useEventSearch` hook (`website/src/hooks/useEventSearch.js`) has an internal state called `apiError`. It successfully catches failing network requests and updates this state via `setApiError`. However, this state variable was **never included in the return object** of the hook. Consequently, consumer components (like `SearchBar`) were completely blind to these errors.

## 🛠️ Proposed Changes
- Modified `website/src/hooks/useEventSearch.js` to expose the `apiError` variable in the returned properties of the hook.
- `SearchBar` (and any other components using this hook) will now be able to consume `apiError` and gracefully render error messages or fallback UIs when search requests fail.

## 🔗 Related Issue
- Resolves #[2859](https://github.com/Ayushh-Sharmaa/NexaSphere/issues/2859)

## 📋 Expected Behavior

**Before this PR:**
If the `/api/content/team` endpoint failed, `useEventSearch` would update its internal error state but fail to pass it outward. The UI would confusingly display "No results found" or an empty dropdown, leaving the user with no context.

**After this PR:**
The error state seamlessly flows from the `useEventSearch` hook to the UI. If the endpoint goes down or times out, the search bar will be able to display the appropriate error message (e.g., `"Team member search unavailable (500)"` or `"Failed to search team members. Please try again."`), dramatically improving UX and developer debugging.

## ✅ Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## 🧪 How to Test
1. Spin up the application locally.
2. Intercept the network request to `/api/content/team` (using Chrome DevTools Network Tab -> Block Request URL, or an adblocker).
3. Attempt to type a query into the Search bar.
4. Verify that the UI component now receives the `apiError` from the hook instead of remaining silent. 
