### PR TITLE
fix: safely parse email campaign JSON fields

### DIFF
--- a/server/repositories/emailCampaignRepository.js
+++ b/server/repositories/emailCampaignRepository.js
@@ -1,5 +1,13 @@
 import { withDb } from './db.js';
 
+function safeParseJSON(str, fallback = {}) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return fallback;
+  }
+}
+
 function mapCampaignRow(row) {
   if (!row) return null;
   return {
@@ -7,10 +15,10 @@ function mapCampaignRow(row) {
     name: row.name,
     subject: row.subject,
     templateName: row.template_name,
-    content: typeof row.content === 'string' ? JSON.parse(row.content) : (row.content ?? {}),
+    content: typeof row.content === 'string' ? safeParseJSON(row.content) : (row.content ?? {}),
     segmentCriteria:
       typeof row.segment_criteria === 'string'
-        ? JSON.parse(row.segment_criteria)
+        ? safeParseJSON(row.segment_criteria)
         : (row.segment_criteria ?? {}),
     status: row.status,
     scheduledAt: row.scheduled_at,


### PR DESCRIPTION
## Description

This PR fixes a backend crash caused by unguarded `JSON.parse()` calls in the email campaign repository.

Previously, malformed JSON stored in the `content` or `segment_criteria` fields caused `JSON.parse()` to throw a `SyntaxError`, crashing the email campaign endpoint.

This PR introduces a reusable `safeParseJSON()` helper that safely parses JSON and falls back to a default object when parsing fails.

---

## Changes Made

- Added a reusable `safeParseJSON()` helper.
- Replaced direct `JSON.parse()` calls for `content`.
- Replaced direct `JSON.parse()` calls for `segment_criteria`.
- Added safe fallback objects when parsing fails.
- Prevented endpoint crashes caused by malformed database content.

---

## Testing

- Simulated malformed JSON in the `content` field.
- Simulated malformed JSON in the `segment_criteria` field.
- Verified that the endpoint no longer throws `SyntaxError`.
- Confirmed valid JSON continues to be parsed correctly.

---

## Related Issue

Closes #3427

---

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.