### PR TITLE
feat: add public leaderboard page

### DIFF
--- a/website/src/pages/leaderboard/LeaderboardPage.jsx
+++ b/website/src/pages/leaderboard/LeaderboardPage.jsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react';
+import { Trophy } from 'lucide-react';
+import { useStudentAuth } from '../../context/StudentAuthContext';
+import Leaderboard from '../../components/dashboard/Leaderboard';
+import { gamificationService } from '../../services/gamification/gamificationService';
+
+export default function LeaderboardPage() {
+  const { user } = useStudentAuth();
+  const [leaderboard, setLeaderboard] = useState([]);
+  const [timeframe, setTimeframe] = useState('month');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    const loadLeaderboard = async () => {
+      setLoading(true);
+      try {
+        const data = await gamificationService.getLeaderboard(timeframe);
+        if (mounted) {
+          setLeaderboard(data || []);
+        }
+      } finally {
+        if (mounted) setLoading(false);
+      }
+    };
+
+    loadLeaderboard();
+
+    return () => {
+      mounted = false;
+    };
+  }, [timeframe]);
+
+  return (
+    <div style={{ maxWidth: '1200px', margin: '0 auto', padding: '40px 20px' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: '14px', marginBottom: '28px' }}>
+        <div
+          style={{
+            width: '44px',
+            height: '44px',
+            borderRadius: '12px',
+            display: 'grid',
+            placeItems: 'center',
+            background: 'rgba(204,17,17,0.12)',
+            border: '1px solid rgba(204,17,17,0.25)',
+            color: 'var(--c1)',
+          }}
+        >
+          <Trophy size={22} />
+        </div>
+        <div>
+          <h1 style={{ margin: 0, color: 'var(--t1)', fontSize: '2rem' }}>Leaderboard</h1>
+          <p style={{ margin: '4px 0 0', color: 'var(--t2)' }}>
+            See who is leading the community this{' '}
+            {timeframe === 'week' ? 'week' : timeframe === 'month' ? 'month' : 'season'}.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div style={{ color: 'var(--t2)', padding: '32px 0' }}>Loading leaderboard...</div>
+      ) : (
+        <Leaderboard
+          users={leaderboard}
+          currentUserId={user?.id || user?.email || null}
+          timeframe={timeframe}
+          setTimeframe={setTimeframe}
+        />
+      )}
+    </div>
+  );
+}

--- a/website/src/router/routes.jsx
+++ b/website/src/router/routes.jsx
@@ -22,6 +22,7 @@ const CertificateVerifyPage = lazy(() => import('../pages/certificates/Certifica
 const PortfolioBuilder = lazy(() => import('../components/portfolio/PortfolioBuilder'));
 const PublicPortfolio = lazy(() => import('../pages/portfolio/PublicPortfolio'));
 const DashboardPage = lazy(() => import('../pages/dashboard/DashboardPage'));
+const LeaderboardPage = lazy(() => import('../pages/leaderboard/LeaderboardPage'));
 const AnalyticsPage = lazy(() => import('../pages/analytics/AnalyticsPage'));
 const WorkspacePage = lazy(() => import('../pages/workspace/WorkspacePage'));
 const GamificationDashboard = lazy(
@@ -595,6 +596,16 @@ export function AppRoutes({
         }
       />
 
+      {/* ── Public Leaderboard ── */}
+      <Route
+        path="/leaderboard"
+        element={
+          <PageIn k="leaderboard">
+            <LeaderboardPage />
+          </PageIn>
+        }
+      />
+
       {/* ── Skill Exchange ── */}
       <Route
         path="/skill-exchange"
@@ -618,8 +629,26 @@ export function AppRoutes({
       />
 
       {/* ── Profile & Settings ── */}
-      <Route path="/profile" element={<ProtectedRoute><PageIn k="profile"><ProfilePage /></PageIn></ProtectedRoute>} />
-      <Route path="/settings/account" element={<ProtectedRoute><PageIn k="settings"><AccountSettingsPage /></PageIn></ProtectedRoute>} />
+      <Route
+        path="/profile"
+        element={
+          <ProtectedRoute>
+            <PageIn k="profile">
+              <ProfilePage />
+            </PageIn>
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/settings/account"
+        element={
+          <ProtectedRoute>
+            <PageIn k="settings">
+              <AccountSettingsPage />
+            </PageIn>
+          </ProtectedRoute>
+        }
+      />
 
       {/* ── 404 ── */}
       <Route path="*" element={<NotFoundPage onGoHome={onBackHome} />} />

--- a/website/src/services/gamification/gamificationService.js
+++ b/website/src/services/gamification/gamificationService.js
@@ -633,7 +633,7 @@ class GamificationService {
     return Math.min(100, Math.max(0, progress));
   }
 
-  async getLeaderboard() {
+  async getLeaderboard(filter = 'all') {
     const MOCK_LEADERBOARD = [
       { rank: 1, name: 'Alex Johnson', xp: 2850, level: 8, avatar: '👨‍💻', streak: 12 },
       { rank: 2, name: 'Sarah Chen', xp: 2420, level: 7, avatar: '👩‍💻', streak: 7 },
@@ -646,18 +646,23 @@ class GamificationService {
     if (!base) return MOCK_LEADERBOARD;
 
     try {
-      const res = await fetch(`${base}/api/dashboard/leaderboard`);
+      const res = await fetch(
+        `${base}/api/dashboard/leaderboard?filter=${encodeURIComponent(filter)}`
+      );
       if (!res.ok) return MOCK_LEADERBOARD;
       const data = await res.json();
       if (!Array.isArray(data) || data.length === 0) return MOCK_LEADERBOARD;
       // Map backend UserProfileEntity shape to leaderboard display shape
       return data.map((user, i) => ({
+        id: user.id || user.user_id || user.email || `leaderboard-${i + 1}`,
         rank: i + 1,
         name: user.username || user.name || 'Anonymous',
+        username: user.username || user.name || 'Anonymous',
         xp: user.xp ?? 0,
         level: user.level ?? 1,
-        avatar: '👤',
+        avatar: user.avatar || '👤',
         streak: user.current_streak ?? user.streak ?? 0,
+        badges: user.badges || [],
       }));
     } catch {
       return MOCK_LEADERBOARD;

--- a/website/src/shared/Navbar.jsx
+++ b/website/src/shared/Navbar.jsx
@@ -6,6 +6,7 @@ import { ThemeToggle } from '../components/common/ThemeToggle';
 import { useStudentAuth } from '../context/StudentAuthContext';
 import LanguageSelector from '../components/common/LanguageSelector';
 import { useTranslation } from 'react-i18next';
+import { Trophy } from 'lucide-react';
 import { useWalkthroughStep } from '../hooks/useWalkthroughStep';
 import { WalkthroughWrapper } from '../components/walkthrough/WalkthroughWrapper';
 
@@ -154,6 +155,27 @@ export default function Navbar({
               📋
             </button>
             <button
+              onClick={() => navigate('/leaderboard')}
+              aria-label="Leaderboard"
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--t1)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '6px',
+                borderRadius: '50%',
+                transition: 'background 0.2s',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.08)')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
+              title="Open leaderboard"
+            >
+              <Trophy size={16} />
+            </button>
+            <button
               onClick={onSearchToggle}
               aria-label="Search"
               style={{
@@ -284,6 +306,27 @@ export default function Navbar({
               title="View all notifications"
             >
               📋
+            </button>
+            <button
+              onClick={() => navigate('/leaderboard')}
+              aria-label="Leaderboard"
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'var(--t1)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '6px',
+                borderRadius: '50%',
+                transition: 'background 0.2s',
+              }}
+              onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,0.08)')}
+              onMouseLeave={(e) => (e.currentTarget.style.background = 'none')}
+              title="Open leaderboard"
+            >
+              <Trophy size={16} />
             </button>
             <button
               onClick={onSearchToggle}


### PR DESCRIPTION
Refs #3532\n\nSummary:\n- Add a public /leaderboard page backed by the existing gamification leaderboard API\n- Forward the selected timeframe filter to the backend so week/month/all views are real\n- Reuse the shared leaderboard component and surface the page from the top navigation on desktop and mobile\n\nValidation:\n- git diff --check\n- node --check server-side JS touched in the helper changes\n- npx prettier --check on the touched website files