### PR TITLE
fix: validate thread date before formatting in ForumPage.jsx

### DIFF
--- a/website/src/pages/forum/ForumPage.jsx
+++ b/website/src/pages/forum/ForumPage.jsx
@@ -1,4 +1,13 @@
 import { useState, useEffect, useMemo } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatThreadDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
 import { useNavigate } from 'react-router-dom';
 import { apiClient } from '../../utils/apiClient';
 import { getApiBase } from '../../utils/runtimeConfig';
@@ -329,7 +338,7 @@ export default function ForumPage({ onBack }) {
                     <div
                       style={{ fontSize: '0.8rem', color: 'var(--text-secondary)', marginTop: 8 }}
                     >
-                      by {thread.authorName} · {new Date(thread.createdAt).toLocaleDateString()}
+                      by {thread.authorName} · {formatThreadDate(thread.createdAt)}
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Description
`ForumPage.jsx` line 332 passed `thread.createdAt` directly into `new Date(...).toLocaleDateString()` with no validation. If `createdAt` was `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the thread list next to the author name.

Changes made:
- Added a `formatThreadDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown date"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #2813

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings