### PR TITLE
fix: use stable forum post skeleton keys

### DIFF
--- a/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
+++ b/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
@@ -7,7 +7,7 @@ export function ForumPostSkeleton({ count = 5 }) {
     <div role="status" aria-label="Loading forum posts..." aria-busy="true">
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`forum-post-skeleton-${i}`}
           style={{
             padding: '20px 24px',
             borderBottom: '1px solid var(--bdr, rgba(255,255,255,0.06))',


### PR DESCRIPTION
Closes #3249

Use descriptive keys for forum post skeleton items to keep loading placeholders stable.

Validation: git show --check --stat fix/forumpostskeleton-key-3249