### PR TITLE
fix: guard JSON.parse when loading user interest data

### DIFF
--- a/website/src/services/recommendation/userInterestTracker.js
+++ b/website/src/services/recommendation/userInterestTracker.js
@@ -39,30 +39,37 @@ class UserInterestTracker {
 
   loadInterests() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_INTERESTS);
-    return stored
-      ? JSON.parse(stored)
-      : {
-          categories: {},
-          tags: {},
-          events: {},
-        };
+    const defaults = {
+      categories: {},
+      tags: {},
+      events: {},
+    };
+    if (stored) {
+      try { return JSON.parse(stored); } catch (e) {}
+    }
+    return defaults;
   }
 
   loadHistory() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_HISTORY);
-    return stored ? JSON.parse(stored) : [];
+    if (stored) {
+      try { return JSON.parse(stored); } catch (e) {}
+    }
+    return [];
   }
 
   loadPreferences() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_PREFERENCES);
-    return stored
-      ? JSON.parse(stored)
-      : {
-          preferredCategories: [],
-          preferredTags: [],
-          preferredTimeSlots: [],
-          preferredLocations: [],
-        };
+    const defaults = {
+      preferredCategories: [],
+      preferredTags: [],
+      preferredTimeSlots: [],
+      preferredLocations: [],
+    };
+    if (stored) {
+      try { return JSON.parse(stored); } catch (e) {}
+    }
+    return defaults;
   }
 
   trackEventInteraction(eventId, action, metadata = {}) {


### PR DESCRIPTION
## Summary

This PR fixes #3354 by guarding `JSON.parse()` calls when loading user interest data from `localStorage`.

### Changes Made

- Wrapped `JSON.parse()` calls in `try/catch` blocks.
- Added safe fallback values when stored data is malformed.
- Preserved existing behavior for valid stored data.
- Prevented the recommendation service from crashing due to corrupted `localStorage` entries.

### Why

Previously, the recommendation service directly parsed cached user data from `localStorage` without handling malformed JSON. If the stored data became corrupted or was manually modified, `JSON.parse()` would throw a `SyntaxError`, preventing the recommendation system from initializing correctly.

This change allows the service to recover gracefully by falling back to default values instead of crashing.

Closes #3354

## Testing

- Added invalid JSON to the relevant `localStorage` keys.
- Verified that the application no longer crashes.
- Verified that default values are returned when parsing fails.
- Verified that valid stored data continues to load correctly.

## Rollback Plan

Revert this commit to restore the previous parsing behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review