### PR TITLE
fix: cancel analytics requests and preserve partial data

### DIFF
--- a/website/src/hooks/analytics/useAnalyticsData.ts
+++ b/website/src/hooks/analytics/useAnalyticsData.ts
@@ -28,6 +28,7 @@ export const useAnalyticsData = () => {
 
   useEffect(() => {
     let isMounted = true;
+    const controller = new AbortController();
     setLoading(true);
 
     const months =
@@ -55,41 +56,52 @@ export const useAnalyticsData = () => {
     const token = localStorage.getItem('ns_student_token');
     const headers = token ? { Authorization: `Bearer ${token}` } : {};
 
-    Promise.all([
-      apiClient(`${base}/api/admin/analytics/stats`, { headers }),
-      apiClient(`${base}/api/admin/analytics/growth`, { headers }),
-      apiClient(`${base}/api/admin/analytics/events`, { headers }),
-    ])
-      .then(([stats, growth, events]) => {
-        if (!isMounted) return;
-        setIsOffline(false);
+    (async () => {
+      const results = await Promise.allSettled([
+        apiClient(`${base}/api/admin/analytics/stats`, { headers, signal: controller.signal }),
+        apiClient(`${base}/api/admin/analytics/growth`, { headers, signal: controller.signal }),
+        apiClient(`${base}/api/admin/analytics/events`, { headers, signal: controller.signal }),
+      ]);
 
-        // Map API responses to chart data shapes.
-        // growth is expected to be an array of { name, users, activity, projects }
-        if (Array.isArray(growth) && growth.length > 0) {
-          setTrendData(growth as TrendDataPoint[]);
-        } else {
-          setTrendData(generateTrendData(filters.timeGranularity, effectiveMonths));
-        }
+      if (!isMounted) return;
 
-        // events is expected to be an array of { name, value } category distribution
-        if (Array.isArray(events) && events.length > 0) {
-          setDistributionData(events as DistributionDataPoint[]);
-          setComparisonData(generateComparisonData(filters.categories));
-        } else {
-          setDistributionData(generateDistributionData(filters.categories));
-          setComparisonData(generateComparisonData(filters.categories));
-        }
+      const [statsResult, growthResult, eventsResult] = results;
+      const hasAnySuccess = results.some((result) => result.status === 'fulfilled');
 
-        setLoading(false);
-      })
-      .catch(() => {
-        // API unreachable — fall back to mock data with a visible indicator
+      if (!hasAnySuccess) {
         applyMockData();
-      });
+        return;
+      }
+
+      setIsOffline(false);
+
+      // Map API responses to chart data shapes.
+      // growth is expected to be an array of { name, users, activity, projects }
+      if (growthResult.status === 'fulfilled' && Array.isArray(growthResult.value) && growthResult.value.length > 0) {
+        setTrendData(growthResult.value as TrendDataPoint[]);
+      } else {
+        setTrendData(generateTrendData(filters.timeGranularity, effectiveMonths));
+      }
+
+      // events is expected to be an array of { name, value } category distribution
+      if (eventsResult.status === 'fulfilled' && Array.isArray(eventsResult.value) && eventsResult.value.length > 0) {
+        setDistributionData(eventsResult.value as DistributionDataPoint[]);
+      } else {
+        setDistributionData(generateDistributionData(filters.categories));
+      }
+      setComparisonData(generateComparisonData(filters.categories));
+
+      // statsResult is currently used as a health check for the analytics API.
+      // If it failed while the other endpoints succeeded, we still keep the
+      // partial analytics view instead of dropping back to mock data.
+      void statsResult;
+
+      setLoading(false);
+    })();
 
     return () => {
       isMounted = false;
+      controller.abort();
     };
   }, [filters]);
 


### PR DESCRIPTION
Closes #3227\n\nSummary:\n- Abort in-flight analytics requests when the page unmounts\n- Preserve whichever analytics requests finish successfully instead of dropping all data on one failure\n\nValidation:\n- git diff --check HEAD -- website/src/hooks/analytics/useAnalyticsData.ts