### PR TITLE
feat(infra): Add health check endpoints for microservices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,11 @@ services:
     networks:
       - default
       - observability
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8000/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3
 
 networks:
   observability:
@@ -131,3 +136,25 @@ networks:
     driver: bridge
 
 # Redis is used for rate limiting and Socket.IO session sharing.
+
+  # ── Java Microservices API (optional) ────────────────────────────────────────
+  java-api:
+    profiles: ['java', 'observability']
+    build:
+      context: ./server-java
+      dockerfile: Dockerfile
+    expose:
+      - '8081'
+    environment:
+      SPRING_PROFILES_ACTIVE: docker
+      OTEL_SERVICE_NAME: nexasphere-java
+      OTEL_ENABLED: 'false'
+    restart: unless-stopped
+    networks:
+      - default
+      - observability
+    healthcheck:
+      test: ['CMD', 'wget', '-qO-', 'http://localhost:8081/health']
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/server-java/src/main/java/org/nexasphere/controller/HealthController.java
+++ b/server-java/src/main/java/org/nexasphere/controller/HealthController.java
@@ -1,0 +1,25 @@
+package org.nexasphere.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.lang.management.ManagementFactory;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public ResponseEntity<Map<String, Object>> healthCheck() {
+        Map<String, Object> response = new HashMap<>();
+        response.put("status", "healthy");
+        
+        // Get JVM uptime in seconds
+        long uptimeMillis = ManagementFactory.getRuntimeMXBean().getUptime();
+        response.put("uptime", uptimeMillis / 1000.0);
+        
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server-python/routers/health.py
+++ b/server-python/routers/health.py
@@ -13,8 +13,13 @@ async def health_check(response: Response):
     """
     start_time = time.time()
     
+    import psutil
+    process = psutil.Process(os.getpid())
+    uptime = time.time() - process.create_time()
+
     health_status = {
-        "status": "ok",
+        "status": "healthy",
+        "uptime": uptime,
         "dependencies": {
             "supabase": "unknown",
             "google_sheets": "unknown",

--- a/server/routes/health.js
+++ b/server/routes/health.js
@@ -15,7 +15,12 @@ const router = Router();
  * and load balancers (Render, Railway, etc.).
  */
 router.get('/health', (_req, res) => {
-  res.json({ status: 'ok', service: 'nexasphere-api', timestamp: new Date().toISOString() });
+  res.json({ 
+    status: 'healthy', 
+    uptime: process.uptime(),
+    service: 'nexasphere-api', 
+    timestamp: new Date().toISOString() 
+  });
 });
 
 /**


### PR DESCRIPTION
This PR adds standardized \/health\ endpoints across all microservices (Node.js, Python, Java) to improve container orchestration and observability. It also updates \docker-compose.yml\ to actively use these health checks for better deployment reliability.

Closes #3382