### PR TITLE
fix: preserve budget details when one fetch fails

### DIFF
--- a/website/src/pages/finance/EventBudgetPage.jsx
+++ b/website/src/pages/finance/EventBudgetPage.jsx
@@ -235,7 +235,7 @@ export default function EventBudgetPage() {
   const selectBudget = useCallback(
     async (budget) => {
       setSelectedBudget(budget);
-      await Promise.all([
+      await Promise.allSettled([
         fetchExpenses(budget.id),
         fetchRevenues(budget.id),
         fetchVariance(budget.id),


### PR DESCRIPTION
Closes #3230\n\nSummary:\n- Use Promise.allSettled for the EventBudgetPage detail fetches\n- Keep whichever budget data loads successfully when one request fails\n\nValidation:\n- git diff --check HEAD -- website/src/pages/finance/EventBudgetPage.jsx