### PR TITLE
fix: use stable keys in NodeModal resources

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -405,7 +405,7 @@ export const NodeModal: React.FC<NodeModalProps> = ({ theme }) => {
               >
                 {resources.map((res, index) => (
                   <div
-                    key={index}
+                    key={`${res.title}-${res.url}`}
                     className="resource-item-edit-row glassmorphic-panel flex justify-between items-center text-xs"
                     style={{ padding: '8px 14px', borderRadius: '8px' }}
                   >


### PR DESCRIPTION
Closes #3248

Summary:
- replace the NodeModal resource array index key with a stable composite key
- keep resource rows from remounting when the list changes

Validation:
- git diff --check
- targeted source review