### PR TITLE
fix: log EventDetailPage localStorage failures

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -943,7 +943,11 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
           stored.push(localTicket);
           localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch {}
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.warn('[EventDetailPage] Failed to persist local registration:', error);
+          }
+        }
       }
     } catch (err) {
       if (err.message?.includes('waitlist')) {


### PR DESCRIPTION
Closes #3236

Summary:
- add DEV-only logging for local registration storage failures
- keep the existing fallback behavior intact
- make malformed localStorage and quota failures visible during development

Validation:
- git diff --check
- targeted source review