### PR TITLE
Use stable keys in mentor card skeleton

### DIFF
--- a/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/MentorCardSkeleton.jsx
@@ -16,7 +16,7 @@ export function MentorCardSkeleton({ count = 6 }) {
     >
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`mentor-card-skeleton-${i}`}
           style={{
             padding: '24px',
             borderRadius: 'var(--r2, 14px)',


### PR DESCRIPTION
Closes #3250

Summary:
- use stable mentor identifiers for skeleton card keys

Validation:
- git diff --check HEAD^..HEAD
- npx prettier --check website/src/components/ui/skeleton/MentorCardSkeleton.jsx