### PR TITLE
fix: show error feedback when clipboard copy fails in TeamMemberModal

### DIFF
--- a/website/src/pages/team/TeamMemberModal.jsx
+++ b/website/src/pages/team/TeamMemberModal.jsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 // ── Copy Popup ──
 function CopyPopup({ value, onClose }) {
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const timeoutRef = useRef(null);
   const copiedTimeoutRef = useRef(null);
 
@@ -14,13 +15,24 @@ function CopyPopup({ value, onClose }) {
       .writeText(sanitized)
       .then(() => {
         setCopied(true);
+        setCopyError(false);
         if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
         copiedTimeoutRef.current = setTimeout(() => {
           setCopied(false);
+          setCopyError(false);
           copiedTimeoutRef.current = null;
         }, 2000);
       })
-      .catch(() => {});
+      .catch((err) => {
+        console.error('Failed to copy to clipboard', err);
+        setCopyError(true);
+        setCopied(false);
+        if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+        copiedTimeoutRef.current = setTimeout(() => {
+          setCopyError(false);
+          copiedTimeoutRef.current = null;
+        }, 2000);
+      });
   };
 
   useEffect(() => {
@@ -46,7 +58,7 @@ function CopyPopup({ value, onClose }) {
     <div className="copy-popup">
       <span className="copy-popup-value">{value}</span>
       <button className="copy-popup-btn" onClick={handleCopy}>
-        {copied ? '✅ Copied!' : '📋 Copy'}
+        {copyError ? '❌ Copy failed' : copied ? '✅ Copied!' : '📋 Copy'}
       </button>
     </div>
   );


### PR DESCRIPTION
## Summary

This PR fixes #3284 by handling clipboard copy failures in `TeamMemberModal` instead of silently swallowing promise rejections.

### Changes Made

- Added a `copyError` state to track clipboard copy failures.
- Replaced the empty `.catch()` block with proper error handling.
- Logged clipboard copy failures using `console.error()` for easier debugging.
- Displayed a user-friendly error message when the copy operation fails.
- Automatically reset the error state after a short delay.

### Why

Previously, clipboard copy failures were silently ignored, providing no feedback to users and making debugging difficult. This change improves both the user experience and error visibility while preserving the existing copy functionality.

Closes #3284

## Testing

- Verified the success message is shown when the copy operation succeeds.
- Simulated clipboard failures and verified that an error message is displayed.
- Confirmed errors are logged to the browser console.
- Verified the UI resets automatically after the timeout.

## Rollback Plan

Revert this commit to restore the previous clipboard copy behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review