### PR TITLE
fix: use stable system health core keys

### DIFF
--- a/website/src/pages/monitoring/SystemHealthPage.jsx
+++ b/website/src/pages/monitoring/SystemHealthPage.jsx
@@ -352,7 +352,7 @@ export default function SystemHealthPage() {
               }}
             >
               {system.cpu.perCore.map((usage, i) => (
-                <div key={i} style={{ textAlign: 'center' }}>
+                <div key={`core-${i}`} style={{ textAlign: 'center' }}>
                   <div style={{ fontSize: '12px', color: '#9CA3AF', marginBottom: '4px' }}>
                     Core {i}
                   </div>


### PR DESCRIPTION
Closes #3243\n\nReplace the CPU core array index key with a descriptive prefixed key in the System Health page so the per-core cards have stable, readable identities.\n\nValidation:\n- git diff --check\n- targeted source review of website/src/pages/monitoring/SystemHealthPage.jsx