### PR TITLE
fix: replace key={index} with stable key for resource items in NodeModal.tsx

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -405,7 +405,7 @@ export const NodeModal: React.FC<NodeModalProps> = ({ theme }) => {
               >
                 {resources.map((res, index) => (
                   <div
-                    key={index}
+                    key={res.url || `resource-${index}`}
                     className="resource-item-edit-row glassmorphic-panel flex justify-between items-center text-xs"
                     style={{ padding: '8px 14px', borderRadius: '8px' }}
                   >


### PR DESCRIPTION
## Description
`NodeModal.tsx` rendered resource list items with `key={index}` (array index). When resources were added or removed, React reused `<div>` elements at the same index position rather than tracking by resource identity — items at shifted positions could render stale resource data (title, URL) from the previous render.

Changes made:
- Replaced `key={index}` with `` key={res.url || `resource-${index}`} `` using the resource URL as the primary stable identifier (since URLs are unique per resource) with an index fallback for resources without a URL
- Zero new TypeScript errors introduced

Fixes #3248

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings