### PR TITLE
fix: use stable keys in ProjectCardSkeleton

### DIFF
--- a/website/src/components/ui/skeleton/ProjectCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/ProjectCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function ProjectCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`project-card-skeleton-${i}`}
           style={{
             padding: '22px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3251

Summary:
- replace the index key with a descriptive stable key
- keep skeleton items from remounting when count changes

Validation:
- git diff --check
- targeted source review