### PR TITLE
fix: prevent reverse tabnabbing in HeroSection

### DIFF
--- a/website/src/pages/home/HeroSection.jsx
+++ b/website/src/pages/home/HeroSection.jsx
@@ -418,7 +418,7 @@ export default function HeroSection({ onTabChange, onApply, onJoin, theme = 'dar
 
       <div className="hero-content" style={{ position: 'relative', zIndex: 2, paddingBottom: '80px' }}>
           {activeBanner ? (
-            <div className="mb-8 w-full max-w-4xl mx-auto cursor-pointer" onClick={() => activeBanner.linkUrl ? window.open(activeBanner.linkUrl, '_blank') : null}>
+            <div className="mb-8 w-full max-w-4xl mx-auto cursor-pointer" onClick={() => activeBanner.linkUrl ? window.open(activeBanner.linkUrl, '_blank', 'noopener,noreferrer') : null}>
               <img src={activeBanner.imageUrl} alt={activeBanner.title} style={{ width: '100%', borderRadius: '16px', boxShadow: '0 12px 32px rgba(0,0,0,0.4)', objectFit: 'cover', maxHeight: '400px' }} />
             </div>
           ) : (


### PR DESCRIPTION
## Description

This PR fixes a reverse tabnabbing vulnerability in the `HeroSection` component.

Previously, external links were opened using:

```js
window.open(activeBanner.linkUrl, "_blank");
```

This allowed the newly opened page to access `window.opener`, which could potentially redirect or manipulate the original NexaSphere tab.

This PR updates the call to use the `noopener,noreferrer` window features, preventing reverse tabnabbing while preserving the existing behavior.

---

## Changes Made

- Updated `window.open()` to include `noopener,noreferrer`.
- Prevented access to `window.opener` for external links.
- Preserved the existing user experience.

---

## Testing

- Verified that external banner links still open in a new tab.
- Confirmed that the opened page cannot access `window.opener`.
- Confirmed no regressions in banner navigation.

---

## Related Issue

Closes #3421

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update