### PR TITLE
fix: preserve forum data when one fetch fails

### DIFF
--- a/website/src/pages/forum/ForumPage.jsx
+++ b/website/src/pages/forum/ForumPage.jsx
@@ -43,21 +43,36 @@ export default function ForumPage({ onBack }) {
       setLoading(false);
       return;
     }
-    Promise.all([
-      apiClient(`${base}/api/forum/categories`),
-      apiClient(
-        `${base}/api/forum/threads?sort=${sort}${activeCategory ? `&category=${activeCategory}` : ''}`
-      ),
-    ])
-      .then(([catData, threadData]) => {
-        if (catData?.categories) setCategories(catData.categories);
-        if (threadData?.threads) setThreads(threadData.threads);
-      })
-      .catch(() => {
+    let alive = true;
+
+    (async () => {
+      const [catData, threadData] = await Promise.allSettled([
+        apiClient(`${base}/api/forum/categories`),
+        apiClient(
+          `${base}/api/forum/threads?sort=${sort}${activeCategory ? `&category=${activeCategory}` : ''}`
+        ),
+      ]);
+
+      if (!alive) return;
+
+      if (catData.status === 'fulfilled' && catData.value?.categories) {
+        setCategories(catData.value.categories);
+      } else {
         setCategories(fallbackCategories);
+      }
+
+      if (threadData.status === 'fulfilled' && threadData.value?.threads) {
+        setThreads(threadData.value.threads);
+      } else {
         setThreads(fallbackThreads);
-      })
-      .finally(() => setLoading(false));
+      }
+
+      setLoading(false);
+    })();
+
+    return () => {
+      alive = false;
+    };
   }, [sort, activeCategory]);
 
   const filteredThreads = useMemo(() => {


### PR DESCRIPTION
Closes #3228

Use Promise.allSettled so one failed forum endpoint does not discard the successfully fetched categories or threads.

Validation: git diff --check && git show --check --stat HEAD