### PR TITLE
fix: delete only processed digests

### DIFF
--- a/server/services/notificationsService.js
+++ b/server/services/notificationsService.js
@@ -205,6 +205,7 @@ class NotificationsService {
   async processDigests(frequency) {
     const digests = await supabaseRequest(`pending_digests?frequency=eq.${frequency}`);
     if (!digests || digests.length === 0) return;
+    const digestIds = digests.map((digest) => digest.id).filter(Boolean);
 
     const userGroups = digests.reduce((acc, d) => {
       acc[d.user_id] = acc[d.user_id] || [];
@@ -227,7 +228,11 @@ class NotificationsService {
       }
     }
     // Cleanup processed digests
-    await supabaseRequest(`pending_digests?frequency=eq.${frequency}`, { method: 'DELETE' });
+    if (digestIds.length > 0) {
+      await supabaseRequest(`pending_digests?id=in.(${digestIds.join(',')})`, {
+        method: 'DELETE',
+      });
+    }
   }
 
   computePriority({ type, title, message, richData }) {

--- a/server/test/notificationsServiceDigest.test.js
+++ b/server/test/notificationsServiceDigest.test.js
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+process.env.SUPABASE_URL = 'https://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+
+const fetchCalls = [];
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = async (url, options = {}) => {
+  const method = options.method || 'GET';
+  fetchCalls.push({ url: String(url), method });
+
+  if (String(url) === 'https://supabase.test/rest/v1/pending_digests?frequency=eq.daily_digest' && method === 'GET') {
+    return new Response(
+      JSON.stringify([
+        {
+          id: 'digest-1',
+          user_id: 'user-a',
+          notification_data: { title: 'One' },
+        },
+        {
+          id: 'digest-2',
+          user_id: 'user-a',
+          notification_data: { title: 'Two' },
+        },
+        {
+          id: 'digest-3',
+          user_id: 'user-b',
+          notification_data: { title: 'Three' },
+        },
+      ]),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+
+  if (
+    String(url) ===
+      'https://supabase.test/rest/v1/pending_digests?id=in.(digest-1,digest-2,digest-3)' &&
+    method === 'DELETE'
+  ) {
+    return new Response('', { status: 200 });
+  }
+
+  throw new Error(`Unexpected fetch call: ${method} ${String(url)}`);
+};
+
+const { default: notificationsService } = await import('../services/notificationsService.js');
+
+test.after(() => {
+  globalThis.fetch = originalFetch;
+});
+
+test('processDigests deletes only the digests it fetched', async () => {
+  const sent = [];
+  const originalSendNow = notificationsService.sendNow;
+  notificationsService.sendNow = async (userId, payload) => {
+    sent.push({ userId, payload });
+  };
+
+  try {
+    await notificationsService.processDigests('daily_digest');
+  } finally {
+    notificationsService.sendNow = originalSendNow;
+  }
+
+  assert.deepEqual(
+    sent.map((entry) => entry.userId),
+    ['user-a', 'user-b']
+  );
+  assert.equal(fetchCalls.length, 2);
+  assert.equal(
+    fetchCalls[1].url,
+    'https://supabase.test/rest/v1/pending_digests?id=in.(digest-1,digest-2,digest-3)'
+  );
+  assert.equal(fetchCalls[1].method, 'DELETE');
+  assert.equal(
+    fetchCalls.some(
+      (call) => call.method === 'DELETE' && call.url.includes('frequency=eq.daily_digest')
+    ),
+    false
+  );
+});


### PR DESCRIPTION
# Summary
Delete only the digest records fetched and processed by the current digest batch.

## Related Issue

Fixes #3172

## Type of Change

- [x] Bug Fix
- [x] Testing

## Changes Implemented

- Capture the exact pending digest IDs loaded at the start of processDigests.
- Delete only those processed IDs instead of deleting the entire frequency bucket.
- Add regression coverage for the targeted cleanup request.

## Technical Details

### Backend

The cleanup request is scoped to the fetched batch, so newly-created digests are left for the next run.

## Testing

### Unit Tests

- [x] node --test test/notificationsServiceDigest.test.js

### Manual Testing

- [x] git diff --check

## Security Review

No new input paths or permissions are introduced.

## Accessibility Review

Not applicable to this backend service change.

## Performance Impact

Cleanup remains bounded to the current batch and avoids deleting unrelated rows.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review
