### PR TITLE
fix: use stable mentor card skeleton keys

### DIFF
--- a/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function MentorCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`mentor-card-skeleton-${i}`}
           style={{
             padding: '24px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3250

Use descriptive keys for mentor card skeleton items so remounts do not reset loading UI.

Validation: git show --check --stat fix/mentorcardskeleton-key-3250