### PR TITLE
fix: log notification persistence failures

### DIFF
--- a/website/src/hooks/useNotifications.js
+++ b/website/src/hooks/useNotifications.js
@@ -174,7 +174,9 @@ export function useNotifications() {
                 suppressedReason: !channelEnabled ? 'channel' : dnd ? 'dnd' : 'quiet',
               });
               localStorage.setItem(key, JSON.stringify(arr));
-            } catch (e) {}
+            } catch (e) {
+              console.error('[useNotifications] Failed to persist suppressed notification:', e);
+            }
             return;
           }
 
@@ -320,7 +322,9 @@ export function useNotifications() {
           body: JSON.stringify({ id }),
         });
         analytics.trackNotificationOpened({ id });
-      } catch (e) {}
+        } catch (e) {
+          console.error('[useNotifications] Failed to mark notification as read:', e);
+        }
     })();
   }, []);
 
@@ -336,7 +340,9 @@ export function useNotifications() {
           method: 'POST',
           headers: getAuthHeaders(),
         });
-      } catch (e) {}
+      } catch (e) {
+        console.error('[useNotifications] Failed to mark all notifications as read:', e);
+      }
     })();
   }, []);
 
@@ -348,7 +354,9 @@ export function useNotifications() {
           method: 'DELETE',
           headers: getAuthHeaders(),
         });
-      } catch (e) {}
+      } catch (e) {
+        console.error('[useNotifications] Failed to clear notifications:', e);
+      }
     })();
   }, []);
 


### PR DESCRIPTION
Closes #3282\n\nReplace the silent notification persistence catch blocks with console errors so failures to persist, mark as read, clear all, or queue suppressed notifications are visible during debugging.\n\nValidation:\n- git diff --check\n- targeted source review of website/src/hooks/useNotifications.js