### PR TITLE
fix: use stable project card skeleton keys

### DIFF
--- a/website/src/components/ui/skeleton/ProjectCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/ProjectCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function ProjectCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`project-card-skeleton-${i}`}
           style={{
             padding: '22px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3251

Use descriptive keys for project card skeleton items so the loading placeholders keep stable identity.

Validation: git show --check --stat fix/projectcard-skeleton-key-3251