### PR TITLE
fix: honor user list pagination and role filters

### DIFF
--- a/server/repositories/usersRepository.js
+++ b/server/repositories/usersRepository.js
@@ -1,42 +1,57 @@
 import { withDb } from './db.js';
 
+function buildUserListQuery({ includeEmail = false, page = 1, limit = 20, role }) {
+  const selectColumns = [
+    'id',
+    'username',
+    'display_name',
+    'avatar_url',
+    'bio',
+    'phone_number',
+    'created_at as joined_at',
+  ];
+
+  if (includeEmail) {
+    selectColumns.push('email', 'admin_roles', 'last_login');
+  }
+
+  const params = [limit, (page - 1) * limit];
+  const conditions = [];
+
+  if (role) {
+    params.push(role);
+    conditions.push(`(role = $${params.length} OR admin_roles = $${params.length})`);
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  return {
+    text: `
+      SELECT
+        ${selectColumns.join(',\n        ')}
+      FROM users
+      ${whereClause}
+      ORDER BY created_at DESC
+      LIMIT $1
+      OFFSET $2
+    `,
+    values: params,
+  };
+}
+
 export const usersRepository = {
-  async getAllPublicUsers() {
+  async getAllPublicUsers({ page = 1, limit = 20, role } = {}) {
     return withDb(async (client) => {
-      const { rows } = await client.query(`
-        SELECT 
-          id, 
-          username, 
-          display_name, 
-          avatar_url, 
-          bio, 
-          phone_number,
-          created_at as joined_at
-        FROM users
-        ORDER BY created_at DESC
-        LIMIT 100
-      `);
+      const { text, values } = buildUserListQuery({ page, limit, role });
+      const { rows } = await client.query(text, values);
       return rows;
     });
   },
 
-  async getAllUsersAdmin() {
+  async getAllUsersAdmin({ page = 1, limit = 20, role } = {}) {
     return withDb(async (client) => {
-      const { rows } = await client.query(`
-        SELECT 
-          id, 
-          username, 
-          display_name, 
-          avatar_url, 
-          bio, 
-          phone_number,
-          created_at as joined_at,
-          email,
-          admin_roles,
-          last_login
-        FROM users
-        ORDER BY created_at DESC
-      `);
+      const { text, values } = buildUserListQuery({ includeEmail: true, page, limit, role });
+      const { rows } = await client.query(text, values);
       return rows;
     });
   },

--- a/server/test/usersApi.test.js
+++ b/server/test/usersApi.test.js
@@ -46,10 +46,14 @@ test('Scenario 5: Admin endpoint - Privileged fields only', () => {
 
 test('Controller handles public API responses correctly', async () => {
   const originalGetAll = usersRepository.getAllPublicUsers;
-  usersRepository.getAllPublicUsers = async () => [mockRawUser];
+  let receivedArgs;
+  usersRepository.getAllPublicUsers = async (args) => {
+    receivedArgs = args;
+    return [mockRawUser];
+  };
 
   let jsonRes;
-  const req = {};
+  const req = { query: { page: '2', limit: '5', role: 'moderator' } };
   const res = {
     json: (data) => {
       jsonRes = data;
@@ -60,6 +64,7 @@ test('Controller handles public API responses correctly', async () => {
 
   await getPublicUsers(req, res);
 
+  assert.deepEqual(receivedArgs, { page: 2, limit: 5, role: 'moderator' });
   assert.ok(Array.isArray(jsonRes));
   assert.equal(jsonRes.length, 1);
   assert.equal(jsonRes[0].username, 'hacker123');


### PR DESCRIPTION
Closes #3264

Propagate pagination and role filters into the users repository so the public and admin user lists stop ignoring the parsed query parameters.

Validation: node --check server/repositories/usersRepository.js && node --check server/test/usersApi.test.js; targeted node --test was blocked locally because the worktree does not have the pg package installed.