### PR TITLE
fix: log local registration storage failures in dev

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -943,7 +943,11 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
           stored.push(localTicket);
           localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch {}
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn('Failed to persist event registration ticket locally:', err);
+          }
+        }
       }
     } catch (err) {
       if (err.message?.includes('waitlist')) {


### PR DESCRIPTION
Closes #3236

Surface local registration storage parse/write failures during development so they are not silently swallowed.

Validation: git diff --check && git show --check --stat HEAD