### PR TITLE
fix: switch Promise.all to Promise.allSettled in useAnalyticsData.ts

### DIFF
--- a/website/src/hooks/analytics/useAnalyticsData.ts
+++ b/website/src/hooks/analytics/useAnalyticsData.ts
@@ -55,14 +55,35 @@ export const useAnalyticsData = () => {
     const token = localStorage.getItem('ns_student_token');
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
-    Promise.all([
+    Promise.allSettled([
       apiClient(`${base}/api/admin/analytics/stats`, { headers }),
       apiClient(`${base}/api/admin/analytics/growth`, { headers }),
       apiClient(`${base}/api/admin/analytics/events`, { headers }),
     ])
-      .then(([stats, growth, events]) => {
+      .then(([statsResult, growthResult, eventsResult]) => {
         if (!isMounted) return;
+        if (import.meta.env.DEV) {
+          if (statsResult.status === 'rejected') {
+            console.warn('[useAnalyticsData] Stats fetch failed:', statsResult.reason?.message);
+          }
+          if (growthResult.status === 'rejected') {
+            console.warn('[useAnalyticsData] Growth fetch failed:', growthResult.reason?.message);
+          }
+          if (eventsResult.status === 'rejected') {
+            console.warn('[useAnalyticsData] Events fetch failed:', eventsResult.reason?.message);
+          }
+        }
+        if (
+          statsResult.status === 'rejected' &&
+          growthResult.status === 'rejected' &&
+          eventsResult.status === 'rejected'
+        ) {
+          applyMockData();
+          return;
+        }
         setIsOffline(false);
+        const growth = growthResult.status === 'fulfilled' ? growthResult.value : null;
+        const events = eventsResult.status === 'fulfilled' ? eventsResult.value : null;
 
         // Map API responses to chart data shapes.
         // growth is expected to be an array of { name, users, activity, projects }
@@ -84,8 +105,7 @@ export const useAnalyticsData = () => {
         setLoading(false);
       })
       .catch(() => {
-        // API unreachable — fall back to mock data with a visible indicator
-        applyMockData();
+        if (isMounted) applyMockData();
       });
 
     return () => {


### PR DESCRIPTION
## Description
`useAnalyticsData.ts` used `Promise.all` across three independent `apiClient` calls (stats, growth, events). A single endpoint failure caused `Promise.all` to reject and fall back to full mock data — discarding data from the other two endpoints that may have loaded successfully.

Changes made:
- Replaced `Promise.all` with `Promise.allSettled` so each result is handled independently
- Growth and events results are now extracted individually — a failed endpoint uses generated fallback data while successful results are still applied
- Only falls back to `applyMockData()` if all three endpoints fail simultaneously
- Added `import.meta.env.DEV`-guarded `console.warn` per rejected result for development traceability
- Existing `isMounted` guard preserved in `.then()` and added to `.catch()`
- Zero new TypeScript errors introduced

Fixes #3227

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings