### PR TITLE
fix: show user feedback when clipboard copy fails

### DIFF
--- a/website/src/pages/contact/ContactPage.jsx
+++ b/website/src/pages/contact/ContactPage.jsx
@@ -421,13 +421,14 @@ function MessageCTA() {
   const [name, setName] = useState('');
   const [message, setMessage] = useState('');
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const copyTimeoutRef = useRef(null);
 
   useEffect(() => {
-    if (!copied) return;
-    const timer = setTimeout(() => setCopied(false), 2200);
+    if (!copied && !copyError) return;
+    const timer = setTimeout(() => { setCopied(false); setCopyError(false); }, 2200);
     return () => clearTimeout(timer);
-  }, [copied]);
+  }, [copied, copyError]);
 
   const handleCopy = () => {
     if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
@@ -435,9 +436,15 @@ function MessageCTA() {
       .writeText(EMAIL)
       .then(() => {
         setCopied(true);
-        copyTimeoutRef.current = setTimeout(() => setCopied(false), 2200);
+        setCopyError(false);
+        copyTimeoutRef.current = setTimeout(() => { setCopied(false); setCopyError(false); }, 2200);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.error('Failed to copy to clipboard', err);
+        setCopyError(true);
+        setCopied(false);
+        copyTimeoutRef.current = setTimeout(() => setCopyError(false), 2200);
+      });
   };
 
   useEffect(() => {
@@ -567,7 +574,7 @@ function MessageCTA() {
           onClick={handleCopy}
           style={{ flex: 1, minWidth: 0, justifyContent: 'center' }}
         >
-          {copied ? '✅ Copied!' : '📋 Copy Email'}
+          {copyError ? '❌ Copy failed' : copied ? '✅ Copied!' : '📋 Copy Email'}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary

This PR fixes #3283 by handling clipboard copy failures gracefully in the Contact page instead of silently swallowing promise rejections.

### Changes Made

- Added a `copyError` state to track clipboard copy failures.
- Replaced the empty `.catch()` block with proper error handling.
- Logged clipboard errors using `console.error()` for easier debugging.
- Displayed a user-friendly error message when the copy operation fails.
- Reset the success/error state automatically after a short delay.

### Why

Previously, clipboard copy failures were silently ignored, providing no feedback to users and making debugging difficult. This change improves both the user experience and error visibility while preserving the existing copy functionality.

Closes #3283

## Testing

- Verified the success message is shown when the email is copied successfully.
- Simulated clipboard failures and verified an error message is displayed.
- Confirmed errors are logged to the browser console.
- Verified the UI resets automatically after the timeout.

## Rollback Plan

Revert this commit to restore the previous clipboard copy behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review