### PR TITLE
fix: store and clear showToast setTimeout in MentorshipDashboard.jsx

### DIFF
--- a/website/src/pages/mentorship/MentorshipDashboard.jsx
+++ b/website/src/pages/mentorship/MentorshipDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 
 // Validates a date value before formatting — avoids rendering literal
 // "Invalid Date" text when the API returns a null or malformed timestamp.
@@ -55,10 +55,18 @@ function MentorshipDashboard() {
   const [sessionForm, setSessionForm] = useState({ title: '', notes: '', duration_minutes: '' });
   const [submitting, setSubmitting] = useState(false);
   const [toast, setToast] = useState(null);
+  const toastTimeoutRef = useRef(null);
 
   const showToast = useCallback((message, type) => {
     setToast({ message, type });
-    setTimeout(() => setToast(null), 4000);
+    if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
+    toastTimeoutRef.current = setTimeout(() => setToast(null), 4000);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
+    };
   }, []);
 
   const fetchMentorships = useCallback(async () => {


### PR DESCRIPTION
## Description
`MentorshipDashboard.jsx`'s `showToast` called `setTimeout(() => setToast(null), 4000)` with no ref storage or cleanup. If the component unmounted before 4000ms elapsed (e.g. user navigates away after logging a session), `setToast(null)` fired on an unmounted component.

Changes made:
- Added `toastTimeoutRef` (via `useRef`) to store the timeout ID
- `showToast` now clears any previous pending timeout before scheduling a new one, preventing rapid successive toasts from racing each other
- Added a `useEffect` cleanup that clears the timeout on unmount
- Zero new TypeScript errors introduced

Fixes #3220

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings