### PR TITLE
fix: use stable node modal resource keys

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -405,7 +405,7 @@ export const NodeModal: React.FC<NodeModalProps> = ({ theme }) => {
               >
                 {resources.map((res, index) => (
                   <div
-                    key={index}
+                    key={`${res.title}-${res.url}`}
                     className="resource-item-edit-row glassmorphic-panel flex justify-between items-center text-xs"
                     style={{ padding: '8px 14px', borderRadius: '8px' }}
                   >


### PR DESCRIPTION
Closes #3248\n\nSummary:\n- Replace index keys in NodeModal resource rendering with stable keys\n- Prevent unnecessary remounts when resource order changes\n\nValidation:\n- git diff --check HEAD -- website/src/components/roadmaps/NodeModal.tsx