### PR TITLE
fix: guard JSON.parse when loading moderation data

### DIFF
--- a/website/src/services/moderationService.js
+++ b/website/src/services/moderationService.js
@@ -247,7 +247,11 @@ class ModerationService {
   getFlaggedContent(status = 'pending') {
     const stored = localStorage.getItem('moderation_flagged');
     if (stored) {
-      this.flaggedContent = JSON.parse(stored);
+      try {
+        this.flaggedContent = JSON.parse(stored);
+      } catch (err) {
+        this.flaggedContent = [];
+      }
     }
     return status ? this.flaggedContent.filter((f) => f.status === status) : this.flaggedContent;
   }


### PR DESCRIPTION
## Summary

This PR fixes #3320 by guarding `JSON.parse` with a `try/catch` block when loading moderation data from `localStorage`.

### Changes Made

- Wrapped `JSON.parse(stored)` in a `try/catch`.
- Falls back to an empty array if parsing fails.
- Prevents the moderation dashboard from crashing due to malformed or corrupted `localStorage` data.

### Why

Previously, invalid JSON stored in `localStorage` would throw an uncaught exception and crash the moderation dashboard. This change safely handles parsing failures and keeps the application functional.

Closes #3320

## Testing

- Stored invalid JSON in `localStorage` for `moderation_flagged`.
- Verified the dashboard no longer crashes.
- Verified the application falls back to an empty list.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally