### PR TITLE
fix: clear ProjectRecommendations fallback timer

### DIFF
--- a/website/src/components/recommendations/ProjectRecommendations.jsx
+++ b/website/src/components/recommendations/ProjectRecommendations.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ResumeUpload from './ResumeUpload';
 import RecommendationCard from './RecommendationCard';
 import RecommendationSkeleton from './RecommendationSkeleton';
@@ -10,6 +10,14 @@ export default function ProjectRecommendations({ onBack }) {
   const [recommendations, setRecommendations] = useState([]);
   const [isDemo, setIsDemo] = useState(false);
   const [error, setError] = useState('');
+  const fallbackTimerRef = useRef(null);
+
+  useEffect(() => {
+    return () => {
+      if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current);
+      fallbackTimerRef.current = null;
+    };
+  }, []);
 
   const handleUpload = async (file) => {
     setStep('analyzing');
@@ -44,7 +52,8 @@ export default function ProjectRecommendations({ onBack }) {
     }
 
     // Backend unavailable, fallback to demo mode
-    setTimeout(() => {
+    if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current);
+    fallbackTimerRef.current = setTimeout(() => {
       setIsDemo(true);
       // Hardcoded fallback recommendations matching our mock projects list
       setRecommendations([
@@ -68,6 +77,7 @@ export default function ProjectRecommendations({ onBack }) {
         },
       ]);
       setStep('result');
+      fallbackTimerRef.current = null;
     }, 2000);
   };
 


### PR DESCRIPTION
Closes #3223

Summary:
- store the demo fallback timer in a ref
- clear it on repeated uploads and unmount
- keep the demo fallback from firing on a dead component

Validation:
- git diff --check
- targeted source review