### PR TITLE
fix: guard malformed skill session dates

### DIFF
--- a/website/src/pages/skills/SkillExchangePage.jsx
+++ b/website/src/pages/skills/SkillExchangePage.jsx
@@ -2,6 +2,13 @@ import { useState, useEffect, useCallback } from 'react';
 import apiClient from '../../utils/apiClient';
 import { getApiBase, buildUrl } from '../../utils/runtimeConfig';
 
+function formatSkillSessionDate(value) {
+  if (!value) return 'Unknown date';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Unknown date';
+  return date.toLocaleDateString();
+}
+
 const USER_ID = localStorage.getItem('ns_user_id') || `user-${Date.now().toString(36)}`;
 const PROFICIENCY = ['Beginner', 'Intermediate', 'Advanced'];
 const FORMATS = ['Video', 'Chat', 'In-person'];
@@ -460,7 +467,7 @@ export default function SkillExchangePage({ onBack }) {
                     </div>
                     <div style={{ fontSize: '0.85rem', color: 'var(--t2)' }}>
                       Status: <strong>{s.status}</strong> · Scheduled:{' '}
-                      {new Date(s.scheduledAt).toLocaleDateString()}
+                      {formatSkillSessionDate(s.scheduledAt)}
                     </div>
                     {s.notes && (
                       <div style={{ fontSize: '0.85rem', color: 'var(--t3)' }}>


### PR DESCRIPTION
Closes #3231\n\nValidate  before formatting it in the skill exchange sessions list so malformed or missing timestamps render as a friendly placeholder instead of .\n\nValidation:\n- git diff --check\n- targeted source review of website/src/pages/skills/SkillExchangePage.jsx