### PR TITLE
fix: remove duplicate server imports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -115,8 +115,6 @@ import { schedulerService } from './services/schedulerService.js';
 import feedbackRouter from './routes/feedbackRoutes.js';
 import * as slackController from './controllers/slackController.js';
 import activityTimelineRoutes from './routes/activityTimeline.js';
-import notificationPreferenceRoutes from './routes/notificationPreference.js';
-import { readOnlyGuard } from './services/readOnlyService.js';
 
 import { initializeTypesenseCollections } from './config/typesense.js';
 import moderationRouter from './routes/moderation.js';


### PR DESCRIPTION
Closes #3137\n\nSummary:\n- Remove duplicate import declarations in server/index.js\n- Restore backend startup under strict ESM syntax checks\n\nValidation:\n- node --check server/index.js\n- git diff --check