### PR TITLE
fix: resolve update coalesce trap to allow explicit nulls (#3298)

### DIFF
--- a/server/repositories/eventsRepository.js
+++ b/server/repositories/eventsRepository.js
@@ -54,21 +54,50 @@ export const eventsRepository = {
 
   async update(id, patch) {
     return withDb(async (client) => {
-      const { rows } = await client.query(
-        `update events set
-           name = coalesce($2, name),
-           short_name = coalesce($3, short_name),
-           date_text = coalesce($4, date_text),
-           description = coalesce($5, description),
-           status = coalesce($6, status),
-           icon = coalesce($7, icon),
-           tags = coalesce($8, tags),
-           updated_at = now()
-         where id = $1
-         returning *`,
-        [id, patch.name ?? null, patch.shortName ?? null, patch.date ?? null, patch.description ?? null, patch.status ?? null, patch.icon ?? null, patch.tags ?? null]
-      );
+      const keys = Object.keys(patch);
+      
+      // If the patch payload is empty, skip the DB call and just return the current record
+      if (keys.length === 0) {
+        const { rows } = await client.query('select * from events where id = $1', [id]);
+        return rows.length ? mapRow(rows[0]) : null;
+      }
+
+      // Map JavaScript camelCase properties back to database snake_case columns
+      const fieldMap = {
+        name: 'name',
+        shortName: 'short_name',
+        date: 'date_text',
+        description: 'description',
+        status: 'status',
+        icon: 'icon',
+        tags: 'tags'
+      };
+
+      const setClauses = [];
+      const values = [id]; // $1 is always the ID for the WHERE clause
+      let paramIndex = 2;   // Dynamic parameters start at $2
+
+      for (const key of keys) {
+        // Ensure the key exists in our map (prevents arbitrary injection of unmapped properties)
+        if (fieldMap[key] !== undefined) {
+          setClauses.push(`${fieldMap[key]} = $${paramIndex}`);
+          values.push(patch[key]); // This safely passes explicit nulls, strings, etc.
+          paramIndex++;
+        }
+      }
+
+      // Always append the updated timestamp
+      setClauses.push(`updated_at = now()`);
+
+      const queryText = `
+        update events 
+        set ${setClauses.join(', ')} 
+        where id = $1 
+        returning *`;
+
+      const { rows } = await client.query(queryText, values);
       if (!rows.length) return null;
+      
       return mapRow(rows[0]);
     });
   },


### PR DESCRIPTION
# Summary

This pull request resolves a critical data persistence bug in the `eventsRepository.update` method. Previously, the use of a strict `COALESCE` clause inside the SQL update query made it impossible to explicitly clear out or reset optional table columns (like `description`, `icon`, or `status`) back to `NULL`. The updated logic shifts to a clean, dynamic query execution structure that respects explicitly passed `null` values while safely omitting unprovided payload keys.

## Related Issue

Fixes #3298

## Type of Change

- [ ] Feature
- [x] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [x] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Removed the rigid static SQL fallback string `coalesce($2, name)` inside `eventsRepository.update`.
- Replaced it with a dynamic SQL `SET` string builder parsing the exact keys sent in the `patch` object.
- Added properties to explicit internal mapping definitions (`fieldMap`) to prevent arbitrary property injection vulnerabilities.
- Guaranteed that explicit `null` updates are transmitted cleanly directly down to the storage layers while missing payload keys (`undefined`) are cleanly skipped.

## Technical Details

### Frontend

- None. (Backend entity service adjustments)

### Backend

- **Refactored Method:** `eventsRepository.update(id, patch)`
- **Dynamic Parameter Construction:** Implemented a string builder loop iterating through keys of the incoming object array, creating dynamic relational clauses (e.g., `name = $2`, `description = $3`).
- **Timestamp Handling:** Preserved standard audit tracing updates by manually appending `updated_at = now()` to all dynamic query paths.

### Database

- Standardized target updates for optional schema columns using pure explicit typing updates instead of default positional matching fallbacks.

### API

- Restored expected RESTful `PATCH` behaviors where `{ field: null }` clears database entries and omitting fields retains existing structures.

### Infrastructure

- None.

## Screenshots

### Before
```json
// PATCH Payload sent to server:
{ "description": null }

// Database internal state before PR:
// description column = "Original Description" (COALESCE fallback ignored the change)