### PR TITLE
fix(security): use crypto.randomInt for recovery codes and add rate l…

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,13 +63,11 @@
     "lightningcss-win32-x64-msvc": "^1.32.0"
   },
   "dependencies": {
- feat/i18n-localization-1397
     "@prisma/client": "^7.8.0",
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
 
     "@prisma/client": "^6.4.0",
- main
     "jwt-decode": "^4.0.0",
     "lru-cache": "^11.5.1",
     "next-intl": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "i18next": "^26.3.1",
     "i18next-browser-languagedetector": "^8.2.1",
 
-    "@prisma/client": "^6.4.0",
     "jwt-decode": "^4.0.0",
     "lru-cache": "^11.5.1",
     "next-intl": "^4.13.0",

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -92,7 +92,7 @@ router.delete(
   adminAuthMiddleware.requireScope('events:write'),
   activityEventsController.deleteActivityEvent
 );
-router.post('/account-recovery/request', async (req, res) => {
+router.post('/account-recovery/request', authRateLimiter, async (req, res) => {
   const { email } = req.body;
   if (!email) {
     return res.status(400).json({ error: 'Email is required' });
@@ -105,7 +105,7 @@ router.post('/account-recovery/request', async (req, res) => {
     message: 'If an account with that email exists, a recovery code has been sent.',
   });
 });
-router.post('/account-recovery/verify', async (req, res) => {
+router.post('/account-recovery/verify', authRateLimiter, async (req, res) => {
   const { email, enteredCode } = req.body;
   if (!email || !enteredCode) {
     return res.status(400).json({ error: 'Email and code are required' });

--- a/server/services/studentAuthService.js
+++ b/server/services/studentAuthService.js
@@ -54,7 +54,7 @@ export const studentAuthService = {
   },
 
   generateRecoveryCode() {
-    return Math.floor(100000 + Math.random() * 900000).toString();
+    return crypto.randomInt(100000, 1000000).toString();
   },
 
   hashRecoveryCode(code) {


### PR DESCRIPTION
## Description

Fixes #2802.

`generateRecoveryCode()` used `Math.random()` to generate account-recovery
codes. This is not cryptographically secure and produces predictable output.
Combined with the lack of rate limiting on the recovery endpoints, an
attacker could brute-force the full ~900,000-code space well within the
15-minute expiry window, leading to account takeover.

## Changes

- **`server/services/studentAuthService.js`**
  Replaced `Math.random()` with `crypto.randomInt(100000, 1000000)` in
  `generateRecoveryCode()`.

- **`server/routes/api.js`**
  Added the existing `authRateLimiter` middleware to:
  - `POST /account-recovery/request`
  - `POST /account-recovery/verify`

- **`package.json`**
  Fixed a pre-existing unresolved merge conflict in the `dependencies`
  block (leftover branch-name text and a duplicate `@prisma/client` entry)
  that was breaking `npm install`/CI for everyone.

## Checklist
- [x] Code follows the project's style guidelines
- [x] I have tested my changes locally
- [ ] Full CI suite passes (in progress — pre-existing repo issues found and fixed along the way)
- [x] I have linked the related issue (#2802)

Fixes #2802