### PR TITLE
fix: repair broken admin login 2FA setup flow

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -421,24 +421,19 @@ async function login(req, res) {
         username: u,
         role,
         scopes,
-      },
-    });
+        secret,
+        backupCodes,
+        ip,
+        userAgent,
+        suspicious,
+      });
 
-    // Write session to shared Redis for cross-service validation
-    try {
-      const tokenHash = hashToken(session.token);
-      const redisKey = REDIS_SESSION_PREFIX + tokenHash;
-      const redisPayload = JSON.stringify({
-        token: tokenHash,
-        email: u,
-        createdAt: new Date().toISOString(),
-        expiresAt: session.expiresAt,
-        metadata: {
-          userAgent: req.get('user-agent') || '',
-          ip,
-          role,
-          scopes,
-        },
+      return res.status(200).json({
+        requiresTwoFactorSetup: true,
+        setupToken,
+        qrCodeDataUrl,
+        backupCodes,
+        expiresAt: Date.now() + PENDING_2FA_TTL_MS,
       });
     }
 


### PR DESCRIPTION
## Fixes #3210

### Summary
Fixed two critical bugs in the admin login function that completely prevented admin authentication when 2FA was not yet enabled.

### Bug 1: Incomplete `setupToken` payload (line 420-425)
The `createPendingToken` call for `pendingTwoFactorSetups` only stored `{username, role, scopes}`. However, `verifyTwoFactorSetup` (line 566) requires:
- `pending.secret` — used to verify the TOTP code (line 575)
- `pending.backupCodes` — passed to `enableAdminTwoFactor` for database storage (line 587)
- `pending.ip`, `pending.userAgent`, `pending.suspicious` — spread into `completeAdminLogin` (line 590)

All were `undefined`, causing every 2FA setup attempt to fail with "Invalid authenticator code" or a 500 error.

### Bug 2: Undefined `session` variable reference (lines 429-443)
Dead code referenced `session.token` and `session.expiresAt` but `session` was never defined in the login function scope. This threw a `ReferenceError` at runtime, caught by the outer try/catch, returning a generic "Unable to create admin session" 500 error — blocking all admin logins for users without 2FA.

### Changes
- Added `secret`, `backupCodes`, `ip`, `userAgent`, `suspicious` to the `setupToken` payload
- Changed response to return `requiresTwoFactorSetup: true` with `setupToken`, `qrCodeDataUrl`, and `backupCodes` for the setup flow
- Removed the broken `session` reference and dead Redis write code from the setup path (session writing is properly handled in `completeAdminLogin` after 2FA verification)

### Flow after fix
1. Admin logs in without 2FA enabled
2. Server generates TOTP secret + backup codes, stores in pending setup token
3. Returns `requiresTwoFactorSetup: true` with QR code and setup token
4. Admin scans QR code, enters authenticator code
5. `verifyTwoFactorSetup` verifies against stored secret, creates session
