### PR TITLE
fix: sanitize SearchBar HTML before rendering highlighted search results

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -15,12 +15,15 @@ import {
 } from 'lucide-react';
 import { useSearch } from '../hooks/useSearch';
 
+import DOMPurify from 'dompurify';
+
 function Highlight({ text, query }) {
   if (!text) return null;
   
   // If the text contains Typesense highlight <mark> tags, render it as HTML safely
   if (String(text).includes('<mark>')) {
-    return <span dangerouslySetInnerHTML={{ __html: text }} />;
+    const clean = DOMPurify.sanitize(text, { ALLOWED_TAGS: ['mark'] });
+    return <span dangerouslySetInnerHTML={{ __html: clean }} />;
   }
 
   if (!query) return <>{text}</>;


### PR DESCRIPTION
## Description

This PR fixes an XSS vulnerability in the `SearchBar` component by sanitizing HTML before rendering it with `dangerouslySetInnerHTML`.

Previously, search result text containing HTML was rendered directly, which could allow malicious content to execute in the browser if untrusted input was displayed.

## Changes Made

- Added `DOMPurify` to sanitize search result HTML.
- Allowed only the `<mark>` tag to preserve search highlighting.
- Prevented execution of malicious HTML while maintaining existing functionality.

## Related Issue

Closes #3419

## Testing

- Verified that highlighted search results continue to render correctly.
- Tested with malicious HTML (e.g., `<img src=x onerror=alert(1)>`) and confirmed it is sanitized.
- Confirmed that only safe `<mark>` tags are preserved.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update