### PR TITLE
Use stable resource keys in NodeModal

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -405,7 +405,7 @@ export const NodeModal: React.FC<NodeModalProps> = ({ theme }) => {
               >
                 {resources.map((res, index) => (
                   <div
-                    key={index}
+                    key={`${res.title}-${res.url}`}
                     className="resource-item-edit-row glassmorphic-panel flex justify-between items-center text-xs"
                     style={{ padding: '8px 14px', borderRadius: '8px' }}
                   >


### PR DESCRIPTION
Closes #3248

Summary:
- replace array index keys with resource identifiers in the roadmap modal

Validation:
- git diff --check HEAD^..HEAD
- npx prettier --check website/src/components/roadmaps/NodeModal.tsx