### PR TITLE
fix: fail closed when content moderation service encounters errors

### DIFF
--- a/website/src/hooks/useContentModeration.js
+++ b/website/src/hooks/useContentModeration.js
@@ -13,7 +13,7 @@ export function useContentModeration() {
       return result;
     } catch (error) {
       console.error('Moderation failed:', error);
-      return { isAppropriate: true, action: 'allow', flags: [] };
+      return { isAppropriate: false, action: 'block', flags: [{ type: 'system_error', confidence: 1 }] };
     } finally {
       setModerating(false);
     }


### PR DESCRIPTION
## Description

This PR fixes a fail-open moderation bypass in the `useContentModeration` hook.

Previously, if the AI moderation service encountered a network error or timeout, the catch block returned:

```js
{
  isAppropriate: true,
  action: "allow",
  flags: []
}
```

This allowed content to bypass moderation whenever the moderation service was unavailable.

This PR changes the behavior to **fail closed** by blocking content whenever moderation cannot be completed.

---

## Changes Made

- Updated the error handling in `useContentModeration`.
- Changed the fallback response from `allow` to `block`.
- Returned `isAppropriate: false` on moderation failures.
- Added a `system_error` flag to indicate moderation could not be completed.
- Prevented content from bypassing moderation during service outages.

---

## Testing

- Simulated moderation service/network failures.
- Verified that the hook returns:
  - `isAppropriate: false`
  - `action: "block"`
  - `flags: [{ type: "system_error", confidence: 1 }]`
- Confirmed that content is blocked instead of being silently allowed.

---

## Related Issue

Fixes #3420

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.