### PR TITLE
feat: add error tracking grouping metadata

### DIFF
--- a/server/services/errorTrackingService.js
+++ b/server/services/errorTrackingService.js
@@ -4,6 +4,7 @@ import 'dotenv/config';
  * Manages error logging, tracking, and analysis
  */
 
+import crypto from 'crypto';
 import logger from '../utils/logger.js';
 import { captureMessage, addBreadcrumb } from '../utils/sentry.js';
 import securityPatchManager from '../utils/securityPatchManager.js';
@@ -14,15 +15,38 @@ const errorStore = {
   errors: [],
 };
 
+function getEnvironmentMetadata() {
+  return {
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    nodeEnv: process.env.NODE_ENV || 'unknown',
+  };
+}
+
+function generateErrorFingerprint(error, context = {}) {
+  const name = error?.name || 'Error';
+  const message = error?.message || 'Unknown error';
+  const endpoint = `${context.method || 'UNKNOWN'} ${context.url || 'unknown'}`;
+
+  return crypto
+    .createHash('sha1')
+    .update(`${name}:${message}:${endpoint}`)
+    .digest('hex');
+}
+
 /**
  * Log error with full context
  * @param {Error} error - Error object
  * @param {Object} context - Request context
  */
 async function logError(error, context = {}) {
+  const fingerprint = generateErrorFingerprint(error, context);
+  const environment = getEnvironmentMetadata();
   const errorData = {
     timestamp: new Date(),
     message: error.message,
+    fingerprint,
     status: context.status || 500,
     stack: error.stack,
     url: context.url,
@@ -33,6 +57,7 @@ async function logError(error, context = {}) {
     requestBody: sanitizeData(context.requestBody),
     queryParams: truncateData(context.queryParams, 512),
     headers: sanitizeHeaders(context.headers),
+    environment,
   };
 
   // Store error
@@ -107,12 +132,33 @@ function getErrorStats() {
       errorCount: count,
     }));
 
+  const errorsByFingerprintMap = {};
+  for (const err of errorStore.errors) {
+    const key = err.fingerprint || `${err.method} ${err.url} ${err.message}`;
+    errorsByFingerprintMap[key] = errorsByFingerprintMap[key] || {
+      fingerprint: err.fingerprint || key,
+      message: err.message,
+      endpoint: `${err.method} ${err.url}`,
+      count: 0,
+      lastSeen: err.timestamp,
+    };
+    errorsByFingerprintMap[key].count += 1;
+    if (new Date(err.timestamp) > new Date(errorsByFingerprintMap[key].lastSeen)) {
+      errorsByFingerprintMap[key].lastSeen = err.timestamp;
+    }
+  }
+
+  const groupedErrors = Object.values(errorsByFingerprintMap)
+    .sort((a, b) => b.count - a.count)
+    .slice(0, 10);
+
   return {
     total,
     lastHour,
     last24Hours,
     errorsByStatus,
     topEndpoints,
+    groupedErrors,
   };
 }
 

--- a/server/test/errorTracking.test.js
+++ b/server/test/errorTracking.test.js
@@ -166,3 +166,27 @@ test('retrieval methods (recent, endpoint, user) work correctly', async () => {
   assert.strictEqual(userErrors.length, 1);
   assert.strictEqual(userErrors[0].message, 'User error');
 });
+
+test('logError stores environment metadata and groups similar errors', async () => {
+  await logError(new Error('Grouped error'), {
+    status: 503,
+    url: '/api/grouped',
+    method: 'POST',
+  });
+  await logError(new Error('Grouped error'), {
+    status: 503,
+    url: '/api/grouped',
+    method: 'POST',
+  });
+
+  const recent = getRecentErrors(2);
+  assert.strictEqual(recent[0].environment.nodeVersion, process.version);
+  assert.strictEqual(recent[0].environment.platform, process.platform);
+  assert.ok(recent[0].fingerprint);
+  assert.strictEqual(recent[0].fingerprint, recent[1].fingerprint);
+
+  const stats = getErrorStats();
+  assert.ok(Array.isArray(stats.groupedErrors));
+  assert.strictEqual(stats.groupedErrors[0].message, 'Grouped error');
+  assert.strictEqual(stats.groupedErrors[0].count, 2);
+});


### PR DESCRIPTION
# Summary
Adds error-tracking environment metadata and stable fingerprints so similar errors are grouped in monitoring summaries.

## Related Issue
Fixes #1633

## Type of Change
- [x] Feature
- [x] Tests

## Changes Implemented
- Stores environment metadata with each tracked error.
- Groups similar errors with stable fingerprints.
- Surfaces grouped error summaries alongside endpoint and status statistics.

## Technical Details
### Backend
Extended error-tracking records and aggregation output.

## Testing
### Unit Tests
- git diff --check
- node --test test/errorTracking.test.js

## Security Review
No new secrets or authentication paths are introduced.

## Accessibility Review
No user-facing interaction changes.

## Performance Impact
Adds bounded grouping metadata to existing monitoring records.

## Breaking Changes
None.

## Checklist
- [x] Linked the related issue.
- [x] Added focused tests.
- [x] Kept the change scoped to the issue.
