### PR TITLE
fix: preserve budget details when one fetch fails

### DIFF
--- a/website/src/pages/finance/EventBudgetPage.jsx
+++ b/website/src/pages/finance/EventBudgetPage.jsx
@@ -235,7 +235,7 @@ export default function EventBudgetPage() {
   const selectBudget = useCallback(
     async (budget) => {
       setSelectedBudget(budget);
-      await Promise.all([
+      await Promise.allSettled([
         fetchExpenses(budget.id),
         fetchRevenues(budget.id),
         fetchVariance(budget.id),


### PR DESCRIPTION
Closes #3230

Use Promise.allSettled so one failed budget section does not prevent the other successfully fetched sections from rendering.

Validation: git diff --check && git show --check --stat HEAD