### PR TITLE
fix: show PDF export errors to users

### DIFF
--- a/website/src/hooks/useCertificateExport.ts
+++ b/website/src/hooks/useCertificateExport.ts
@@ -13,6 +13,7 @@ export interface UseCertificateExportOptions {
 
 export const useCertificateExport = (options: UseCertificateExportOptions) => {
   const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
   const isIOSDevice = isIOS();
 
   // Setup standard react-to-print hook for non-iOS devices
@@ -55,6 +56,7 @@ export const useCertificateExport = (options: UseCertificateExportOptions) => {
 
     try {
       setIsExporting(true);
+      setExportError(null);
       if (options.onBeforeGetContent) {
         await options.onBeforeGetContent();
       }
@@ -65,7 +67,7 @@ export const useCertificateExport = (options: UseCertificateExportOptions) => {
       await generatePDFBlob(element, `${options.documentTitle || 'export'}.pdf`);
     } catch (error) {
       console.error('PDF generation failed:', error);
-      // Could show a toast notification here in a real app
+      setExportError(error instanceof Error ? error.message : 'Failed to generate PDF');
     } finally {
       setIsExporting(false);
       if (options.onAfterPrint) {
@@ -77,5 +79,6 @@ export const useCertificateExport = (options: UseCertificateExportOptions) => {
   return {
     handlePrint,
     isExporting,
+    exportError,
   };
 };

--- a/website/src/pages/portfolio/PublicPortfolio.jsx
+++ b/website/src/pages/portfolio/PublicPortfolio.jsx
@@ -54,7 +54,7 @@ export default function PublicPortfolio({ username, onBack }) {
 
   const portfolioRef = useRef();
 
-  const { handlePrint, isExporting } = useCertificateExport({
+  const { handlePrint, isExporting, exportError } = useCertificateExport({
     content: () => portfolioRef.current,
     documentTitle: `${username}_Portfolio`,
     removeAfterPrint: true,
@@ -254,6 +254,12 @@ export default function PublicPortfolio({ username, onBack }) {
           Build Yours
         </button>
       </div>
+
+      {exportError && (
+        <div className="no-print" style={{ color: '#ef4444', textAlign: 'center', margin: '1rem auto', padding: '0.5rem', background: '#fee2e2', borderRadius: '8px', border: '1px solid #f87171', maxWidth: '800px' }}>
+          {exportError}
+        </div>
+      )}
 
       {/* Main presentation sheet */}
       <div className="portfolio-shell">


### PR DESCRIPTION
## Description

This PR fixes a silent PDF export failure in `useCertificateExport` by providing user-facing error feedback when PDF generation fails.

Previously, export failures were only logged to the console, leaving users without any indication that the export operation had failed.

This PR introduces an `exportError` state in the hook and displays an error message in the portfolio UI when PDF generation fails.

---

## Changes Made

- Added `exportError` state to `useCertificateExport`.
- Cleared previous errors before starting a new export.
- Captured PDF generation errors in the hook.
- Exposed `exportError` to consuming components.
- Displayed a user-friendly error message in `PublicPortfolio` when export fails.

---

## Testing

- Simulated PDF generation failure.
- Verified that the error is stored in `exportError`.
- Confirmed that an error message is displayed in the UI.
- Ensured existing PDF export functionality remains unchanged.

---

## Related Issue

Closes #3423

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.