### PR TITLE
feat(a11y): Enhance keyboard navigation and focus management in modal dialogs

### DIFF
--- a/website/src/components/ShareHub/ShareHub.jsx
+++ b/website/src/components/ShareHub/ShareHub.jsx
@@ -1,19 +1,12 @@
 import { useState, useEffect, useCallback } from 'react';
 import { PLATFORMS, addUtmParams, getQRUrl, copyToClipboard } from '../../utils/shareUtils';
+import useFocusTrap from '../../hooks/useFocusTrap';
 import './ShareHub.css';
 
 export default function ShareHub({ isOpen, onClose, data }) {
   const [copied, setCopied] = useState(false);
   const [showQR, setShowQR] = useState(false);
-
-  useEffect(() => {
-    if (!isOpen) return;
-    const handler = (e) => {
-      if (e.key === 'Escape') onClose();
-    };
-    document.addEventListener('keydown', handler);
-    return () => document.removeEventListener('keydown', handler);
-  }, [isOpen, onClose]);
+  const modalRef = useFocusTrap(isOpen, onClose);
 
   useEffect(() => {
     document.body.style.overflow = isOpen ? 'hidden' : '';
@@ -46,9 +39,6 @@ export default function ShareHub({ isOpen, onClose, data }) {
   function handleNativeShare() {
     if (navigator.share) {
       navigator.share({ title: shareTitle, url: shareUrl }).catch((err) => {
-        // User cancelled (AbortError) — no feedback needed.
-        // Any other failure (e.g. share target unavailable) falls back to
-        // copying the URL to clipboard so the user can still share manually.
         if (err?.name !== 'AbortError' && navigator.clipboard) {
           navigator.clipboard.writeText(shareUrl).catch(() => {});
         }
@@ -64,7 +54,7 @@ export default function ShareHub({ isOpen, onClose, data }) {
       aria-modal="true"
       aria-label="Share"
     >
-      <div className="sharehub-modal" onClick={(e) => e.stopPropagation()}>
+      <div ref={modalRef} className="sharehub-modal" onClick={(e) => e.stopPropagation()}>
         <div className="sharehub-header">
           <h2 className="sharehub-heading">Share</h2>
           <button className="sharehub-close" onClick={onClose} aria-label="Close">

--- a/website/src/components/moderation/ModerationDashboard.jsx
+++ b/website/src/components/moderation/ModerationDashboard.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { buildUrl } from '../../utils/runtimeConfig';
+import useFocusTrap from '../../hooks/useFocusTrap';
 
 const pageStyle = {
   padding: '24px',
@@ -110,6 +111,10 @@ export default function ModerationDashboard() {
   const [showResolveModal, setShowResolveModal] = useState(false);
   const [showNoteModal, setShowNoteModal] = useState(false);
   const [selectedFlag, setSelectedFlag] = useState(null);
+
+  const reportModalRef = useFocusTrap(showReportModal, () => setShowReportModal(false));
+  const resolveModalRef = useFocusTrap(showResolveModal, () => setShowResolveModal(false));
+  const noteModalRef = useFocusTrap(showNoteModal, () => setShowNoteModal(false));
 
   const [reportForm, setReportForm] = useState({
     contentType: 'comment',
@@ -522,8 +527,8 @@ export default function ModerationDashboard() {
 
         {/* Report Content Modal */}
         {showReportModal && (
-          <div style={MODAL_OVERLAY} onClick={() => setShowReportModal(false)}>
-            <div style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
+          <div style={MODAL_OVERLAY} onClick={() => setShowReportModal(false)} role="dialog" aria-modal="true">
+            <div ref={reportModalRef} style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
               <h3
                 style={{
                   margin: '0 0 24px 0',
@@ -615,8 +620,8 @@ export default function ModerationDashboard() {
 
         {/* Resolve Modal */}
         {showResolveModal && selectedFlag && (
-          <div style={MODAL_OVERLAY} onClick={() => setShowResolveModal(false)}>
-            <div style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
+          <div style={MODAL_OVERLAY} onClick={() => setShowResolveModal(false)} role="dialog" aria-modal="true">
+            <div ref={resolveModalRef} style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
               <h3
                 style={{
                   margin: '0 0 24px 0',
@@ -670,8 +675,8 @@ export default function ModerationDashboard() {
 
         {/* Add Note Modal */}
         {showNoteModal && (
-          <div style={MODAL_OVERLAY} onClick={() => setShowNoteModal(false)}>
-            <div style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
+          <div style={MODAL_OVERLAY} onClick={() => setShowNoteModal(false)} role="dialog" aria-modal="true">
+            <div ref={noteModalRef} style={MODAL_STYLE} onClick={(e) => e.stopPropagation()}>
               <h3
                 style={{
                   margin: '0 0 24px 0',

--- a/website/src/hooks/useFocusTrap.js
+++ b/website/src/hooks/useFocusTrap.js
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from 'react';
+
+export default function useFocusTrap(isActive, onClose) {
+  const modalRef = useRef(null);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const handleKeyDown = (e) => {
+      if (e.key === 'Escape' && onClose) {
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && modalRef.current) {
+        const focusableElements = modalRef.current.querySelectorAll(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusableElements.length === 0) return;
+
+        const firstElement = focusableElements[0];
+        const lastElement = focusableElements[focusableElements.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstElement) {
+            lastElement.focus();
+            e.preventDefault();
+          }
+        } else {
+          if (document.activeElement === lastElement) {
+            firstElement.focus();
+            e.preventDefault();
+          }
+        }
+      }
+    };
+
+    // Auto-focus first element when modal opens
+    if (modalRef.current) {
+      const focusableElements = modalRef.current.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusableElements.length > 0 && !modalRef.current.contains(document.activeElement)) {
+        focusableElements[0].focus();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isActive, onClose]);
+
+  return modalRef;
+}


### PR DESCRIPTION
This PR introduces a reusable \useFocusTrap\ hook to improve accessibility for modal dialogs. It ensures that when a modal is open, keyboard focus remains trapped within its bounds. The hook also manages the Escape key for easy closing. Implemented across \ShareHub\ and \ModerationDashboard\ components.

Closes #3378