### PR TITLE
fix: use existing event search hook

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -13,7 +13,7 @@ import {
   Folder,
   MessageSquare,
 } from 'lucide-react';
-import { useSearch } from '../hooks/useSearch';
+import { useEventSearch } from '../hooks/useEventSearch';
 
 function Highlight({ text, query }) {
   if (!text) return null;
@@ -141,7 +141,7 @@ export default function SearchBar({ open, onClose, activities, events, onNavigat
     recentSearches,
     addRecentSearch,
     removeRecentSearch,
-  } = useSearch(activities, events);
+  } = useEventSearch(activities, events);
 
   const [localQuery, setLocalQuery] = useState('');
   const timeoutRef = useRef(null);


### PR DESCRIPTION
Closes #3317\n\nReplace the missing  import in  with the existing  hook, which already exposes the fields SearchBar expects. This removes the fresh-clone import failure described in the issue.\n\nValidation:\n- git diff --check\n- targeted source review of SearchBar.jsx and the existing event search hook\n\nNote: I could not run the website build in this environment because  currently fails on the repo's package setup, which is tracked separately in #3360.