### PR TITLE
fix: improve clipboard error handling in ShareHub

### DIFF
--- a/website/src/components/ShareHub/ShareHub.jsx
+++ b/website/src/components/ShareHub/ShareHub.jsx
@@ -4,6 +4,7 @@ import './ShareHub.css';
 
 export default function ShareHub({ isOpen, onClose, data }) {
   const [copied, setCopied] = useState(false);
+  const [copyError, setCopyError] = useState(false);
   const [showQR, setShowQR] = useState(false);
 
   useEffect(() => {
@@ -30,6 +31,9 @@ export default function ShareHub({ isOpen, onClose, data }) {
     if (ok) {
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    } else {
+      setCopyError(true);
+      setTimeout(() => setCopyError(false), 3000);
     }
   }, [shareUrl]);
 
@@ -50,7 +54,13 @@ export default function ShareHub({ isOpen, onClose, data }) {
         // Any other failure (e.g. share target unavailable) falls back to
         // copying the URL to clipboard so the user can still share manually.
         if (err?.name !== 'AbortError' && navigator.clipboard) {
-          navigator.clipboard.writeText(shareUrl).catch(() => {});
+          navigator.clipboard.writeText(shareUrl).then(() => {
+            setCopied(true);
+            setTimeout(() => setCopied(false), 2000);
+          }).catch(() => {
+            setCopyError(true);
+            setTimeout(() => setCopyError(false), 3000);
+          });
         }
       });
     }
@@ -116,10 +126,15 @@ export default function ShareHub({ isOpen, onClose, data }) {
             readOnly
             aria-label="Shareable link"
           />
-          <button className="sharehub-copy-btn" onClick={handleCopy}>
-            {copied ? 'Copied!' : 'Copy'}
+          <button className={`sharehub-copy-btn ${copyError ? 'error' : ''}`} onClick={handleCopy}>
+            {copied ? 'Copied!' : (copyError ? 'Failed' : 'Copy')}
           </button>
         </div>
+        {copyError && (
+          <p style={{ color: '#ef4444', fontSize: '0.8rem', marginTop: '4px', textAlign: 'center' }}>
+            Clipboard access denied. Please manually copy the link above.
+          </p>
+        )}
 
         <button
           className="sharehub-qr-toggle"


### PR DESCRIPTION
## Summary

This PR is improving error handling for clipboard write failures in the ShareHub component.

### Changes Made

- Replaced the silently swallowed clipboard write failure with proper error handling.
- Added user-facing feedback when copying the share link fails.
- Displayed a fallback message instructing users to manually copy the share link.
- Preserved the existing success flow for successful clipboard operations.

### Why

Previously, clipboard write failures were silently ignored using an empty `.catch(() => {})`, making the failure invisible to users. This change provides clear feedback so users know the copy operation failed and can manually copy the link instead.

Close #3319

## Testing

- Simulated clipboard permission denial.
- Verified that the copy action no longer fails silently.
- Verified that the UI displays an appropriate error message.
- Verified that successful clipboard copy behavior remains unchanged.

## Rollback Plan

Revert this commit to restore the previous clipboard error handling behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review