### PR TITLE
fix: add missing auth middleware to notification preference routes

### DIFF
--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -15,6 +15,7 @@ import { pushSubscriptionsRepository } from '../repositories/pushSubscriptionsRe
 import { notificationPreferencesRepository } from '../repositories/notificationPreferencesRepository.js';
 import { studentAuthService } from '../services/studentAuthService.js';
 import { notificationSchema } from '../validators/notificationSchemas.js';
+import { requireNotificationPrefAuth } from '../middleware/auth/customAuth.js';
 
 const router = Router();
 


### PR DESCRIPTION
## Fixes #3209

### Summary
Fixed three notification preference routes that had **zero authentication middleware**, allowing any unauthenticated user on the internet to read and modify any user's notification settings.

### Root Cause
`server/routes/notifications.js` referenced `requireNotificationPrefAuth` on lines 360, 370, and 391 but **never imported it**. This left the following routes completely unprotected:

- `GET /notifications/preferences` — read any user's preferences
- `PUT /notifications/preferences` — modify any user's preferences
- `PUT /notifications/preferences/bulk` — bulk update any user's preferences

### Fix
Added the missing import:
```js
import { requireNotificationPrefAuth } from '../middleware/auth/customAuth.js';
```

The `requireNotificationPrefAuth` middleware (from `customAuth.js`) enforces:
- **Admin authentication** — admin sessions are accepted for all operations
- **Student authentication** — student tokens are accepted only for the student's own userId
- **401 Unauthorized** — returned for unauthenticated requests
- **403 Forbidden** — returned when a student tries to access/modify another user's preferences

### Impact
Before: Any unauthenticated user could silently disable all notifications for any user, or redirect notifications to attacker-controlled settings.

After: All preference routes require valid authentication and users can only access their own preferences (admins can access all).
