### PR TITLE
fix: use existing event search hook

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -13,7 +13,7 @@ import {
   Folder,
   MessageSquare,
 } from 'lucide-react';
-import { useSearch } from '../hooks/useSearch';
+import { useEventSearch } from '../hooks/useEventSearch';
 
 function Highlight({ text, query }) {
   if (!text) return null;
@@ -141,7 +141,7 @@ export default function SearchBar({ open, onClose, activities, events, onNavigat
     recentSearches,
     addRecentSearch,
     removeRecentSearch,
-  } = useSearch(activities, events);
+  } = useEventSearch(activities, events);
 
   const [localQuery, setLocalQuery] = useState('');
   const timeoutRef = useRef(null);


### PR DESCRIPTION
Closes #3317

Use the existing event search hook in SearchBar rather than duplicating search logic.

Validation: git show --check --stat fix/searchbar-hook-import-3317