### PR TITLE
fix: store and clear setCopied setTimeout in ShareHub.jsx

### DIFF
--- a/website/src/components/ShareHub/ShareHub.jsx
+++ b/website/src/components/ShareHub/ShareHub.jsx
@@ -1,10 +1,16 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { PLATFORMS, addUtmParams, getQRUrl, copyToClipboard } from '../../utils/shareUtils';
 import './ShareHub.css';
 
 export default function ShareHub({ isOpen, onClose, data }) {
   const [copied, setCopied] = useState(false);
   const [showQR, setShowQR] = useState(false);
+  const copiedTimeoutRef = useRef(null);
+  useEffect(() => {
+    return () => {
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+    };
+  }, []);
 
   useEffect(() => {
     if (!isOpen) return;
@@ -29,7 +35,8 @@ export default function ShareHub({ isOpen, onClose, data }) {
     const ok = await copyToClipboard(shareUrl);
     if (ok) {
       setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current);
+      copiedTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
     }
   }, [shareUrl]);
 


### PR DESCRIPTION
## Description
`ShareHub.jsx`'s copy-to-clipboard handler called `setTimeout(() => setCopied(false), 2000)` with no ref storage or cleanup. If the ShareHub modal was closed within 2000ms of clicking copy, `setCopied(false)` fired on an unmounted component.

Changes made:
- Added `copiedTimeoutRef` (via `useRef`) to store the timeout ID
- Clears any previous pending timeout before scheduling a new one, so rapid successive copy clicks don't race each other
- Added a `useEffect` cleanup that clears the timeout on unmount
- Zero new TypeScript errors introduced

Fixes #3224

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings