### PR TITLE
fix: clear fallback setTimeout on unmount in ProjectRecommendations.jsx

### DIFF
--- a/website/src/components/recommendations/ProjectRecommendations.jsx
+++ b/website/src/components/recommendations/ProjectRecommendations.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import ResumeUpload from './ResumeUpload';
 import RecommendationCard from './RecommendationCard';
 import RecommendationSkeleton from './RecommendationSkeleton';
@@ -10,6 +10,15 @@ export default function ProjectRecommendations({ onBack }) {
   const [recommendations, setRecommendations] = useState([]);
   const [isDemo, setIsDemo] = useState(false);
   const [error, setError] = useState('');
+  const isMountedRef = useRef(true);
+  const fallbackTimeoutRef = useRef(null);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      if (fallbackTimeoutRef.current) clearTimeout(fallbackTimeoutRef.current);
+    };
+  }, []);
 
   const handleUpload = async (file) => {
     setStep('analyzing');
@@ -44,7 +53,8 @@ export default function ProjectRecommendations({ onBack }) {
     }
 
     // Backend unavailable, fallback to demo mode
-    setTimeout(() => {
+    fallbackTimeoutRef.current = setTimeout(() => {
+      if (!isMountedRef.current) return;
       setIsDemo(true);
       // Hardcoded fallback recommendations matching our mock projects list
       setRecommendations([


### PR DESCRIPTION
## Description
`ProjectRecommendations.jsx`'s `handleUpload` used `setTimeout` for the demo-mode fallback with no ref storage or cleanup. If the component unmounted during the delay (e.g. user navigates away while the resume is being analyzed), `setIsDemo`, `setRecommendations`, and `setStep` all fired on an unmounted component.

Changes made:
- Added `isMountedRef` and `fallbackTimeoutRef` via `useRef`
- A `useEffect` cleanup sets `isMountedRef.current = false` and clears the pending timeout on unmount
- Added an `isMountedRef.current` guard at the start of the timeout callback so state updates are skipped if the component already unmounted
- Stored the timeout ID in `fallbackTimeoutRef` so it can be explicitly cleared
- Zero new TypeScript errors introduced

Fixes #3223

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings