### PR TITLE
fix: use stable revenue skeleton keys

### DIFF
--- a/website/src/pages/monitoring/RevenueDashboardPage.jsx
+++ b/website/src/pages/monitoring/RevenueDashboardPage.jsx
@@ -49,7 +49,7 @@ export default function RevenueDashboardPage() {
         <h1 style={styles.heading}>Revenue Analytics Dashboard</h1>
         <div style={styles.loadingGrid}>
           {[...Array(3)].map((_, i) => (
-            <div key={i} style={styles.skeletonCard} />
+            <div key={`skeleton-card-${i}`} style={styles.skeletonCard} />
           ))}
         </div>
       </div>


### PR DESCRIPTION
Closes #3242

Use descriptive skeleton keys so loading cards do not remount unnecessarily when the count changes.

Validation: git show --check --stat fix/revenue-skeleton-key-3242