### PR TITLE
fix: fallback to UI notifications when localStorage fails

### DIFF
--- a/website/src/hooks/useNotifications.js
+++ b/website/src/hooks/useNotifications.js
@@ -174,7 +174,9 @@ export function useNotifications() {
                 suppressedReason: !channelEnabled ? 'channel' : dnd ? 'dnd' : 'quiet',
               });
               localStorage.setItem(key, JSON.stringify(arr));
-            } catch (e) {}
+            } catch (e) {
+              setNotifications((prev) => [note, ...prev]);
+            }
             return;
           }
 


### PR DESCRIPTION
## Description

This PR fixes an issue where notifications were silently dropped if `localStorage.setItem()` failed (for example, when the browser storage quota was exceeded).

Previously, the `catch` block was empty, causing notifications to be lost without any user feedback.

This PR adds a fallback that updates the in-memory notification state, ensuring notifications remain visible even if they cannot be persisted to `localStorage`.

---

## Changes Made

- Replaced the empty `catch` block with a fallback.
- Updated the notification state when `localStorage` operations fail.
- Prevented notifications from being silently dropped.

---

## Testing

- Simulated a `localStorage.setItem()` failure.
- Verified that notifications still appear in the UI.
- Confirmed that the application no longer silently loses notifications.

---

## Related Issue

Closes #3422

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update