### PR TITLE
fix: use stable keys in ForumPostSkeleton

### DIFF
--- a/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
+++ b/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
@@ -7,7 +7,7 @@ export function ForumPostSkeleton({ count = 5 }) {
     <div role="status" aria-label="Loading forum posts..." aria-busy="true">
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`forum-post-skeleton-${i}`}
           style={{
             padding: '20px 24px',
             borderBottom: '1px solid var(--bdr, rgba(255,255,255,0.06))',


### PR DESCRIPTION
Closes #3249

Summary:
- replace the ForumPostSkeleton array index key with a stable descriptive key
- keep forum skeleton rows from remounting when the count changes

Validation:
- git diff --check
- targeted source review