### PR TITLE
fix: validate stream timestamps before formatting in LiveStreamPage.jsx

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -1,4 +1,19 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatStreamDate(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleString();
+}
+function formatStreamTime(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleTimeString();
+}
 import { getApiBase } from '../../utils/runtimeConfig';
 import { useParams } from 'react-router-dom';
 import {
@@ -349,7 +364,7 @@ function LiveStreamPage() {
               <Users className="w-4 h-4" /> {stream.viewerCount || 0} viewers
             </span>
             {stream.scheduledStart && (
-              <span>Scheduled: {new Date(stream.scheduledStart).toLocaleString()}</span>
+              <span>Scheduled: {formatStreamDate(stream.scheduledStart)}</span>
             )}
           </div>
         </div>
@@ -412,7 +427,7 @@ function LiveStreamPage() {
                   <div className="flex justify-between">
                     <span className="text-gray-400">Started</span>
                     <span className="font-medium">
-                      {new Date(stream.startedAt).toLocaleTimeString()}
+                      {formatStreamTime(stream.startedAt)}
                     </span>
                   </div>
                 )}
@@ -420,7 +435,7 @@ function LiveStreamPage() {
                   <div className="flex justify-between">
                     <span className="text-gray-400">Ended</span>
                     <span className="font-medium">
-                      {new Date(stream.endedAt).toLocaleTimeString()}
+                      {formatStreamTime(stream.endedAt)}
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Description
`LiveStreamPage.jsx` passed `stream.scheduledStart`, `stream.startedAt`, and `stream.endedAt` directly into `new Date(...).toLocaleString()`/`toLocaleTimeString()` with no validation. If any of these fields were `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the Stream Info panel.

Changes made:
- Added `formatStreamDate()` and `formatStreamTime()` helpers that check for a falsy value and validate via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown"` otherwise
- Replaced all three unguarded inline call sites with the helpers
- Zero new TypeScript errors introduced

Fixes #2814

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings