### PR TITLE
fix: clear EventDetailPage countdown interval

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -52,6 +52,7 @@ function StatCard({ label, value, color }) {
   const [count, setCount] = useState(0);
   const ref = useRef(null);
   const started = useRef(false);
+  const intervalRef = useRef(null);
   useEffect(() => {
     const obs = new IntersectionObserver(
       ([e]) => {
@@ -63,11 +64,12 @@ function StatCard({ label, value, color }) {
             return;
           }
           let cur = 0;
-          const t = setInterval(() => {
+          intervalRef.current = setInterval(() => {
             cur += Math.ceil(num / 40);
             if (cur >= num) {
               setCount(num);
-              clearInterval(t);
+              if (intervalRef.current) clearInterval(intervalRef.current);
+              intervalRef.current = null;
             } else setCount(cur);
           }, 25);
         }
@@ -75,7 +77,11 @@ function StatCard({ label, value, color }) {
       { threshold: 0.5 }
     );
     if (ref.current) obs.observe(ref.current);
-    return () => obs.disconnect();
+    return () => {
+      obs.disconnect();
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    };
   }, [value]);
   const rgb = hexToRgb(color);
   return (


### PR DESCRIPTION
Closes #3246

Summary:
- store the countdown interval in a ref
- clear it on unmount as well as on completion
- prevent stale stat animation updates after leaving the page

Validation:
- git diff --check
- targeted source review