### PR TITLE
fix: respect caller abort signals in api client

### DIFF
--- a/website/src/pages/explore/ExplorePage.jsx
+++ b/website/src/pages/explore/ExplorePage.jsx
@@ -33,11 +33,8 @@ export default function ExplorePage({ onBack, eventsData }) {
   const [activeTab, setActiveTab] = useState('discover');
 
   useEffect(() => {
-    // apiClient creates its own internal AbortController per call (for its
-    // request timeout) and does not currently accept an external signal, so
-    // in-flight requests here cannot be cancelled directly. Guard against
-    // state updates firing after unmount with an `alive` flag instead,
-    // consistent with the pattern already used in TeamPage.jsx.
+    // Guard against state updates after unmount; this page does not pass its
+    // own AbortSignal to apiClient, so we still need an `alive` flag here.
     let alive = true;
     const fetchData = async () => {
       const base = getApiBase();

--- a/website/src/utils/apiClient.js
+++ b/website/src/utils/apiClient.js
@@ -39,6 +39,51 @@ function getIDBCacheKey(url) {
  */
 const MUTATING_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 
+function createAbortSignal(timeout, callerSignal) {
+  const timeoutController = new AbortController();
+  const timeoutId = setTimeout(() => timeoutController.abort(), timeout);
+
+  if (!callerSignal) {
+    return {
+      signal: timeoutController.signal,
+      cleanup: () => clearTimeout(timeoutId),
+    };
+  }
+
+  if (typeof AbortSignal.any === 'function') {
+    return {
+      signal: AbortSignal.any([timeoutController.signal, callerSignal]),
+      cleanup: () => clearTimeout(timeoutId),
+    };
+  }
+
+  const combinedController = new AbortController();
+  const abortCombined = () => {
+    if (!combinedController.signal.aborted) {
+      combinedController.abort();
+    }
+  };
+
+  const onTimeoutAbort = () => abortCombined();
+  const onCallerAbort = () => abortCombined();
+
+  timeoutController.signal.addEventListener('abort', onTimeoutAbort, { once: true });
+  if (callerSignal.aborted) {
+    abortCombined();
+  } else {
+    callerSignal.addEventListener('abort', onCallerAbort, { once: true });
+  }
+
+  return {
+    signal: combinedController.signal,
+    cleanup: () => {
+      clearTimeout(timeoutId);
+      timeoutController.signal.removeEventListener('abort', onTimeoutAbort);
+      callerSignal.removeEventListener('abort', onCallerAbort);
+    },
+  };
+}
+
 /**
  * Centralized async API wrapper for fetch
  * =========================================
@@ -143,25 +188,14 @@ export const apiClient = async (url, options = {}) => {
 
   // ── Normal online fetch ────────────────────────────────────────────────────
 
-  const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), timeout);
-
-  // Combine the timeout controller's signal with any caller-provided signal.
-  // AbortSignal.any() (available in modern browsers/Node ≥20) fires whichever
-  // signal aborts first, so component unmount AND timeout both work correctly.
   const callerSignal = fetchOptions.signal;
-  const combinedSignal =
-    callerSignal && typeof AbortSignal.any === 'function'
-      ? AbortSignal.any([controller.signal, callerSignal])
-      : controller.signal;
+  const { signal, cleanup } = createAbortSignal(timeout, callerSignal);
 
   try {
     const response = await fetch(url, {
       ...fetchOptions,
-      signal: combinedSignal,
+      signal,
     });
-
-    clearTimeout(id);
 
     if (response.type === 'opaque') {
       return null;
@@ -213,8 +247,6 @@ export const apiClient = async (url, options = {}) => {
 
     return await response.text();
   } catch (error) {
-    clearTimeout(id);
-
     let standardError;
     if (error instanceof ApiError) {
       standardError = error;
@@ -238,6 +270,8 @@ export const apiClient = async (url, options = {}) => {
     }
 
     throw standardError;
+  } finally {
+    cleanup();
   }
 };
 


### PR DESCRIPTION
Closes #2116\n\nSummary:\n- Preserve caller-provided AbortSignal in apiClient\n- Combine caller aborts with request timeout aborts, with a fallback when AbortSignal.any is unavailable\n- Update the stale ExplorePage comment to match the new behavior\n\nValidation:\n- node --check website/src/utils/apiClient.js\n- git diff --check