### PR TITLE
fix: use stable mentor card skeleton keys

### DIFF
--- a/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function MentorCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`mentor-card-skeleton-${i}`}
           style={{
             padding: '24px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3250\n\nSummary:\n- Replace index keys in MentorCardSkeleton with stable keys\n- Reduce loading-state remount churn for mentor cards\n\nValidation:\n- git diff --check HEAD -- website/src/components/ui/skeleton/MentorCardSkeleton.jsx