### PR TITLE
fix: use window.confirm in UserManager confirmation dialogs

### DIFF
--- a/admin-dashboard/src/pages/UserManager.jsx
+++ b/admin-dashboard/src/pages/UserManager.jsx
@@ -191,7 +191,7 @@ export default function UserManager() {
   }
 
   async function handleDeactivate(id) {
-    if (!confirm('Deactivate this user?')) return;
+    if (!window.confirm('Deactivate this user?')) return;
     setDeleting(id);
     try {
       const res = await fetch(`/api/admin/users/${id}`, {
@@ -235,7 +235,7 @@ export default function UserManager() {
   }
 
   async function handleUnlock(id) {
-    if (!confirm('Unlock this user account?')) return;
+    if (!window.confirm('Unlock this user account?')) return;
     try {
       const res = await fetch(`/api/admin/users/${id}/unlock`, {
         method: 'POST',


### PR DESCRIPTION
## Summary

This PR fixes #3281 by replacing the global `confirm()` calls with `window.confirm()` in the User Manager page.

### Changes Made

- Replaced `confirm()` with `window.confirm()` when deactivating a user.
- Replaced `confirm()` with `window.confirm()` when unlocking a user account.
- Preserved the existing confirmation flow while making the browser API reference explicit.

### Why

Using `window.confirm()` avoids potential `ReferenceError` issues in strict bundler environments and keeps the implementation consistent with the rest of the codebase.

Closes #3281

## Testing

- Verified the confirmation dialog appears before deactivating a user.
- Verified the confirmation dialog appears before unlocking a user.
- Verified the action is cancelled when **Cancel** is clicked.
- Verified the action proceeds normally when **OK** is clicked.

## Rollback Plan

Revert this commit to restore the previous behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review