### PR TITLE
fix: validate session date before formatting in MentorshipDashboard.jsx

### DIFF
--- a/website/src/pages/mentorship/MentorshipDashboard.jsx
+++ b/website/src/pages/mentorship/MentorshipDashboard.jsx
@@ -1,4 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatSessionDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
 import {
   Users,
   BookOpen,
@@ -298,7 +307,7 @@ function MentorshipDashboard() {
                         </div>
                         {s.notes && <p className="text-xs text-gray-400 line-clamp-2">{s.notes}</p>}
                         <p className="text-xs text-gray-500 mt-1">
-                          {new Date(s.sessionDate || s.createdAt).toLocaleDateString()}
+                          {formatSessionDate(s.sessionDate || s.createdAt)}
                         </p>
                       </div>
                     ))


### PR DESCRIPTION
## Description
`MentorshipDashboard.jsx` line 301 passed `s.sessionDate || s.createdAt` directly into `new Date(...).toLocaleDateString()` with no validation. If both fields were `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the session list.

Changes made:
- Added a `formatSessionDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown date"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #2816

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings