### PR TITLE
fix: clear StatCard count interval on unmount in EventDetailPage.jsx

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -52,6 +52,7 @@ function StatCard({ label, value, color }) {
   const [count, setCount] = useState(0);
   const ref = useRef(null);
   const started = useRef(false);
+  const countIntervalRef = useRef(null);
   useEffect(() => {
     const obs = new IntersectionObserver(
       ([e]) => {
@@ -63,11 +64,12 @@ function StatCard({ label, value, color }) {
             return;
           }
           let cur = 0;
-          const t = setInterval(() => {
+          countIntervalRef.current = setInterval(() => {
             cur += Math.ceil(num / 40);
             if (cur >= num) {
               setCount(num);
-              clearInterval(t);
+              clearInterval(countIntervalRef.current);
+              countIntervalRef.current = null;
             } else setCount(cur);
           }, 25);
         }
@@ -75,7 +77,13 @@ function StatCard({ label, value, color }) {
       { threshold: 0.5 }
     );
     if (ref.current) obs.observe(ref.current);
-    return () => obs.disconnect();
+    return () => {
+      obs.disconnect();
+      if (countIntervalRef.current) {
+        clearInterval(countIntervalRef.current);
+        countIntervalRef.current = null;
+      }
+    };
   }, [value]);
   const rgb = hexToRgb(color);
   return (


### PR DESCRIPTION
## Description
`StatCard` in `EventDetailPage.jsx` used `setInterval` for its count-up animation with the ID stored only in a local `const t`. The interval was cleared inside the callback when the count reached its target, but the `useEffect` cleanup only called `obs.disconnect()` — if `StatCard` unmounted mid-animation (e.g. user navigates away), the interval continued to fire and called `setCount` on an unmounted component.

Changes made:
- Added `countIntervalRef` (via `useRef`) to store the interval ID
- `useEffect` cleanup now clears the interval alongside `obs.disconnect()` so the animation stops immediately on unmount
- Interval callback also clears `countIntervalRef.current` to `null` on normal completion, keeping the ref accurate
- Zero new TypeScript errors introduced

Fixes #3246

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings