### PR TITLE
fix: log view tracking failures in PublicPortfolio

### DIFF
--- a/website/src/pages/portfolio/PublicPortfolio.jsx
+++ b/website/src/pages/portfolio/PublicPortfolio.jsx
@@ -34,7 +34,9 @@ export default function PublicPortfolio({ username, onBack }) {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ referrer: document.referrer || null }),
-        }).catch(() => {});
+        }).catch((err) => {
+          console.error('[PublicPortfolio] View tracking failed:', err);
+        });
       } catch (err) {
         if (alive) {
           setError(err.message);


### PR DESCRIPTION
## Summary

This PR fixes #3285 by replacing an empty `.catch()` block with proper error logging in `PublicPortfolio`.

### Changes Made

- Replaced the empty `.catch(() => {})` block with `console.error()` logging.
- Preserved the existing portfolio loading behavior even if view tracking fails.
- Improved debugging by making view tracking failures visible in the browser console.

### Why

Previously, failures during portfolio view tracking were silently ignored, making them difficult to diagnose. This change surfaces those failures in the console while keeping the page functional for users.

Closes #3285

## Testing

- Simulated a failed view tracking request.
- Verified that the portfolio continues to load normally.
- Verified that the error is logged to the browser console.

## Rollback Plan

Revert this commit to restore the previous behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review