### PR TITLE
fix: cap stacked toast notifications

### DIFF
--- a/admin-dashboard/src/__tests__/components/Toast.test.jsx
+++ b/admin-dashboard/src/__tests__/components/Toast.test.jsx
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { Toast } from '../../components/Toast';
+import { eventEmitter, EVENTS } from '../../services/eventEmitter';
+
+describe('Toast', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    eventEmitter.clear(EVENTS.NOTIFY);
+  });
+
+  afterEach(() => {
+    cleanup();
+    eventEmitter.clear(EVENTS.NOTIFY);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  test('caps visible toasts and removes the oldest toast when the limit is exceeded', () => {
+    render(<Toast />);
+
+    act(() => {
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'info', message: 'Toast 1' });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'info', message: 'Toast 2' });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'info', message: 'Toast 3' });
+      eventEmitter.emit(EVENTS.NOTIFY, { type: 'info', message: 'Toast 4' });
+    });
+
+    expect(screen.queryByText('Toast 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Toast 2')).toBeInTheDocument();
+    expect(screen.getByText('Toast 3')).toBeInTheDocument();
+    expect(screen.getByText('Toast 4')).toBeInTheDocument();
+    expect(screen.getAllByRole('button', { name: /close notification/i })).toHaveLength(3);
+
+    act(() => {
+      vi.advanceTimersByTime(3000);
+    });
+
+    expect(screen.queryByText('Toast 2')).not.toBeInTheDocument();
+    expect(screen.queryByText('Toast 3')).not.toBeInTheDocument();
+    expect(screen.queryByText('Toast 4')).not.toBeInTheDocument();
+  });
+});

--- a/admin-dashboard/src/components/Toast.jsx
+++ b/admin-dashboard/src/components/Toast.jsx
@@ -2,12 +2,25 @@ import { useState, useCallback } from 'react';
 import { useEventListener } from '../hooks/useEventListener';
 import { EVENTS } from '../services/eventEmitter';
 
+const MAX_TOASTS = 3;
+
+function createToastId() {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
 export function Toast() {
   const [toasts, setToasts] = useState([]);
 
   const handleNotify = useCallback(({ type, message }) => {
-    const id = Date.now();
-    setToasts((prev) => [...prev, { id, type, message }]);
+    const id = createToastId();
+    setToasts((prev) => {
+      const next = [...prev, { id, type, message }];
+      return next.length > MAX_TOASTS ? next.slice(next.length - MAX_TOASTS) : next;
+    });
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3000);
   }, []);
 


### PR DESCRIPTION
Closes #1404

Caps visible admin toasts at three items and removes the oldest toast when the limit is exceeded.

Validation: git diff --check; vitest run src/__tests__/components/Toast.test.jsx