### PR TITLE
fix: use window.confirm for event definition deletion

### DIFF
--- a/admin-dashboard/src/pages/CustomEventTracking.jsx
+++ b/admin-dashboard/src/pages/CustomEventTracking.jsx
@@ -405,7 +405,7 @@ export function CustomEventTracking() {
   }
 
   async function handleDelete(id) {
-    if (!confirm('Delete this event definition and all its logs? This cannot be undone.')) return;
+    if (!window.confirm('Delete this event definition and all its logs? This cannot be undone.')) return;
     await fetch(`${API_BASE}/api/admin/custom-events/definitions/${id}`, {
       method: 'DELETE',
       credentials: 'include',


### PR DESCRIPTION
## Summary

This PR fixes #3280 by replacing the global `confirm()` call with `window.confirm()` in the Custom Event Tracking page.

### Changes Made

- Replaced `confirm()` with `window.confirm()` in the event deletion confirmation flow.
- Preserved the existing delete behavior while making the browser API reference explicit.

### Why

Using `window.confirm()` avoids potential `ReferenceError` issues in strict environments and is more consistent with the rest of the codebase.

Closes #3280

## Testing

- Verified the confirmation dialog appears before deleting an event definition.
- Verified deletion is cancelled when the user clicks **Cancel**.
- Verified deletion proceeds normally when the user clicks **OK**.

## Rollback Plan

Revert this commit to restore the previous behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review