### PR TITLE
fix: guard JSON.parse when loading workspace data

### DIFF
--- a/website/src/lib/workspaceService.js
+++ b/website/src/lib/workspaceService.js
@@ -35,7 +35,11 @@ export const initializeWorkspaces = () => {
     localStorage.setItem(WORKSPACES_KEY, JSON.stringify(DEFAULT_WORKSPACES));
     return DEFAULT_WORKSPACES;
   }
-  return JSON.parse(stored);
+  try {
+    return JSON.parse(stored);
+  } catch (error) {
+    return DEFAULT_WORKSPACES;
+  }
 };
 
 /**


### PR DESCRIPTION
## Summary

This PR fixes #3355 by guarding the `JSON.parse()` call when loading persisted workspace data from `localStorage`.

### Changes Made

- Wrapped the `JSON.parse()` call in a `try/catch` block.
- Added a safe fallback to `DEFAULT_WORKSPACES` when parsing fails.
- Preserved the existing behavior for valid stored workspace data.
- Prevented the application from crashing when workspace data in `localStorage` is malformed or corrupted.

### Why

Previously, the workspace service directly parsed persisted workspace data using `JSON.parse()` without handling malformed JSON. If the stored value became corrupted or was manually modified, the application would throw a `SyntaxError` during initialization instead of falling back to the default workspace configuration.

This change ensures the application recovers gracefully by using `DEFAULT_WORKSPACES` whenever parsing fails.

Closes #3355

## Testing

- Stored invalid JSON in the workspace `localStorage` key.
- Verified that the application no longer crashes on startup.
- Verified that `DEFAULT_WORKSPACES` is returned when parsing fails.
- Verified that valid workspace data continues to load correctly.

## Rollback Plan

Revert this commit to restore the previous parsing behavior.

## Checklist

- [x] Code follows project standards
- [x] No breaking changes introduced
- [x] Tested locally
- [x] Ready for review