### PR TITLE
docs: correct API docs routes

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -31,7 +31,7 @@ The `server/` directory contains the **Node.js / Express** backend API that powe
 - **Auth:** Firebase Admin SDK (token verification)
 - **Real-Time:** Socket.io 4
 - **Validation:** Zod schemas
-- **API Docs:** Swagger UI at `/api-docs` · ReDoc at `/redoc`
+- **API Docs:** Swagger UI at `/api/docs` · ReDoc at `/api/redoc` · OpenAPI JSON at `/api/swagger.json`
 
 ---
 
@@ -193,7 +193,10 @@ curl http://localhost:8080/healthz
 | URL         | Description             |
 | ----------- | ----------------------- |
 | `/api-docs` | Interactive Swagger UI  |
-| `/redoc`    | ReDoc API documentation |
+| `/api/docs` | Swagger UI API documentation |
+| `/api/redoc` | ReDoc API documentation |
+| `/api/swagger.json` | OpenAPI JSON specification |
+| `/api/swagger.yaml` | OpenAPI YAML specification |
 
 ---
 


### PR DESCRIPTION
Closes #1603

Validation: `git diff --check`.
