### PR TITLE
fix: guard JSON.parse in content store

### DIFF
--- a/server/repositories/contentStore.js
+++ b/server/repositories/contentStore.js
@@ -43,7 +43,15 @@ export async function supabasePaginatedRequest(pathname, page, limit) {
     throw new Error(`Supabase error (${res.status}): ${text}`);
   }
   const text = await res.text();
-  const rows = text ? JSON.parse(text) : [];
+  let rows = [];
+  if (text) {
+    try {
+      rows = JSON.parse(text);
+    } catch (e) {
+      console.error('[contentStore] Failed to parse Supabase response:', e);
+      rows = [];
+    }
+  }
   // Content-Range format from PostgREST: "0-19/150" or "*/0" when empty
   const contentRange = res.headers.get('content-range') || '';
   const totalMatch = contentRange.match(/\/(\d+)$/);


### PR DESCRIPTION
## Description

This PR fixes a backend crash caused by unguarded `JSON.parse()` calls in the content store.

Previously, if Supabase returned malformed JSON or an unexpected HTML response, `JSON.parse()` threw a `SyntaxError`, causing the backend request to fail.

This PR wraps the parsing logic in a `try...catch` block and safely falls back to an empty array when parsing fails.

---

## Changes Made

- Wrapped `JSON.parse()` in a `try...catch` block.
- Added error logging for malformed Supabase responses.
- Returned an empty array as a safe fallback when parsing fails.
- Prevented backend crashes caused by invalid JSON responses.

---

## Testing

- Simulated a malformed Supabase response.
- Verified that no `SyntaxError` is thrown.
- Confirmed that the backend continues execution using an empty array.
- Ensured normal JSON responses continue to work correctly.

---

## Related Issue

Closes #3426

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.