### PR TITLE
fix: handle malformed localStorage data in gamification service

### DIFF
--- a/src/services/gamification/gamificationService.js
+++ b/src/services/gamification/gamificationService.js
@@ -158,7 +158,11 @@ class GamificationService {
   loadUserData() {
     const stored = localStorage.getItem('gamification_user_data');
     if (stored) {
-      return JSON.parse(stored);
+      try {
+        return JSON.parse(stored);
+      } catch (e) {
+        // Fall through to defaults if corrupted
+      }
     }
     return {
       userId: null,


### PR DESCRIPTION
## Description

This PR fixes a crash in the gamification service caused by malformed data stored in `localStorage`.

Previously, `JSON.parse()` was called directly when restoring cached user data. If the stored value contained invalid JSON, the application threw a `SyntaxError` and failed to initialize the gamification service.

## Changes Made

- Wrapped `JSON.parse()` in a `try...catch` block.
- Gracefully fall back to the default gamification state if parsing fails.
- Prevent application crashes caused by corrupted cached data.

## Related Issue

Closes #3356

## Testing

- Added invalid JSON to `localStorage`.
- Refreshed the application.
- Verified that the application no longer crashes.
- Confirmed that the default gamification state is used when cached data is invalid.

## Type of Change

- [x] Bug fix

