### PR TITLE
Log EventDetailPage storage failures in dev

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -943,7 +943,11 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
           stored.push(localTicket);
           localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch {}
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn('Failed to persist event registration ticket locally:', err);
+          }
+        }
       }
     } catch (err) {
       if (err.message?.includes('waitlist')) {


### PR DESCRIPTION
Closes #3236

Summary:
- log local registration storage failures in development so the failure is visible

Validation:
- git diff --check HEAD^..HEAD
- npx prettier --check website/src/pages/events/EventDetailPage.jsx