### PR TITLE
fix: show error state when history search API fails

### DIFF
--- a/website/src/components/history/SearchBar.jsx
+++ b/website/src/components/history/SearchBar.jsx
@@ -7,6 +7,7 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
   const [results, setResults] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [searchError, setSearchError] = useState(null);
 
   const handleSearch = useCallback(
     async (searchQuery) => {
@@ -15,10 +16,12 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
       if (!searchQuery.trim()) {
         setResults([]);
         setShowResults(false);
+        setSearchError(null);
         return;
       }
 
       setIsSearching(true);
+      setSearchError(null);
       try {
         const foundPrompts = await searchPrompts(searchQuery, workspace);
         setResults(foundPrompts);
@@ -27,7 +30,9 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
         if (import.meta.env.DEV) {
           console.error('[HistorySearchBar] Search error:', error.message);
         }
+        setSearchError('Search service is currently unavailable. Please try again later.');
         setResults([]);
+        setShowResults(true);
       } finally {
         setIsSearching(false);
       }
@@ -89,7 +94,11 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
 
       {showResults && query && results.length === 0 && !isSearching && (
         <div className="search-empty">
-          <p>No results found</p>
+          {searchError ? (
+            <p className="error-message" style={{ color: '#ef4444' }}>{searchError}</p>
+          ) : (
+            <p>No results found</p>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Description

This PR fixes an issue where the History SearchBar displayed a misleading **"No results found"** message when the search API request failed.

Previously, API failures cleared the search results without distinguishing between an empty result set and a backend error, causing users to receive incorrect feedback.

This PR introduces a dedicated error state and displays a meaningful error message when the search service is unavailable.

---

## Changes Made

- Added a `searchError` state to track API failures.
- Cleared previous errors before each search.
- Set a descriptive error message when the search request fails.
- Displayed the error message instead of "No results found" during API failures.
- Preserved the existing "No results found" behavior for successful searches with no matching results.

---

## Testing

- Simulated a search API failure.
- Verified that the error message is displayed.
- Confirmed that "No results found" is only shown for successful empty search results.
- Ensured normal search functionality remains unchanged.

---

## Related Issue

Closes #3424

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.