### PR TITLE
fix: use stable system health core keys

### DIFF
--- a/website/src/pages/monitoring/SystemHealthPage.jsx
+++ b/website/src/pages/monitoring/SystemHealthPage.jsx
@@ -352,7 +352,7 @@ export default function SystemHealthPage() {
               }}
             >
               {system.cpu.perCore.map((usage, i) => (
-                <div key={i} style={{ textAlign: 'center' }}>
+                <div key={`core-${i}`} style={{ textAlign: 'center' }}>
                   <div style={{ fontSize: '12px', color: '#9CA3AF', marginBottom: '4px' }}>
                     Core {i}
                   </div>


### PR DESCRIPTION
Closes #3243

Use descriptive per-core keys for the CPU usage cards to keep identity stable and match the issue expectation.

Validation: git show --check --stat fix/system-health-core-key-3243