### PR TITLE
fix: use stable keys in MentorCardSkeleton

### DIFF
--- a/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function MentorCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`mentor-card-skeleton-${i}`}
           style={{
             padding: '24px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3250

Summary:
- replace the MentorCardSkeleton index key with a descriptive stable key
- keep skeleton rows from remounting when the count changes

Validation:
- git diff --check
- targeted source review