### PR TITLE
fix: use req.adminSession instead of undefined req.user in webhook ro…

### DIFF
--- a/server/migrations/1810_fix-webhooks-created-by-type.js
+++ b/server/migrations/1810_fix-webhooks-created-by-type.js
@@ -1,0 +1,18 @@
+// Fixes Issue #3262: the webhooks table's `created_by` column was created as
+// UUID, but admin identity in this codebase is tracked by username (string),
+// not a UUID (see req.adminSession.username, and e.g. audit_runs.created_by_admin_id
+// varchar(255)). Storing a username in a UUID column would fail with a
+// Postgres "invalid input syntax for type uuid" error, so the column type
+// needs to change to match how admins are actually identified.
+
+export const up = (pgm) => {
+  pgm.alterColumn('webhooks', 'created_by', {
+    type: 'varchar(255)',
+  });
+};
+
+export const down = (pgm) => {
+  pgm.alterColumn('webhooks', 'created_by', {
+    type: 'uuid',
+  });
+};

--- a/server/routes/webhooks.js
+++ b/server/routes/webhooks.js
@@ -17,7 +17,7 @@ router.get('/events', protectedActionRateLimiter, adminAuthMiddleware.requireAdm
 
 router.post('/', protectedActionRateLimiter, adminAuthMiddleware.requireAdmin, async (req, res) => {
   try {
-    const webhook = await webhookService.createWebhook(req.body, req.user);
+    const webhook = await webhookService.createWebhook(req.body, req.adminSession);
     res.status(201).json({ success: true, data: webhook });
   } catch (error) {
     const status = error.message.includes('HTTPS') || error.message.includes('event') ? 400 : 500;
@@ -47,7 +47,7 @@ router.get('/:webhookId', protectedActionRateLimiter, adminAuthMiddleware.requir
 
 router.put('/:webhookId', protectedActionRateLimiter, adminAuthMiddleware.requireAdmin, async (req, res) => {
   try {
-    const webhook = await webhookService.updateWebhook(req.params.webhookId, req.body, req.user);
+    const webhook = await webhookService.updateWebhook(req.params.webhookId, req.body, req.adminSession);
     res.json({ success: true, data: webhook });
   } catch (error) {
     const status = error.message.includes('not found')

--- a/server/services/webhookService.js
+++ b/server/services/webhookService.js
@@ -33,7 +33,7 @@ export const webhookService = {
       secret,
       events: data.events,
       isActive: data.isActive !== false,
-      createdBy: user.id,
+      createdBy: user?.username || 'unknown',
     });
   },
 


### PR DESCRIPTION
## Description
`req.user` is undefined on admin routes (admin auth attaches `req.adminSession`, not `req.user`), causing `TypeError: Cannot read properties of undefined (reading 'id')` on webhook creation, as described.

Fixing just the property name isn't enough though: `webhooks.created_by` is `UUID NOT NULL`, but admin identity here is a username string, not a UUID (see `req.adminSession.username`, and `audit_runs.created_by_admin_id varchar(255)` elsewhere in this codebase). Storing a username in a UUID column would just trade one crash for a Postgres type error.

## Changes
- [x] Migration: `webhooks.created_by` UUID → varchar(255)
- [x] `webhooks.js`: pass `req.adminSession` instead of `req.user`
- [x] `webhookService.js`: read `user?.username` instead of `user.id`, matching the pattern already used in `customEventController.js`

## Checklist
- [x] Tested locally
- [x] No breaking changes to existing tests
- [x] Follows repo contribution guidelines

Closes #3262.