### PR TITLE
Use stable keys in forum post skeleton

### DIFF
--- a/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
+++ b/website/src/components/ui/skeleton/ForumPostSkeleton.jsx
@@ -7,7 +7,7 @@ export function ForumPostSkeleton({ count = 5 }) {
     <div role="status" aria-label="Loading forum posts..." aria-busy="true">
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`forum-post-skeleton-${i}`}
           style={{
             padding: '20px 24px',
             borderBottom: '1px solid var(--bdr, rgba(255,255,255,0.06))',


### PR DESCRIPTION
Closes #3249

Summary:
- switch forum post skeleton rows to stable keys

Validation:
- git diff --check HEAD^..HEAD
- npx prettier --check website/src/components/ui/skeleton/ForumPostSkeleton.jsx