### PR TITLE
fix: replace hardcoded /api/feedback path with buildUrl in EventFeedbackForm.jsx

### DIFF
--- a/website/src/pages/EventFeedbackForm.jsx
+++ b/website/src/pages/EventFeedbackForm.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { buildUrl } from '../utils/runtimeConfig';
 import { useParams, useNavigate } from 'react-router-dom';
 
 const EventFeedbackForm = () => {
@@ -16,7 +17,7 @@ const EventFeedbackForm = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      const response = await fetch('/api/feedback', {
+      const response = await fetch(buildUrl('/api/feedback'), {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Description
`EventFeedbackForm.jsx` called `fetch('/api/feedback', ...)` with a hardcoded relative path. Every other fetch call in the codebase uses `buildUrl()` or `getApiBase()` to construct the correct API URL. Using a hardcoded `/api/feedback` path silently breaks when the API base URL is not at the root (e.g. proxied environments, staging, or when `VITE_API_BASE` is set to a non-root URL).

Changes made:
- Imported `buildUrl` from `../utils/runtimeConfig`
- Replaced `fetch('/api/feedback', ...)` with `fetch(buildUrl('/api/feedback'), ...)`, consistent with all other API calls in the codebase
- Zero new TypeScript errors introduced

Fixes #3226

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings