### PR TITLE
feat(pwa): Implement offline fallback page for un-cached routes

### DIFF
--- a/website/src/sw-nexasphere.js
+++ b/website/src/sw-nexasphere.js
@@ -18,8 +18,9 @@ import {
   precacheAndRoute,
   cleanupOutdatedCaches,
   createHandlerBoundToURL,
+  matchPrecache,
 } from 'workbox-precaching';
-import { registerRoute, NavigationRoute } from 'workbox-routing';
+import { registerRoute, NavigationRoute, setCatchHandler } from 'workbox-routing';
 import { CacheFirst, NetworkFirst, StaleWhileRevalidate } from 'workbox-strategies';
 import { ExpirationPlugin } from 'workbox-expiration';
 import { CacheableResponsePlugin } from 'workbox-cacheable-response';
@@ -197,4 +198,14 @@ self.addEventListener('sync', (event) => {
   if (event.tag === 'nexasphere-offline-queue') {
     console.log('[SW] Background sync triggered for offline queue.');
   }
+});
+
+// ── 5. Offline Fallback ───────────────────────────────────────────────────────
+// Provide a fallback response when a navigation request fails because the app
+// is offline and the requested route isn't cached.
+setCatchHandler(async ({ request }) => {
+  if (request.destination === 'document') {
+    return (await matchPrecache('/offline.html')) || Response.error();
+  }
+  return Response.error();
 });


### PR DESCRIPTION
This PR introduces a robust offline fallback mechanism. By utilizing Workbox's \setCatchHandler\, the service worker will now seamlessly serve \/offline.html\ whenever a user navigates to an un-cached route without an internet connection, vastly improving the offline experience.

Closes #3376