### PR TITLE
fix: prevent SQL injection via table name interpolation

### DIFF
--- a/server/scripts/validate-database.js
+++ b/server/scripts/validate-database.js
@@ -22,6 +22,7 @@
  */
 
 import { withDb } from '../repositories/db.js';
+import { validateTableName, validateColumnName } from '../utils/sqlSafety.js';
 
 const MODE = process.argv.includes('--pre') ? 'pre' : 'post';
 
@@ -194,7 +195,7 @@ async function checkNotNullConstraints(client) {
     }
 
     const res = await client.query(
-      `SELECT COUNT(*) AS count FROM ${table} WHERE ${column} IS NULL`
+      `SELECT COUNT(*) AS count FROM ${validateTableName(table)} WHERE ${validateColumnName(column)} IS NULL`
     );
     const nullCount = parseInt(res.rows[0].count, 10);
     if (nullCount > 0) {
@@ -217,7 +218,7 @@ async function checkRowCounts(client) {
       continue;
     }
 
-    const res = await client.query(`SELECT COUNT(*) AS count FROM ${table}`);
+    const res = await client.query(`SELECT COUNT(*) AS count FROM ${validateTableName(table)}`);
     const count = parseInt(res.rows[0].count, 10);
     console.log(`  → "${table}": ${count} rows (minimum: ${minCount})`);
     if (count < minCount) {

--- a/server/services/backupService.js
+++ b/server/services/backupService.js
@@ -14,6 +14,7 @@ import logger from '../utils/logger.js';
 import { withDb } from '../repositories/db.js';
 import { HAS_SUPABASE } from '../storage/supabaseClient.js';
 import { sendSlackAlert } from '../utils/slack.js';
+import { validateTableName, validateIdentifier } from '../utils/sqlSafety.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -171,26 +172,20 @@ export const backupService = {
         // Truncate all tables first
         for (const table of Object.keys(tables)) {
           // Validate table name to prevent SQL injection
-          if (!/^[a-zA-Z0-9_]+$/.test(table)) {
-            throw new Error(`Invalid table name in restore schema: ${table}`);
-          }
+          validateTableName(table);
           // codeql[js/sql-injection]
-          await client.query(`TRUNCATE TABLE "${table}" CASCADE`);
+          await client.query(`TRUNCATE TABLE ${validateTableName(table)} CASCADE`);
         }
 
         // Insert rows back
         for (const [table, rows] of Object.entries(tables)) {
           if (!rows || rows.length === 0) continue;
           // Validate table name to prevent SQL injection
-          if (!/^[a-zA-Z0-9_]+$/.test(table)) {
-            throw new Error(`Invalid table name in restore data: ${table}`);
-          }
+          validateTableName(table);
 
           const columns = Object.keys(rows[0]);
           for (const col of columns) {
-            if (!/^[a-zA-Z0-9_]+$/.test(col)) {
-              throw new Error(`Invalid column name in restore data: ${col}`);
-            }
+            validateIdentifier(col);
           }
           const colString = columns.map((c) => `"${c}"`).join(', ');
 

--- a/server/services/bulkOperationsService.js
+++ b/server/services/bulkOperationsService.js
@@ -4,6 +4,7 @@ import { eventsRepository } from '../repositories/eventsRepository.js';
 import { auditLogRepository } from '../repositories/auditLogRepository.js';
 import { parseCSV, generateCSV } from '../utils/csvParser.js';
 import { sendEmail } from './emailService.js';
+import { validateTableName } from '../utils/sqlSafety.js';
 import crypto from 'crypto';
 import bcrypt from 'bcryptjs';
 
@@ -986,7 +987,7 @@ class BulkOperationsService {
 
         if (op.type === 'insert') {
           // A insert rollback deletes the created row
-          await client.query(`DELETE FROM ${op.table} WHERE id = $1`, [op.key]);
+          await client.query(`DELETE FROM ${validateTableName(op.table)} WHERE id = $1`, [op.key]);
           rolledBackOps.push({ type: 'delete', table: op.table, key: op.key });
         } else if (op.type === 'update') {
           // A update rollback restores previous values
@@ -1006,7 +1007,7 @@ class BulkOperationsService {
           });
 
           values.push(op.key);
-          const sql = `UPDATE ${op.table} SET ${fields.join(', ')} WHERE id = $${index}`;
+          const sql = `UPDATE ${validateTableName(op.table)} SET ${fields.join(', ')} WHERE id = $${index}`;
           await client.query(sql, values);
           rolledBackOps.push({ type: 'update', table: op.table, key: op.key });
         }

--- a/server/utils/sqlSafety.js
+++ b/server/utils/sqlSafety.js
@@ -1,0 +1,132 @@
+/**
+ * SQL safety utilities — validates identifiers (table/column names) against
+ * an allowlist to prevent SQL injection via template-literal interpolation.
+ *
+ * PostgreSQL parameterized queries ($1, $2) only protect *values*, not
+ * *identifiers*. These helpers must be used whenever a table or column name
+ * is interpolated into a query string.
+ */
+
+/**
+ * Allowed table names for dynamic SQL queries.
+ * Add new tables here when they are created via migrations.
+ */
+const ALLOWED_TABLES = new Set([
+  'admin_sessions',
+  'admin_security_accounts',
+  'users',
+  'events',
+  'notifications',
+  'push_subscriptions',
+  'notification_preferences',
+  'moderation_flags',
+  'moderation_user_warnings',
+  'moderation_notes',
+  'moderation_appeals',
+  'forum_threads',
+  'forum_replies',
+  'resources',
+  'stream_chats',
+  'streams',
+  'registrations',
+  'waitlist',
+  'portfolios',
+  'portfolio_analytics',
+  'certificates',
+  'event_certificates',
+  'custom_roles',
+  'user_roles',
+  'rbac_audit_logs',
+  'student_users',
+  'email_campaigns',
+  'user_segments',
+  'custom_events',
+  'analytics_events',
+  'webhook_subscriptions',
+  'backup_metadata',
+  'content_store',
+  'activity_timeline',
+  'announcements',
+  'scheduled_jobs',
+  'pricing_tiers',
+  'subscriptions',
+  'invoices',
+  'payments',
+  'sponsorships',
+  'learning_paths',
+  'learning_path_steps',
+  'user_learning_progress',
+  'forum_thread_tags',
+  'event_feedback',
+  'event_checkins',
+  'leaderboard',
+  'gamification_points',
+  'gamification_badges',
+  'user_badges',
+  'compliance_audit_logs',
+  'gdpr_requests',
+  'pci_audit_logs',
+  'wcag_issues',
+  'outbox_events',
+  'event_stream_outbox',
+]);
+
+/**
+ * Allowed column name pattern — alphanumeric + underscores only.
+ * This is a secondary defense; the primary defense is the table allowlist.
+ */
+const VALID_IDENTIFIER_PATTERN = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+/**
+ * Validates that a table name is in the allowlist.
+ * Throws an error if the table name is not allowed.
+ *
+ * @param {string} table - The table name to validate
+ * @returns {string} The validated table name (quoted for SQL)
+ * @throws {Error} If the table name is not in the allowlist
+ */
+export function validateTableName(table) {
+  if (typeof table !== 'string' || !table) {
+    throw new Error('Table name must be a non-empty string');
+  }
+  if (!ALLOWED_TABLES.has(table)) {
+    throw new Error(`SQL injection blocked: table "${table}" is not in the allowlist`);
+  }
+  return `"${table}"`;
+}
+
+/**
+ * Validates that a column name matches the safe identifier pattern.
+ * Throws an error if the column name contains invalid characters.
+ *
+ * @param {string} column - The column name to validate
+ * @returns {string} The validated column name (quoted for SQL)
+ * @throws {Error} If the column name contains invalid characters
+ */
+export function validateColumnName(column) {
+  if (typeof column !== 'string' || !column) {
+    throw new Error('Column name must be a non-empty string');
+  }
+  if (!VALID_IDENTIFIER_PATTERN.test(column)) {
+    throw new Error(`SQL injection blocked: column "${column}" contains invalid characters`);
+  }
+  return `"${column}"`;
+}
+
+/**
+ * Validates that an identifier (table or column) is safe for SQL interpolation.
+ * Uses a permissive regex for backward compatibility with existing code.
+ *
+ * @param {string} name - The identifier to validate
+ * @returns {string} The validated identifier
+ * @throws {Error} If the identifier contains invalid characters
+ */
+export function validateIdentifier(name) {
+  if (typeof name !== 'string' || !name) {
+    throw new Error('Identifier must be a non-empty string');
+  }
+  if (!/^[a-zA-Z0-9_]+$/.test(name)) {
+    throw new Error(`SQL injection blocked: identifier "${name}" contains invalid characters`);
+  }
+  return name;
+}


### PR DESCRIPTION
## Fixes #3212

### Summary
Prevented SQL injection via table name interpolation in multiple server modules by adding a shared allowlist-based validation utility.

### Problem
PostgreSQL parameterized queries (`$1`, `$2`) only protect **values**, not **identifiers** (table/column names). Several modules interpolated table names directly into SQL query strings using template literals, creating SQL injection vectors — especially in `bulkOperationsService.js` where `op.table` originates from audit log data that could be influenced by user operations.

### Changes

**New — `server/utils/sqlSafety.js`:**
- `validateTableName(table)` — checks table name against an allowlist of known database tables, throws if not found
- `validateColumnName(column)` — validates column names match `/^[a-zA-Z_][a-zA-Z0-9_]*$/`
- `validateIdentifier(name)` — validates identifiers match `/^[a-zA-Z0-9_]+$/`

**`server/scripts/validate-database.js`:**
- Wrapped table/column interpolation with `validateTableName()` and `validateColumnName()`

**`server/services/bulkOperationsService.js`:**
- Wrapped `op.table` with `validateTableName()` in DELETE and UPDATE rollback queries (lines 989, 1009)

**`server/services/backupService.js`:**
- Replaced ad-hoc regex checks with shared `validateTableName()` and `validateIdentifier()` utilities

### Security guarantee
- Table names are validated against an explicit allowlist of 50+ known tables
- Any attempt to inject SQL through a table name throws `"SQL injection blocked: table X is not in the allowlist"`
- New tables must be added to the allowlist in `sqlSafety.js` when created via migrations
