### PR TITLE
fix: rate limit event registrations by user and ip

### DIFF
--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -59,6 +59,10 @@ const createLimiterHandler = (logMessage, clientErrorMessage) => {
   };
 };
 
+const setRetryAfterHeader = (res, windowMs) => {
+  res.setHeader('Retry-After', String(Math.ceil(windowMs / 1000)));
+};
+
 export const apiRateLimiter = rateLimit({
   windowMs: API_WINDOW_MS,
   max: API_MAX_REQUESTS,
@@ -203,8 +207,58 @@ export const eventRegistrationLimiter = rateLimit({
       path: req.originalUrl || req.path,
       method: req.method,
     });
+    setRetryAfterHeader(res, options.windowMs);
     res.status(options.statusCode).json({
       error: 'Too many registration attempts. Please try again later.',
+    });
+  },
+});
+
+function getEventRegistrationIdentity(req) {
+  const email = String(req.body?.email || '').trim().toLowerCase();
+  if (req.user?.id) return `user:${req.user.id}`;
+  if (req.studentUser?.id) return `student:${req.studentUser.id}`;
+  if (req.studentUser?.email) return `student:${String(req.studentUser.email).toLowerCase()}`;
+  if (email) return `email:${email}`;
+  return `ip:${req.ip}`;
+}
+
+export const eventRegistrationUserLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: true,
+  store: createRateLimitStore('rate-limit:event-reg-user:'),
+  keyGenerator: getEventRegistrationIdentity,
+  handler: (req, res, _next, options) => {
+    logger.warn('Event registration user rate limit exceeded', {
+      identity: getEventRegistrationIdentity(req),
+      ip: req.ip,
+      path: req.originalUrl || req.path,
+      method: req.method,
+    });
+    setRetryAfterHeader(res, options.windowMs);
+    res.status(options.statusCode).json({
+      error: 'Too many registration attempts from this user. Please try again later.',
+    });
+  },
+});
+
+export const eventRegistrationIpLimiter = rateLimit({
+  windowMs: 60 * 60 * 1000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: true,
+  store: createRateLimitStore('rate-limit:event-reg-ip:'),
+  handler: (req, res, _next, options) => {
+    logger.warn('Event registration IP rate limit exceeded', {
+      ip: req.ip,
+      path: req.originalUrl || req.path,
+      method: req.method,
+    });
+    setRetryAfterHeader(res, options.windowMs);
+    res.status(options.statusCode).json({
+      error: 'Too many registration attempts from this IP. Please try again later.',
     });
   },
 });
@@ -253,6 +307,9 @@ export function validateLimiters() {
     authRateLimiter,
     notificationRateLimiter,
     activityAuthRateLimiter,
+    eventRegistrationLimiter,
+    eventRegistrationUserLimiter,
+    eventRegistrationIpLimiter,
     syncRateLimiter,
     portfolioRateLimiter,
     searchRateLimiter,

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -15,7 +15,7 @@ import * as bannersController from '../controllers/bannersController.js';
 import { adminAuditMiddleware, attachOldState } from '../middleware/adminAuditMiddleware.js';
 import { eventsRepository } from '../repositories/eventsRepository.js';
 import { authRateLimiter, protectedActionRateLimiter } from '../middleware/authRateLimiter.js';
-import { eventRegistrationLimiter } from '../middleware/rateLimiter.js';
+import { eventRegistrationUserLimiter, eventRegistrationIpLimiter } from '../middleware/rateLimiter.js';
 import { portfolioRepository } from '../repositories/portfolioRepository.js';
 import { achievementsRepository } from '../repositories/achievementsRepository.js';
 import { portfolioService } from '../services/portfolioService.js';
@@ -69,7 +69,8 @@ router.get('/api/content/events', eventsController.listEvents);
 router.get('/api/content/banners', bannersController.listActiveBanners);
 router.post(
   '/api/content/events/:eventId/register',
-  eventRegistrationLimiter,
+  eventRegistrationUserLimiter,
+  eventRegistrationIpLimiter,
   eventRegistrationController.registerForEvent
 );
 router.get('/api/content/events/:eventId/calendar', eventRegistrationController.getEventCalendar);

--- a/server/test/rateLimiter.test.js
+++ b/server/test/rateLimiter.test.js
@@ -4,6 +4,8 @@ import test, { after } from 'node:test';
 import {
   apiRateLimiter,
   formRateLimiter,
+  eventRegistrationUserLimiter,
+  eventRegistrationIpLimiter,
   notificationRateLimiter,
   portfolioRateLimiter,
   validateLimiters,
@@ -184,6 +186,64 @@ test('portfolioRateLimiter calls next() for a first-time request within the limi
     assert.equal(res._status, null, 'Status must not be set for an allowed request');
     done();
   });
+});
+
+test('eventRegistrationUserLimiter enforces 5 registrations per minute per user', async () => {
+  const makeRes = () => makeMockRes();
+  const req = makeMockReq({
+    method: 'POST',
+    path: '/api/content/events/event-1/register',
+    originalUrl: '/api/content/events/event-1/register',
+    body: { email: 'student@example.com' },
+  });
+
+  let allowed = 0;
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => {
+      eventRegistrationUserLimiter(req, makeRes(), () => {
+        allowed++;
+        resolve();
+      });
+    });
+  }
+  assert.equal(allowed, 5);
+
+  const blockedRes = makeRes();
+  await new Promise((resolve) => {
+    eventRegistrationUserLimiter(req, blockedRes, () => resolve());
+    setImmediate(resolve);
+  });
+
+  assert.equal(blockedRes._status, 429);
+  assert.equal(blockedRes._body?.error, 'Too many registration attempts from this user. Please try again later.');
+  assert.ok(blockedRes._headers['Retry-After']);
+});
+
+test('eventRegistrationIpLimiter enforces 100 registrations per hour per IP', async () => {
+  const makeRes = () => makeMockRes();
+  const req = makeMockReq({
+    method: 'POST',
+    path: '/api/content/events/event-2/register',
+    originalUrl: '/api/content/events/event-2/register',
+    body: { email: 'bot@example.com' },
+    ip: '198.51.100.20',
+  });
+
+  for (let i = 0; i < 100; i++) {
+    await new Promise((resolve) => {
+      eventRegistrationIpLimiter(req, makeRes(), () => resolve());
+    });
+  }
+
+  const blockedRes = makeRes();
+  await new Promise((resolve) => {
+    eventRegistrationIpLimiter(req, blockedRes, () => resolve());
+    setImmediate(resolve);
+  });
+
+  assert.equal(blockedRes._status, 429);
+  assert.equal(blockedRes._body?.error, 'Too many registration attempts from this IP. Please try again later.');
+  assert.ok(blockedRes._headers['Retry-After']);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1524\n\nSummary:\n- Add a per-user registration limiter capped at 5 requests per minute\n- Add a per-IP registration limiter capped at 100 requests per hour\n- Apply both limiters to the public event registration route\n- Return 429 responses with Retry-After headers when the caps are exceeded\n\nValidation:\n- git diff --check\n- node --check server/middleware/rateLimiter.js\n- node --check server/routes/api.js\n- node --check server/test/rateLimiter.test.js