### PR TITLE
fix: show error message when pinned chats fail to load

### DIFF
--- a/website/src/components/history/PinnedChats.jsx
+++ b/website/src/components/history/PinnedChats.jsx
@@ -5,16 +5,19 @@ import './PinnedChats.css';
 const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
   const [pinnedPrompts, setPinnedPrompts] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
 
   const loadPinnedPrompts = async () => {
     setLoading(true);
+    setError(null);
     try {
       const pinned = await getPinnedPrompts(workspace);
       setPinnedPrompts(pinned);
-    } catch (error) {
+    } catch (err) {
       if (import.meta.env.DEV) {
-        console.error('[PinnedChats] Error loading pinned prompts:', error.message);
+        console.error('[PinnedChats] Error loading pinned prompts:', err.message);
       }
+      setError('Failed to load pinned chats. Please try again later.');
     } finally {
       setLoading(false);
     }
@@ -33,6 +36,19 @@ const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
   const handleSelectPrompt = (prompt) => {
     onSelectPrompt(prompt);
   };
+
+  if (error) {
+    return (
+      <div className="pinned-chats-container">
+        <div className="pinned-header">
+          <h4>📌 Pinned Conversations</h4>
+        </div>
+        <div className="pinned-error" style={{ color: '#ef4444', padding: '12px 16px', fontSize: '0.9rem' }}>
+          {error}
+        </div>
+      </div>
+    );
+  }
 
   if (pinnedPrompts.length === 0) {
     return null;


### PR DESCRIPTION
## Description

This PR fixes a silent failure in the `PinnedChats` component by providing user-facing feedback when pinned chats fail to load.

Previously, loading errors were silently caught, causing the UI to render an empty state without informing the user that the request had failed.

This PR introduces an error state and displays a meaningful error message whenever loading pinned chats is unsuccessful.

---

## Changes Made

- Added an `error` state to track loading failures.
- Cleared previous errors before fetching pinned chats.
- Captured loading errors in the `catch` block.
- Displayed a user-friendly error message instead of an empty UI.
- Preserved the existing behavior when pinned chats load successfully.

---

## Testing

- Simulated a pinned chats loading failure.
- Verified that an error message is displayed in the UI.
- Confirmed that the UI no longer fails silently.
- Ensured successful loading behavior remains unchanged.

---

## Related Issue

Closes #3425

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.