### PR TITLE
fix: use stable revenue skeleton keys

### DIFF
--- a/website/src/pages/monitoring/RevenueDashboardPage.jsx
+++ b/website/src/pages/monitoring/RevenueDashboardPage.jsx
@@ -49,7 +49,7 @@ export default function RevenueDashboardPage() {
         <h1 style={styles.heading}>Revenue Analytics Dashboard</h1>
         <div style={styles.loadingGrid}>
           {[...Array(3)].map((_, i) => (
-            <div key={i} style={styles.skeletonCard} />
+            <div key={`skeleton-card-${i}`} style={styles.skeletonCard} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Closes #3242\n\nReplace the loading skeleton's array index key with a descriptive prefixed key so the Revenue Dashboard skeleton cards no longer remount unnecessarily when the loading count changes.\n\nValidation:\n- git diff --check\n- targeted source review of website/src/pages/monitoring/RevenueDashboardPage.jsx