### PR TITLE
fix: preserve live stream data when one fetch fails

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -299,7 +299,7 @@ function LiveStreamPage() {
       setError(null);
       const s = await fetchStream();
       if (s) {
-        await Promise.all([fetchMessages(s.id), fetchPolls(s.id)]);
+        await Promise.allSettled([fetchMessages(s.id), fetchPolls(s.id)]);
       } else if (!streamId) {
         setError('No stream found for this event.');
       }


### PR DESCRIPTION
Closes #3229\n\nSummary:\n- Use Promise.allSettled for chat and poll fetches\n- Keep whichever stream data loads successfully when the other request fails\n\nValidation:\n- git diff --check HEAD -- website/src/pages/streaming/LiveStreamPage.jsx