### PR TITLE
fix: store and clear showConflictToast setTimeout in CalendarView.jsx

### DIFF
--- a/website/src/components/events/CalendarView.jsx
+++ b/website/src/components/events/CalendarView.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
 import useSocketConnection from '../../hooks/useSocketConnection';
 import { getEventConflictStatus, detectConflicts } from '../../services/eventConflicts';
 import './CalendarView.css';
@@ -17,6 +17,7 @@ export default function CalendarView({ events: initialEvents, onEventClick, isAd
   const [searchQuery, setSearchQuery] = useState('');
   const [draggedEvent, setDraggedEvent] = useState(null);
   const [conflictToast, setConflictToast] = useState(null); // { message, severity }
+  const conflictToastTimeoutRef = useRef(null);
 
   const { on: onSocket } = useSocketConnection();
 
@@ -67,8 +68,15 @@ export default function CalendarView({ events: initialEvents, onEventClick, isAd
 
   const showConflictToast = (message, severity) => {
     setConflictToast({ message, severity });
-    setTimeout(() => setConflictToast(null), 4000);
+    if (conflictToastTimeoutRef.current) clearTimeout(conflictToastTimeoutRef.current);
+    conflictToastTimeoutRef.current = setTimeout(() => setConflictToast(null), 4000);
   };
+
+  useEffect(() => {
+    return () => {
+      if (conflictToastTimeoutRef.current) clearTimeout(conflictToastTimeoutRef.current);
+    };
+  }, []);
 
   const handleDrop = async (e, targetDate, hour = null) => {
     e.preventDefault();


### PR DESCRIPTION
## Description
`CalendarView.jsx`'s `showConflictToast` called `setTimeout(() => setConflictToast(null), 4000)` with no ref storage or cleanup. If the component unmounted before 4000ms elapsed, `setConflictToast(null)` fired on an unmounted component.

Changes made:
- Added `conflictToastTimeoutRef` (via `useRef`) to store the timeout ID
- `showConflictToast` now clears any previous pending timeout before scheduling a new one, preventing rapid successive toasts from racing each other
- Added a `useEffect` cleanup that clears the timeout on unmount
- Zero new TypeScript errors introduced

Fixes #3221

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings