### PR TITLE
fix: gate issue validation by bug label

### DIFF
--- a/.github/workflows/issue-validate.yml
+++ b/.github/workflows/issue-validate.yml
@@ -6,7 +6,7 @@ name: GSSoC — Issue Validate
 # ─────────────────────────────────────────────────────────────────────────────
 on:
   issues:
-    types: [opened, edited]
+    types: [opened, edited, labeled, unlabeled]
 
 concurrency:
   group: issue-validate-${{ github.event.issue.number }}
@@ -32,10 +32,20 @@ jobs:
             const issueNum = issue.number;
             const body     = issue.body || '';
             const author   = issue.user.login;
+            const labels   = (issue.labels || []).map((label) => label.name);
+            const isBug    = labels.includes('bug');
 
             // ── Skip bots ─────────────────────────────────────────────────────
             if (author.endsWith('[bot]')) {
               console.log('⏭️  Skipping bot-created issue');
+              return;
+            }
+
+            // ── Only validate bug reports ────────────────────────────────────
+            if (!isBug) {
+              await removeLabel('needs-more-info');
+              await removeLabel('valid-issue');
+              console.log(`↩️  Issue #${issueNum} is not labeled bug; skipping validation`);
               return;
             }
 
@@ -63,9 +73,9 @@ jobs:
 
             // ── Define required sections ──────────────────────────────────────
             const REQUIRED_SECTIONS = [
-              { pattern: /##?\s*description/i,           label: '**Description** — What is the issue?' },
-              { pattern: /##?\s*steps\s+to\s+reproduce/i, label: '**Steps to Reproduce** — How can we reproduce the issue?' },
-              { pattern: /##?\s*expected\s+behav/i,      label: '**Expected Behavior** — What should happen?' },
+              { pattern: /^#{1,6}\s*(?:bug\s+)?description\b/im,    label: '**Description** — What is the issue?' },
+              { pattern: /^#{1,6}\s*steps\s+to\s+reproduce\b/im,    label: '**Steps to Reproduce** — How can we reproduce the issue?' },
+              { pattern: /^#{1,6}\s*expected\s+behav(?:ior|iour)\b/im, label: '**Expected Behavior** — What should happen?' },
             ];
 
             const missing = REQUIRED_SECTIONS


### PR DESCRIPTION
Closes #3544

Validation: `git diff --check`; `ruby -e "require 'yaml'; YAML.load_file('/Users/saurabhkumarbajpaiai/Documents/Codex/OpenCode/NexaSphere-3544/.github/workflows/issue-validate.yml')"`.