### PR TITLE
fix: guard JSON.parse when loading moderation data

### DIFF
--- a/website/src/services/moderationService.js
+++ b/website/src/services/moderationService.js
@@ -247,7 +247,11 @@ class ModerationService {
   getFlaggedContent(status = 'pending') {
     const stored = localStorage.getItem('moderation_flagged');
     if (stored) {
-      this.flaggedContent = JSON.parse(stored);
+      try {
+        this.flaggedContent = JSON.parse(stored);
+      } catch (err) {
+        this.flaggedContent = [];
+      }
     }
     return status ? this.flaggedContent.filter((f) => f.status === status) : this.flaggedContent;
   }


### PR DESCRIPTION
## Summary

This PR fixes #3320 by guarding the `JSON.parse()` call used when loading flagged moderation data from `localStorage`.

### Changes Made

- Wrapped `JSON.parse(stored)` in a `try/catch` block.
- Added a safe fallback to an empty array if the stored data is malformed.
- Prevented the moderation dashboard from crashing due to corrupted `localStorage` data.

### Why

Previously, `JSON.parse(stored)` could throw a `SyntaxError` if the value stored in `localStorage` was invalid or corrupted. Since the error was unhandled, it could crash the moderation dashboard. This change ensures invalid data is handled gracefully and the application continues to function.

Closes #3320

## Testing

- Stored invalid JSON in `localStorage` for `moderation_flagged`.
- Verified that the moderation dashboard no longer crashes.
- Verified that the application falls back to an empty flagged content list.
- Verified that valid stored JSON continues to load correctly.

## Rollback Plan

Revert this commit to restore the previous JSON parsing behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review