### PR TITLE
fix: log errors instead of silently swallowing exceptions in useNotifications

### DIFF
--- a/website/src/hooks/useNotifications.js
+++ b/website/src/hooks/useNotifications.js
@@ -174,7 +174,9 @@ export function useNotifications() {
                 suppressedReason: !channelEnabled ? 'channel' : dnd ? 'dnd' : 'quiet',
               });
               localStorage.setItem(key, JSON.stringify(arr));
-            } catch (e) {}
+            } catch (e) {
+              console.error('[useNotifications] Failed to queue digest:', e);
+            }
             return;
           }
 
@@ -320,7 +322,9 @@ export function useNotifications() {
           body: JSON.stringify({ id }),
         });
         analytics.trackNotificationOpened({ id });
-      } catch (e) {}
+      } catch (e) {
+        console.error('[useNotifications] Failed to mark as read:', e);
+      }
     })();
   }, []);
 
@@ -336,7 +340,9 @@ export function useNotifications() {
           method: 'POST',
           headers: getAuthHeaders(),
         });
-      } catch (e) {}
+      } catch (e) {
+        console.error('[useNotifications] Failed to mark all as read:', e);
+      }
     })();
   }, []);
 
@@ -348,7 +354,9 @@ export function useNotifications() {
           method: 'DELETE',
           headers: getAuthHeaders(),
         });
-      } catch (e) {}
+      } catch (e) {
+        console.error('[useNotifications] Failed to clear notifications:', e);
+      }
     })();
   }, []);
 


### PR DESCRIPTION
## Summary

This PR fixes #3282 by replacing empty `catch` blocks in `useNotifications` with `console.error()` logging.

### Changes Made

- Added error logging for failures while queuing notification digests.
- Added error logging for failures while marking notifications as read.
- Added error logging for failures while marking all notifications as read.
- Added error logging for failures while clearing notifications.

### Why

Previously, these `catch` blocks silently ignored exceptions, making notification-related failures difficult to debug. Logging the errors improves observability while preserving the existing application behavior.

Closes #3282

## Testing

- Simulated notification request failures.
- Verified that errors are logged to the browser console.
- Verified that existing notification functionality remains unchanged.

## Rollback Plan

Revert this commit to restore the previous behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review