### PR TITLE
fix: switch Promise.all to Promise.allSettled in ForumPage.jsx

### DIFF
--- a/website/src/pages/forum/ForumPage.jsx
+++ b/website/src/pages/forum/ForumPage.jsx
@@ -43,19 +43,31 @@ export default function ForumPage({ onBack }) {
       setLoading(false);
       return;
     }
-    Promise.all([
+    Promise.allSettled([
       apiClient(`${base}/api/forum/categories`),
       apiClient(
         `${base}/api/forum/threads?sort=${sort}${activeCategory ? `&category=${activeCategory}` : ''}`
       ),
     ])
-      .then(([catData, threadData]) => {
-        if (catData?.categories) setCategories(catData.categories);
-        if (threadData?.threads) setThreads(threadData.threads);
-      })
-      .catch(() => {
-        setCategories(fallbackCategories);
-        setThreads(fallbackThreads);
+      .then(([catResult, threadResult]) => {
+        // Handle each result independently so one endpoint failure
+        // doesn't discard successfully-fetched data from the other.
+        if (catResult.status === 'fulfilled') {
+          if (catResult.value?.categories) setCategories(catResult.value.categories);
+        } else {
+          if (import.meta.env.DEV) {
+            console.warn('[ForumPage] Categories fetch failed:', catResult.reason?.message);
+          }
+          setCategories(fallbackCategories);
+        }
+        if (threadResult.status === 'fulfilled') {
+          if (threadResult.value?.threads) setThreads(threadResult.value.threads);
+        } else {
+          if (import.meta.env.DEV) {
+            console.warn('[ForumPage] Threads fetch failed:', threadResult.reason?.message);
+          }
+          setThreads(fallbackThreads);
+        }
       })
       .finally(() => setLoading(false));
   }, [sort, activeCategory]);


### PR DESCRIPTION
## Description
`ForumPage.jsx` used `Promise.all` to fetch categories and threads simultaneously. If either endpoint failed, `Promise.all` rejected and both results were discarded — real category data was thrown away even when it loaded successfully if only the threads fetch failed, and vice versa.

Changes made:
- Replaced `Promise.all` with `Promise.allSettled` so each result is handled independently
- A failed categories fetch now falls back to `fallbackCategories` while a successful threads fetch is still applied, and vice versa
- Added `import.meta.env.DEV`-guarded `console.warn` per rejected result for development traceability
- Zero new TypeScript errors introduced

Fixes #3228

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings