### PR TITLE
fix: clean up pending animationend listeners on unmount in EventsSection.jsx

### DIFF
--- a/website/src/pages/events/EventsSection.jsx
+++ b/website/src/pages/events/EventsSection.jsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { DynamicIcon } from '../../shared/Icons';
 import EventCountdown from '../../components/events/EventCountdown.jsx';
 import { getEventCountdownStatus, parseDate } from '../../hooks/useCountdown.js';
@@ -15,21 +15,24 @@ export default function EventsSection({ onEventClick, events = [] }) {
     return null;
   };
 
+  const pendingAnimationListenersRef = useRef([]);
   useEffect(() => {
     const obs = new IntersectionObserver(
       (entries) => {
         entries.forEach((e) => {
           if (e.isIntersecting && !e.target.classList.contains('fired')) {
             e.target.classList.add('fired');
-            e.target.addEventListener(
-              'animationend',
-              () => {
-                e.target.style.opacity = '1';
-                e.target.style.transform = 'none';
-              },
-              { once: true }
-            );
-            obs.unobserve(e.target);
+            const target = e.target;
+            const handler = () => {
+              target.style.opacity = '1';
+              target.style.transform = 'none';
+              pendingAnimationListenersRef.current = pendingAnimationListenersRef.current.filter(
+                (entry) => entry.target !== target
+              );
+            };
+            target.addEventListener('animationend', handler, { once: true });
+            pendingAnimationListenersRef.current.push({ target, handler });
+            obs.unobserve(target);
           }
         });
       },
@@ -40,7 +43,13 @@ export default function EventsSection({ onEventClick, events = [] }) {
         '#section-events .pop-in,#section-events .pop-left,#section-events .pop-right,#section-events .pop-word'
       )
       .forEach((el) => obs.observe(el));
-    return () => obs.disconnect();
+    return () => {
+      obs.disconnect();
+      pendingAnimationListenersRef.current.forEach(({ target, handler }) => {
+        target.removeEventListener('animationend', handler);
+      });
+      pendingAnimationListenersRef.current = [];
+    };
   }, []);
 
   const getEffectiveStatus = (ev) => {


### PR DESCRIPTION
## Description
`EventsSection.jsx`'s `IntersectionObserver` callback added `animationend` listeners with `{ once: true }` that were never tracked for removal — the same leak pattern already fixed in `AboutSection.jsx` (#2503), `TeamSection.jsx` (#2504), and `ActivitiesSection.jsx` (#2810). If the component unmounted while an element's CSS animation was still in flight, the listener remained attached and later mutated a detached DOM node's `style` when it eventually fired.

Changes made:
- Added `pendingAnimationListenersRef` to track `{ target, handler }` pairs for all dynamically-added `animationend` listeners
- Cleanup function now removes any still-pending listeners alongside the existing `obs.disconnect()`
- Each handler self-removes its own entry from the ref once it fires normally, keeping the tracked list accurate
- Zero new TypeScript errors introduced

Fixes #2812

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings