### PR TITLE
fix: preserve partial notification fetch results

### DIFF
--- a/website/src/hooks/useNotifications.js
+++ b/website/src/hooks/useNotifications.js
@@ -75,16 +75,17 @@ export function useNotifications() {
           fetchUrls.push(buildUrl(getApiBase(), `/api/notifications?userId=${resolvedUserId}`));
         }
 
-        const responses = await Promise.all(
-          fetchUrls.map((url) =>
-            fetch(url, { headers: getAuthHeaders() }).then((res) =>
-              res.ok ? res.json() : { notifications: [] }
-            )
-          )
+        const responses = await Promise.allSettled(
+          fetchUrls.map(async (url) => {
+            const res = await fetch(url, { headers: getAuthHeaders() });
+            return res.ok ? res.json() : { notifications: [] };
+          })
         );
 
         if (isMounted) {
-          const allNotifications = responses.flatMap((r) => r.notifications || []);
+          const allNotifications = responses
+            .filter((r) => r.status === 'fulfilled')
+            .flatMap((r) => r.value.notifications || []);
           // De-duplicate by unique id
           const seen = new Set();
           const uniqueNotifications = [];
@@ -97,6 +98,9 @@ export function useNotifications() {
           // Sort by creation date (newest first)
           uniqueNotifications.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
           setNotifications(uniqueNotifications);
+          if (import.meta.env.DEV && responses.some((r) => r.status === 'rejected')) {
+            console.warn('[useNotifications] One or more notification fetches failed; using partial results.');
+          }
         }
       } catch (err) {
         // ignore fetch errors — fallback to empty list


### PR DESCRIPTION
Closes #3239

## Summary
- preserve successful notification fetches even if one request fails
- warn in development when a refresh partially fails
- keep the inbox populated with available data instead of dropping everything

## Validation
- git diff --check
- focused review of the notification refresh flow