### PR TITLE
fix: use stable ai mentor suggestion keys

### DIFF
--- a/website/src/components/dashboard/AiMentor.jsx
+++ b/website/src/components/dashboard/AiMentor.jsx
@@ -164,7 +164,7 @@ export default function AiMentor() {
           >
             {result.suggestions &&
               result.suggestions.map((s, i) => (
-                <li key={`suggestion-${i}`} style={{ marginBottom: '4px' }}>
+                <li key={`ai-mentor-suggestion-${i}`} style={{ marginBottom: '4px' }}>
                   {s}
                 </li>
               ))}


### PR DESCRIPTION
Closes #3247

Use descriptive keys for AI mentor suggestion items so list rendering stays stable.

Validation: git show --check --stat fix/aimentor-suggestion-3247