### PR TITLE
fix: log fetch errors instead of silently ignoring them in LiveStreamPage.jsx

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -279,8 +279,10 @@ function LiveStreamPage() {
     try {
       const data = await apiFetch(`/api/streams/${id}/chat?limit=200`);
       setMessages(data.messages || []);
-    } catch {
-      // ignore
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[LiveStreamPage] Failed to fetch messages:', err.message);
+      }
     }
   }, []);
 
@@ -288,8 +290,10 @@ function LiveStreamPage() {
     try {
       const data = await apiFetch(`/api/streams/${id}/polls`);
       setPolls(data.polls || []);
-    } catch {
-      // ignore
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('[LiveStreamPage] Failed to fetch polls:', err.message);
+      }
     }
   }, []);
 


### PR DESCRIPTION
## Description
`fetchMessages` and `fetchPolls` in `LiveStreamPage.jsx` both had bare `catch { // ignore }` blocks that completely discarded errors with no feedback. Failures were invisible even in development — nothing was logged to the console, making it impossible to diagnose issues with the chat or polls endpoints.

Note: Since both functions catch internally and never rethrow, the `Promise.all([fetchMessages, fetchPolls])` wrapping them could never actually reject — so the original issue title's premise about `Promise.all` discarding both results wasn't quite right. The real problem was the silent catch blocks.

Changes made:
- Added `import.meta.env.DEV`-guarded `console.error` calls with `[LiveStreamPage]` prefix and `err.message` to both `fetchMessages` and `fetchPolls` catch blocks
- Zero new TypeScript errors introduced

Fixes #3229

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings