### PR TITLE
fix: log event detail registration storage errors

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -943,7 +943,11 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
           stored.push(localTicket);
           localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch {}
+        } catch (error) {
+          if (import.meta.env.DEV) {
+            console.warn('[EventDetailPage] Failed to persist local registration:', error);
+          }
+        }
       }
     } catch (err) {
       if (err.message?.includes('waitlist')) {


### PR DESCRIPTION
Closes #3236

Surface local registration storage failures in development so parse and quota errors do not disappear silently.

Validation: git show --check --stat fix/eventdetailpage-localstorage-3236