### PR TITLE
fix: move Gemini API calls from frontend to server-side proxy

### DIFF
--- a/server/routes/moderation.js
+++ b/server/routes/moderation.js
@@ -1,8 +1,58 @@
 import { Router } from 'express';
 import { requireStudentAuth } from '../middleware/studentAuthMiddleware.js';
 import * as moderationController from '../controllers/moderationController.js';
+import { GoogleGenerativeAI } from '@google/generative-ai';
 
 const router = Router();
+
+/**
+ * POST /moderation/ai-check — Server-side AI content moderation proxy.
+ * Calls Gemini API using the server-side GEMINI_API_KEY (never exposed to client).
+ */
+router.post('/ai-check', requireStudentAuth, async (req, res) => {
+  try {
+    const { content } = req.body || {};
+    if (!content || typeof content !== 'string') {
+      return res.status(400).json({ error: 'content string is required' });
+    }
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) {
+      return res.json({ flags: [], confidence: 0, explanation: 'AI moderation not configured' });
+    }
+
+    const genAI = new GoogleGenerativeAI(apiKey);
+    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+
+    const prompt = `
+      Analyze the following content for toxicity, hate speech, harassment, and inappropriate material.
+      Content: "${content}"
+      
+      Return a JSON object with:
+      - isAppropriate: boolean
+      - categories: array of detected issues (spam, hate_speech, harassment, toxic, violence, self_harm, sexual)
+      - severity: low/medium/high/critical
+      - confidence: number between 0-1
+      - explanation: brief reason
+      
+      Only return valid JSON, no other text.
+    `;
+
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    const text = response.text();
+    const parsed = JSON.parse(text);
+
+    return res.json({
+      flags: parsed.categories?.map((cat) => ({ type: cat, confidence: parsed.confidence })) || [],
+      confidence: parsed.confidence || 0.7,
+      explanation: parsed.explanation,
+    });
+  } catch (error) {
+    console.error('[AI Moderation] Error:', error.message);
+    return res.json({ flags: [], confidence: 0, explanation: 'AI moderation unavailable' });
+  }
+});
 
 // Public endpoint for submitting reports
 router.post('/reports', moderationController.createFlag);

--- a/src/services/moderationService.js
+++ b/src/services/moderationService.js
@@ -1,8 +1,4 @@
 // src/services/moderationService.js
-import { GoogleGenerativeAI } from '@google/generative-ai';
-
-// Initialize Gemini AI
-const genAI = new GoogleGenerativeAI(import.meta.env.VITE_GEMINI_API_KEY || '');
 
 // Content categories for moderation
 export const MODERATION_CATEGORIES = {
@@ -63,8 +59,8 @@ class ModerationService {
       result.severity = SEVERITY.MEDIUM;
     }
 
-    // Run NLP detection using Gemini
-    if (import.meta.env.VITE_GEMINI_API_KEY) {
+    // Run NLP detection using server-side AI proxy
+    if (this.isConfigured()) {
       const aiResult = await this.detectWithAI(content);
       if (aiResult.flags.length > 0) {
         result.isAppropriate = false;
@@ -73,7 +69,7 @@ class ModerationService {
       }
       result.confidence = aiResult.confidence;
     } else {
-      console.warn('Gemini API key not configured. Using basic detection only.');
+      console.warn('AI moderation endpoint not available. Using basic detection only.');
     }
 
     // Determine action based on user reputation
@@ -127,37 +123,30 @@ class ModerationService {
     };
   }
 
-  // AI-based content detection
+  // Check if server-side AI moderation endpoint is available
+  isConfigured() {
+    const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+    return Boolean(base);
+  }
+
+  // AI-based content detection via server-side proxy
   async detectWithAI(content) {
     try {
-      const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const res = await fetch(`${base}/api/moderation/ai-check`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ content }),
+      });
 
-      const prompt = `
-        Analyze the following content for toxicity, hate speech, harassment, and inappropriate material.
-        Content: "${content}"
-        
-        Return a JSON object with:
-        - isAppropriate: boolean
-        - categories: array of detected issues (spam, hate_speech, harassment, toxic, violence, self_harm, sexual)
-        - severity: low/medium/high/critical
-        - confidence: number between 0-1
-        - explanation: brief reason
-        
-        Only return valid JSON, no other text.
-      `;
+      if (!res.ok) return { flags: [], confidence: 0 };
 
-      const result = await model.generateContent(prompt);
-      const response = await result.response;
-      const text = response.text();
-
-      // Parse JSON response
-      const parsed = JSON.parse(text);
-
+      const data = await res.json();
       return {
-        flags:
-          parsed.categories?.map((cat) => ({ type: cat, confidence: parsed.confidence })) || [],
-        confidence: parsed.confidence || 0.7,
-        explanation: parsed.explanation,
+        flags: data.flags || [],
+        confidence: data.confidence || 0.7,
+        explanation: data.explanation,
       };
     } catch (error) {
       console.error('AI moderation failed:', error);


### PR DESCRIPTION
## Fixes #3211

### Summary
Moved Gemini API calls from the frontend JavaScript bundle to a server-side proxy endpoint, eliminating the exposure of `VITE_GEMINI_API_KEY` to every site visitor.

### Problem
`src/services/moderationService.js` imported `GoogleGenerativeAI` and initialized it with `import.meta.env.VITE_GEMINI_API_KEY`. Vite embeds all `VITE_`-prefixed env vars into the client-side JS bundle at build time, making the API key visible to anyone who inspects the page source or network tab.

### Changes

**Server — `server/routes/moderation.js`:**
- Added `POST /api/moderation/ai-check` endpoint that accepts `{ content }` and calls Gemini API server-side using `process.env.GEMINI_API_KEY`
- Requires student authentication
- Gracefully returns empty results if `GEMINI_API_KEY` is not configured or Gemini fails

**Frontend — `src/services/moderationService.js`:**
- Removed `GoogleGenerativeAI` import and `VITE_GEMINI_API_KEY` initialization
- Updated `detectWithAI()` to call `POST /api/moderation/ai-check` server proxy
- Added `isConfigured()` helper that checks if `VITE_API_BASE` is set

### Security guarantee
- `GEMINI_API_KEY` is only used server-side in `process.env` — never sent to the browser
- The AI moderation endpoint requires authentication
- Frontend only sends content text to the server proxy, never the API key
