### PR TITLE
fix: dedupe SSL expiry alerts

### DIFF
--- a/.github/workflows/certificate-expiry-monitor.yml
+++ b/.github/workflows/certificate-expiry-monitor.yml
@@ -24,6 +24,15 @@ jobs:
         with:
           script: |
             const daysLeft = parseInt(process.env.days_left);
+            const existing = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open in:title "SSL Certificate Expiring in"`,
+            });
+
+            if (existing.data.total_count > 0) {
+              core.info(`SSL expiry issue already exists: #${existing.data.items[0].number}`);
+              return;
+            }
+
             await github.rest.issues.create({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
# Summary
Prevents the certificate expiry workflow from opening duplicate issues when an SSL warning is already open.

## Related Issue
Fixes #3294

## Type of Change
- [x] Bug fix

## Changes Implemented
- Checks for an existing open certificate-expiry issue before creating another.
- Keeps the existing expiry notification behavior for new warnings.

## Technical Details
### Infrastructure
Updated the certificate expiry monitor workflow.

## Testing
### Manual Testing
- git diff --check
- npx prettier --check .github/workflows/certificate-expiry-monitor.yml

## Security Review
No credentials or certificate contents are exposed by the change.

## Accessibility Review
No user-facing UI changes.

## Performance Impact
Avoids redundant issue creation and notification work.

## Breaking Changes
None.

## Checklist
- [x] Linked the related issue.
- [x] Ran formatting validation.
- [x] Kept the change scoped to the workflow.
