### PR TITLE
feat: make open badges generator compliant

### DIFF
--- a/server/services/certificates/openBadgesGenerator.js
+++ b/server/services/certificates/openBadgesGenerator.js
@@ -1,19 +1,96 @@
-// Placeholder OpenBadges generator for #1787.
-// TODO: make it OpenBadges standard-compliant (BadgeClass + Assertion).
+import crypto from 'crypto';
 
-export function buildBadgeClass({ name = 'Workshop Badge', imageUrl = '' } = {}) {
+const OPEN_BADGES_CONTEXT = 'https://w3id.org/openbadges/v2';
+
+function coerceId(id, prefix) {
+  if (id) return id;
+  return `urn:uuid:${prefix}-${crypto.randomUUID()}`;
+}
+
+function normalizeIssuer(issuer = {}) {
+  if (typeof issuer === 'string') {
+    return { id: issuer, type: 'Profile' };
+  }
+
   return {
-    id: '',
-    type: 'Assertion',
-    name,
-    image: imageUrl,
+    id: issuer.id || `${process.env.PUBLIC_APP_URL || 'https://nexasphere.local'}/issuer`,
+    type: issuer.type || 'Profile',
+    name: issuer.name || 'NexaSphere',
+    url: issuer.url || process.env.PUBLIC_APP_URL || 'https://nexasphere.local',
+    email: issuer.email,
   };
 }
 
-export function buildBadgeAssertion({ badgeId, recipient = {}, verificationUrl = '' } = {}) {
+function normalizeRecipient(recipient = {}) {
+  const identity = recipient.identity || recipient.email || recipient.id || 'unknown';
+  const type = recipient.type || (recipient.email ? 'email' : 'email');
+
   return {
-    badge: badgeId,
-    recipient,
-    verification: verificationUrl,
+    identity,
+    type,
+    hashed: recipient.hashed ?? false,
+    salt: recipient.salt,
+    name: recipient.name,
   };
+}
+
+function normalizeCriteria(criteria = {}) {
+  if (!criteria.id && !criteria.narrative) return undefined;
+  return {
+    id: criteria.id || undefined,
+    narrative: criteria.narrative || undefined,
+  };
+}
+
+export function buildBadgeClass({
+  id,
+  name = 'Workshop Badge',
+  description = 'OpenBadges-compliant badge class',
+  imageUrl = '',
+  issuer,
+  criteria,
+} = {}) {
+  const badgeClass = {
+    '@context': OPEN_BADGES_CONTEXT,
+    id: coerceId(id, 'badge-class'),
+    type: 'BadgeClass',
+    name,
+    description,
+    issuer: normalizeIssuer(issuer),
+  };
+
+  if (imageUrl) badgeClass.image = imageUrl;
+
+  const normalizedCriteria = normalizeCriteria(criteria);
+  if (normalizedCriteria) badgeClass.criteria = normalizedCriteria;
+
+  return badgeClass;
+}
+
+export function buildBadgeAssertion({
+  id,
+  badgeId,
+  recipient = {},
+  verificationUrl = '',
+  issuedOn = new Date().toISOString(),
+  evidence,
+} = {}) {
+  const assertion = {
+    '@context': OPEN_BADGES_CONTEXT,
+    id: coerceId(id, 'assertion'),
+    type: 'Assertion',
+    badge: badgeId || coerceId(undefined, 'badge-ref'),
+    recipient: normalizeRecipient(recipient),
+    verification: {
+      type: 'HostedBadge',
+      url: verificationUrl || badgeId || '',
+    },
+    issuedOn,
+  };
+
+  if (Array.isArray(evidence) && evidence.length > 0) {
+    assertion.evidence = evidence;
+  }
+
+  return assertion;
 }

--- a/server/test/openBadgesGenerator.test.js
+++ b/server/test/openBadgesGenerator.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { buildBadgeAssertion, buildBadgeClass } from '../services/certificates/openBadgesGenerator.js';
+
+test('buildBadgeClass returns an OpenBadges-compliant BadgeClass', () => {
+  const badgeClass = buildBadgeClass({
+    id: 'https://nexasphere.test/badges/js-basics',
+    name: 'JS Basics',
+    description: 'Awarded for completing the JavaScript basics track',
+    imageUrl: 'https://nexasphere.test/assets/badges/js-basics.png',
+    issuer: {
+      id: 'https://nexasphere.test/issuer',
+      name: 'NexaSphere',
+    },
+    criteria: {
+      id: 'https://nexasphere.test/badges/js-basics/criteria',
+      narrative: 'Complete the fundamentals assessment.',
+    },
+  });
+
+  assert.equal(badgeClass['@context'], 'https://w3id.org/openbadges/v2');
+  assert.equal(badgeClass.type, 'BadgeClass');
+  assert.equal(badgeClass.id, 'https://nexasphere.test/badges/js-basics');
+  assert.equal(badgeClass.name, 'JS Basics');
+  assert.equal(badgeClass.description, 'Awarded for completing the JavaScript basics track');
+  assert.equal(badgeClass.image, 'https://nexasphere.test/assets/badges/js-basics.png');
+  assert.equal(badgeClass.issuer.id, 'https://nexasphere.test/issuer');
+  assert.equal(badgeClass.issuer.type, 'Profile');
+  assert.equal(badgeClass.criteria.id, 'https://nexasphere.test/badges/js-basics/criteria');
+});
+
+test('buildBadgeAssertion returns an OpenBadges-compliant Assertion', () => {
+  const assertion = buildBadgeAssertion({
+    id: 'https://nexasphere.test/assertions/abc123',
+    badgeId: 'https://nexasphere.test/badges/js-basics',
+    recipient: {
+      email: 'learner@example.com',
+      name: 'Learner',
+    },
+    verificationUrl: 'https://nexasphere.test/certificates/abc123/verify',
+    issuedOn: '2026-07-13T00:00:00.000Z',
+    evidence: [{ id: 'https://nexasphere.test/evidence/1' }],
+  });
+
+  assert.equal(assertion['@context'], 'https://w3id.org/openbadges/v2');
+  assert.equal(assertion.type, 'Assertion');
+  assert.equal(assertion.id, 'https://nexasphere.test/assertions/abc123');
+  assert.equal(assertion.badge, 'https://nexasphere.test/badges/js-basics');
+  assert.equal(assertion.recipient.identity, 'learner@example.com');
+  assert.equal(assertion.recipient.type, 'email');
+  assert.equal(assertion.recipient.hashed, false);
+  assert.equal(assertion.verification.type, 'HostedBadge');
+  assert.equal(assertion.verification.url, 'https://nexasphere.test/certificates/abc123/verify');
+  assert.equal(assertion.issuedOn, '2026-07-13T00:00:00.000Z');
+  assert.equal(assertion.evidence.length, 1);
+});


### PR DESCRIPTION
# Summary
Make the certificate badge generator emit OpenBadges-compatible BadgeClass and Assertion data.

## Related Issue

Fixes #2895

## Type of Change

- [x] Feature
- [x] Testing

## Changes Implemented

- Replace the placeholder generator with OpenBadges v2-style BadgeClass and Assertion builders.
- Include context, issuer, recipient, verification, and issuedOn fields.
- Add regression coverage for both exported builders.

## Technical Details

### Backend

The certificate service now returns interoperable badge structures while preserving the existing generator entry points.

## Testing

### Unit Tests

- [x] node --test test/openBadgesGenerator.test.js

### Manual Testing

- [x] git diff --check

## Security Review

Recipient and issuer values remain represented through the existing generator inputs.

## Accessibility Review

Not applicable to this backend-only change.

## Performance Impact

No material change; the generator remains synchronous.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [x] Performance validated
- [ ] CI/CD passing
- [x] Ready for review
