### PR TITLE
refactor: use createPortal to render the project modal into the document body

### DIFF
--- a/website/src/pages/projects/ProjectsPage.jsx
+++ b/website/src/pages/projects/ProjectsPage.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { Code, ExternalLink, X, Tag, Users } from 'lucide-react';
 import { projectsData } from '../../data/projectsData';
@@ -164,111 +165,114 @@ export default function ProjectsPage({ onBack, loading = false }) {
 
       {/* Project Details Modal */}
       <AnimatePresence>
-        {selectedProject && (
-          <div
-            className="modal-overlay projects-modal-overlay"
-            onClick={() => setSelectedProject(null)}
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="modal-title"
-          >
-            <motion.div
-              initial={{ opacity: 0, y: 50, scale: 0.95 }}
-              animate={{ opacity: 1, y: 0, scale: 1 }}
-              exit={{ opacity: 0, y: 50, scale: 0.95 }}
-              transition={{ type: 'spring', damping: 25, stiffness: 300 }}
-              className="modal-box project-modal"
-              onClick={(e) => e.stopPropagation()}
-            >
-              <button
-                className="modal-close"
+        {selectedProject && typeof document !== 'undefined'
+          ? createPortal(
+              <div
+                className="modal-overlay projects-modal-overlay"
                 onClick={() => setSelectedProject(null)}
-                aria-label="Close modal"
-                autoFocus
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="modal-title"
               >
-                <X size={20} />
-              </button>
+                <motion.div
+                  initial={{ opacity: 0, y: 50, scale: 0.95 }}
+                  animate={{ opacity: 1, y: 0, scale: 1 }}
+                  exit={{ opacity: 0, y: 50, scale: 0.95 }}
+                  transition={{ type: 'spring', damping: 25, stiffness: 300 }}
+                  className="modal-box project-modal"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <button
+                    className="modal-close"
+                    onClick={() => setSelectedProject(null)}
+                    aria-label="Close modal"
+                    autoFocus
+                  >
+                    <X size={20} />
+                  </button>
 
-              <SafeImage
-                src={selectedProject.image}
-                alt={selectedProject.title}
-                className="project-modal-image"
-                fallbackType="project"
-              />
+                  <SafeImage
+                    src={selectedProject.image}
+                    alt={selectedProject.title}
+                    className="project-modal-image"
+                    fallbackType="project"
+                  />
 
-              <div className="project-modal-header">
-                <span className="project-category">{selectedProject.category}</span>
-                <h2 id="modal-title" className="project-modal-title">
-                  {selectedProject.title}
-                </h2>
-              </div>
-
-              <div className="project-modal-body">
-                <p className="project-modal-desc">{selectedProject.longDesc}</p>
-
-                <div className="project-modal-section">
-                  <h4 className="section-title">
-                    <Tag size={16} /> Tech Stack
-                  </h4>
-                  <div className="project-tech-stack">
-                    {selectedProject.techStack.map((tech) => (
-                      <span key={tech} className="tech-pill">
-                        {tech}
-                      </span>
-                    ))}
+                  <div className="project-modal-header">
+                    <span className="project-category">{selectedProject.category}</span>
+                    <h2 id="modal-title" className="project-modal-title">
+                      {selectedProject.title}
+                    </h2>
                   </div>
-                </div>
 
-                <div className="project-modal-section">
-                  <h4 className="section-title">
-                    <Users size={16} /> Team
-                  </h4>
-                  <div className="project-team-list">
-                    {selectedProject.team.map((member, idx) => (
-                      <div key={member.name} className="team-member">
-                        <SafeImage
-                          src={member.photo}
-                          alt={member.name}
-                          className="team-member-photo"
-                          fallbackType="avatar"
-                        />
-                        <div className="team-member-info">
-                          <span className="team-member-name">{member.name}</span>
-                          <span className="team-member-role">{member.role}</span>
-                        </div>
+                  <div className="project-modal-body">
+                    <p className="project-modal-desc">{selectedProject.longDesc}</p>
+
+                    <div className="project-modal-section">
+                      <h4 className="section-title">
+                        <Tag size={16} /> Tech Stack
+                      </h4>
+                      <div className="project-tech-stack">
+                        {selectedProject.techStack.map((tech) => (
+                          <span key={tech} className="tech-pill">
+                            {tech}
+                          </span>
+                        ))}
                       </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
+                    </div>
 
-              <div className="project-modal-footer">
-                {selectedProject.github && selectedProject.github !== '#' && (
-                  <a
-                    href={selectedProject.github}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn-outline"
-                    aria-label="View Source Code on GitHub"
-                  >
-                    <Code size={18} /> Source Code
-                  </a>
-                )}
-                {selectedProject.demo && selectedProject.demo !== '#' && (
-                  <a
-                    href={selectedProject.demo}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="btn btn-primary"
-                    aria-label="View Live Demo"
-                  >
-                    <ExternalLink size={18} /> Live Demo
-                  </a>
-                )}
-              </div>
-            </motion.div>
-          </div>
-        )}
+                    <div className="project-modal-section">
+                      <h4 className="section-title">
+                        <Users size={16} /> Team
+                      </h4>
+                      <div className="project-team-list">
+                        {selectedProject.team.map((member, idx) => (
+                          <div key={member.name} className="team-member">
+                            <SafeImage
+                              src={member.photo}
+                              alt={member.name}
+                              className="team-member-photo"
+                              fallbackType="avatar"
+                            />
+                            <div className="team-member-info">
+                              <span className="team-member-name">{member.name}</span>
+                              <span className="team-member-role">{member.role}</span>
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="project-modal-footer">
+                    {selectedProject.github && selectedProject.github !== '#' && (
+                      <a
+                        href={selectedProject.github}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-outline"
+                        aria-label="View Source Code on GitHub"
+                      >
+                        <Code size={18} /> Source Code
+                      </a>
+                    )}
+                    {selectedProject.demo && selectedProject.demo !== '#' && (
+                      <a
+                        href={selectedProject.demo}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="btn btn-primary"
+                        aria-label="View Live Demo"
+                      >
+                        <ExternalLink size={18} /> Live Demo
+                      </a>
+                    )}
+                  </div>
+                </motion.div>
+              </div>,
+              document.body
+            )
+          : null}
       </AnimatePresence>
     </div>
   );


### PR DESCRIPTION
## Summary

This PR fixes an issue where the **Project Details** modal displayed inconsistent content based on the user's scroll position on the Projects page. Previously, opening the same project from different scroll positions could result in portions of the modal content being clipped or inaccessible.

The modal behavior has been updated to ensure it opens consistently regardless of the background page's scroll state. The project details are now fully accessible, with proper overflow handling and consistent positioning, providing a reliable viewing experience across all scroll positions.

**Related Issue**

Fixes #2473
