### PR TITLE
fix: surface offline sync outcomes

### DIFF
--- a/website/src/components/__tests__/OfflineBanner.test.jsx
+++ b/website/src/components/__tests__/OfflineBanner.test.jsx
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import OfflineBanner from '../pwa/OfflineBanner.jsx';
+
+const mockHookState = vi.hoisted(() => ({
+  isOnline: true,
+  isSyncing: false,
+  queuedCount: 2,
+  syncNow: vi.fn(),
+  syncStats: { synced: 0, failed: 0 },
+}));
+
+vi.mock('../../hooks/useOfflineSync.js', () => ({
+  useOfflineSync: () => mockHookState,
+}));
+
+describe('OfflineBanner', () => {
+  beforeEach(() => {
+    mockHookState.syncNow.mockClear();
+    Object.assign(mockHookState, {
+      isOnline: true,
+      isSyncing: false,
+      queuedCount: 2,
+      syncStats: { synced: 0, failed: 0 },
+    });
+  });
+
+  it('shows a retry toast when sync fails and exposes manual retry', () => {
+    render(<OfflineBanner />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('nexasphere:sync-failed', {
+          detail: {
+            url: '/api/events/123/register',
+            error: 'Request timed out',
+          },
+        })
+      );
+    });
+
+    expect(screen.getByText('Sync failed')).toBeInTheDocument();
+    expect(
+      screen.getByText('/api/events/123/register could not be synced. Request timed out')
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Retry Now/i }));
+    expect(mockHookState.syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a success toast when sync completes cleanly', () => {
+    render(<OfflineBanner />);
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent('nexasphere:sync-complete', {
+          detail: { synced: 2, failed: 0 },
+        })
+      );
+    });
+
+    expect(screen.getByText('Sync complete')).toBeInTheDocument();
+    expect(screen.getByText('2 queued actions synced successfully.')).toBeInTheDocument();
+  });
+});

--- a/website/src/components/pwa/OfflineBanner.jsx
+++ b/website/src/components/pwa/OfflineBanner.jsx
@@ -6,9 +6,11 @@
  *  - Offline state: "📡 You're offline — X actions queued"
  *  - Syncing state: spinner + "Syncing…"
  *  - Back-online flash: "✅ Back online — all synced!" (auto-hides after 3s)
+ *  - Sync toasts for success/failure with retry support
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { AlertTriangle, CheckCircle2, X } from 'lucide-react';
 import { useOfflineSync } from '../../hooks/useOfflineSync.js';
 import '../../styles/pwa.css';
 
@@ -19,8 +21,30 @@ export default function OfflineBanner() {
   const [visible, setVisible] = useState(false);
   // "online" means we just came back online (green variant)
   const [showOnline, setShowOnline] = useState(false);
+  const [toast, setToast] = useState(null);
   const onlineTimerRef = useRef(null);
+  const toastTimerRef = useRef(null);
   const prevOnlineRef = useRef(navigator.onLine);
+
+  const clearToastTimer = useCallback(() => {
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+  }, []);
+
+  const showToast = useCallback(
+    (nextToast) => {
+      clearToastTimer();
+      setToast(nextToast);
+
+      const timeout = nextToast.variant === 'error' ? 8000 : 4500;
+      toastTimerRef.current = setTimeout(() => {
+        setToast(null);
+      }, timeout);
+    },
+    [clearToastTimer]
+  );
 
   useEffect(() => {
     if (!isOnline) {
@@ -43,6 +67,54 @@ export default function OfflineBanner() {
     prevOnlineRef.current = isOnline;
   }, [isOnline]);
 
+  useEffect(() => {
+    const onSyncComplete = (event) => {
+      const { synced = 0, failed = 0 } = event.detail || {};
+      if (synced === 0 && failed === 0) return;
+
+      showToast(
+        failed > 0
+          ? {
+              variant: 'error',
+              title: 'Sync finished with errors',
+              message: `${synced} queued action${synced === 1 ? '' : 's'} synced, but ${failed} failed. Review the banner details and retry when ready.`,
+            }
+          : {
+              variant: 'success',
+              title: 'Sync complete',
+              message: `${synced} queued action${synced === 1 ? '' : 's'} synced successfully.`,
+            }
+      );
+    };
+
+    const onSyncFailed = (event) => {
+      const detail = event.detail || {};
+      const failedPath = (() => {
+        try {
+          return new URL(detail.url, window.location.origin).pathname;
+        } catch {
+          return detail.url || 'the queued request';
+        }
+      })();
+
+      showToast({
+        variant: 'error',
+        title: 'Sync failed',
+        message: detail.error
+          ? `${failedPath} could not be synced. ${detail.error}`
+          : `${failedPath} could not be synced. Try again once the connection is stable.`,
+      });
+    };
+
+    window.addEventListener('nexasphere:sync-complete', onSyncComplete);
+    window.addEventListener('nexasphere:sync-failed', onSyncFailed);
+
+    return () => {
+      window.removeEventListener('nexasphere:sync-complete', onSyncComplete);
+      window.removeEventListener('nexasphere:sync-failed', onSyncFailed);
+    };
+  }, [showToast]);
+
   // Also hide after sync completes if we're online
   useEffect(() => {
     if (isOnline && !isSyncing && queuedCount === 0 && showOnline) {
@@ -56,56 +128,110 @@ export default function OfflineBanner() {
     };
   }, [isOnline, isSyncing, queuedCount, showOnline]);
 
+  useEffect(
+    () => () => {
+      if (onlineTimerRef.current) clearTimeout(onlineTimerRef.current);
+      clearToastTimer();
+    },
+    [clearToastTimer]
+  );
+
   // Render nothing initially (banner is hidden via CSS transform)
   return (
-    <div
-      className={`pwa-offline-banner${visible ? ' pwa-banner--visible' : ''}${showOnline ? ' pwa-banner--online' : ''}`}
-      role="status"
-      aria-live="polite"
-      aria-label={
-        showOnline ? 'Connection restored' : isOnline ? 'Network status' : 'You are offline'
-      }
-    >
-      <div className="pwa-banner__left">
-        <div className="pwa-banner__icon" aria-hidden="true">
-          {showOnline ? '✅' : isSyncing ? '🔄' : '📡'}
+    <>
+      <div
+        className={`pwa-offline-banner${visible ? ' pwa-banner--visible' : ''}${showOnline ? ' pwa-banner--online' : ''}`}
+        role="status"
+        aria-live="polite"
+        aria-label={
+          showOnline ? 'Connection restored' : isOnline ? 'Network status' : 'You are offline'
+        }
+      >
+        <div className="pwa-banner__left">
+          <div className="pwa-banner__icon" aria-hidden="true">
+            {showOnline ? '✅' : isSyncing ? '🔄' : '📡'}
+          </div>
+          <div className="pwa-banner__text">
+            <span className="pwa-banner__title">
+              {showOnline ? 'Back Online' : isSyncing ? 'Syncing…' : "You're Offline"}
+            </span>
+            <span className="pwa-banner__subtitle">
+              {showOnline
+                ? syncStats.failed > 0
+                  ? `${syncStats.synced} synced, ${syncStats.failed} failed — check your actions`
+                  : 'All changes have been synced successfully'
+                : isSyncing
+                  ? `Syncing ${queuedCount} queued action${queuedCount !== 1 ? 's' : ''}…`
+                  : 'Changes will sync when you reconnect'}
+            </span>
+          </div>
         </div>
-        <div className="pwa-banner__text">
-          <span className="pwa-banner__title">
-            {showOnline ? 'Back Online' : isSyncing ? 'Syncing…' : "You're Offline"}
-          </span>
-          <span className="pwa-banner__subtitle">
-            {showOnline
-              ? syncStats.failed > 0
-                ? `${syncStats.synced} synced, ${syncStats.failed} failed — check your actions`
-                : 'All changes have been synced successfully'
-              : isSyncing
-                ? `Syncing ${queuedCount} queued action${queuedCount !== 1 ? 's' : ''}…`
-                : 'Changes will sync when you reconnect'}
-          </span>
+
+        <div className="pwa-banner__right">
+          {isSyncing && <span className="pwa-spinner" aria-hidden="true" />}
+
+          {!isOnline && queuedCount > 0 && (
+            <span className="pwa-banner__badge" aria-label={`${queuedCount} actions queued`}>
+              <span className="pwa-dot" aria-hidden="true" />
+              {queuedCount} queued
+            </span>
+          )}
+
+          {isOnline && !isSyncing && queuedCount > 0 && (
+            <button
+              className="pwa-banner__sync-btn"
+              onClick={syncNow}
+              aria-label="Sync queued changes now"
+            >
+              Sync Now
+            </button>
+          )}
         </div>
       </div>
 
-      <div className="pwa-banner__right">
-        {isSyncing && <span className="pwa-spinner" aria-hidden="true" />}
-
-        {!isOnline && queuedCount > 0 && (
-          <span className="pwa-banner__badge" aria-label={`${queuedCount} actions queued`}>
-            <span className="pwa-dot" aria-hidden="true" />
-            {queuedCount} queued
-          </span>
-        )}
-
-        {isOnline && !isSyncing && queuedCount > 0 && (
-          <button
-            className="pwa-banner__sync-btn"
-            onClick={syncNow}
-            aria-label="Sync queued changes now"
+      {toast && (
+        <div className="pwa-toast-container bottom-right" aria-live="polite">
+          <div
+            className="pwa-toast-card"
+            role={toast.variant === 'error' ? 'alert' : 'status'}
+            aria-label={toast.title}
           >
-            Sync Now
-          </button>
-        )}
-      </div>
-    </div>
+            <div className="pwa-toast-header">
+              <div
+                className={`pwa-toast-icon ${toast.variant === 'error' ? 'warning' : 'success'}`}
+              >
+                {toast.variant === 'error' ? (
+                  <AlertTriangle size={20} />
+                ) : (
+                  <CheckCircle2 size={20} />
+                )}
+              </div>
+              <div className="pwa-toast-body">
+                <h4 className="pwa-toast-title">{toast.title}</h4>
+                <p className="pwa-toast-description">{toast.message}</p>
+              </div>
+              <button
+                type="button"
+                className="pwa-btn-close"
+                onClick={() => {
+                  clearToastTimer();
+                  setToast(null);
+                }}
+                aria-label="Dismiss sync notification"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            {toast.variant === 'error' && queuedCount > 0 && isOnline && (
+              <div className="pwa-toast-actions">
+                <button className="pwa-banner__sync-btn" onClick={syncNow}>
+                  Retry Now
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
# Summary
Surfaces offline sync success and failure feedback in the PWA banner and provides a retry action for failed syncs.

## Related Issue
Fixes #1502

## Type of Change
- [x] Bug fix
- [x] UI/UX improvement
- [x] Tests

## Changes Implemented
- Adds success and failure toasts to offline sync handling.
- Adds a retry action when synchronization fails.
- Covers the behavior with a focused component test.

## Technical Details
### Frontend
Updated the PWA offline banner and its focused component test.

## Testing
### Unit Tests
- git diff --check
- npx prettier --check src/components/pwa/OfflineBanner.jsx src/components/__tests__/OfflineBanner.test.jsx
- npx vitest run src/components/__tests__/OfflineBanner.test.jsx was blocked because local vitest/vite dependencies are missing in the fresh worktree.

## Security Review
No authentication or sensitive data handling changed.

## Accessibility Review
Keeps the existing banner controls and adds a labeled retry action.

## Performance Impact
Adds feedback around the existing sync operation without changing its scheduling.

## Breaking Changes
None.

## Checklist
- [x] Linked the related issue.
- [x] Ran formatting validation.
- [ ] Full focused test requires dependencies unavailable in the fresh worktree.
