### PR TITLE
fix: validate campaign date before formatting in EmailCampaignsPage.jsx

### DIFF
--- a/website/src/pages/email-campaigns/EmailCampaignsPage.jsx
+++ b/website/src/pages/email-campaigns/EmailCampaignsPage.jsx
@@ -1,4 +1,13 @@
 import React, { useState, useEffect } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatCampaignDate(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleDateString();
+}
 import { buildUrl, getApiBase } from '../../utils/runtimeConfig';
 
 const pageStyle = {
@@ -448,7 +457,7 @@ export default function EmailCampaignsPage() {
                     <td style={tdStyle}>
                       <span style={statusBadgeStyle(campaign.status)}>{campaign.status}</span>
                     </td>
-                    <td style={tdStyle}>{new Date(campaign.createdAt).toLocaleDateString()}</td>
+                    <td style={tdStyle}>{formatCampaignDate(campaign.createdAt)}</td>
                     <td style={tdStyle}>
                       <div style={{ display: 'flex', gap: '8px' }}>
                         {campaign.status === 'draft' && (


### PR DESCRIPTION
## Description
`EmailCampaignsPage.jsx` line 451 passed `campaign.createdAt` directly into `new Date(...).toLocaleDateString()` with no validation. If `createdAt` was `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the campaigns table.

Changes made:
- Added a `formatCampaignDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #2815

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings