### PR TITLE
bug(state): Fix memory leak in WebSocket connections on the live chat component

### DIFF
--- a/website/src/pages/events/LiveQa.jsx
+++ b/website/src/pages/events/LiveQa.jsx
@@ -27,10 +27,12 @@ export default function LiveQa({ eventId: propEventId, onBack }) {
     socketRef.current = socket;
     if (socket && eventId) {
       if (socket.id) setSocketId(socket.id);
-      socket.on('connect', () => setSocketId(socket.id));
+      const handleConnect = () => setSocketId(socket.id);
+      socket.on('connect', handleConnect);
       socket.emit('qa:join', { eventId });
       return () => {
         socket.emit('qa:leave', { eventId });
+        socket.off('connect', handleConnect);
       };
     }
   }, [eventId]);


### PR DESCRIPTION
This PR fixes a memory leak in the Live QA component where the 'connect' socket event listener was not being properly cleaned up when the component unmounted or re-rendered with a new eventId.

Closes #3386