### PR TITLE
fix: clear mentorship dashboard toast timer

### DIFF
--- a/website/src/pages/mentorship/MentorshipDashboard.jsx
+++ b/website/src/pages/mentorship/MentorshipDashboard.jsx
@@ -1,13 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
-
-// Validates a date value before formatting — avoids rendering literal
-// "Invalid Date" text when the API returns a null or malformed timestamp.
-function formatSessionDate(value) {
-  if (!value) return 'Unknown date';
-  const d = new Date(value);
-  if (Number.isNaN(d.getTime())) return 'Unknown date';
-  return d.toLocaleDateString();
-}
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Users,
   BookOpen,
@@ -24,6 +15,15 @@ import {
   mentorships as fallbackMentorships,
   sessions as fallbackSessions,
 } from '../../data/mentorshipData.js';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatSessionDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
 
 async function apiFetch(path, options = {}) {
   const base = getApiBase();
@@ -55,10 +55,22 @@ function MentorshipDashboard() {
   const [sessionForm, setSessionForm] = useState({ title: '', notes: '', duration_minutes: '' });
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState(null);
+  const toastTimeoutRef = useRef(null);
 
   const showToast = useCallback((message, type) => {
+    if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
     setToast({ message, type });
-    setTimeout(() => setToast(null), 4000);
+    toastTimeoutRef.current = setTimeout(() => {
+      setToast(null);
+      toastTimeoutRef.current = null;
+    }, 4000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
+      toastTimeoutRef.current = null;
+    };
   }, []);
 
   const fetchMentorships = useCallback(async () => {


### PR DESCRIPTION
Closes #3220

Store the mentorship dashboard toast timeout and clear it on unmount to prevent state updates after navigation.

Validation: git show --check --stat fix/mentorshipdashboard-toast-3220