### PR TITLE
fix: replace key={i} with descriptive prefixed key for CPU perCore items in SystemHealthPage.jsx

### DIFF
--- a/website/src/pages/monitoring/SystemHealthPage.jsx
+++ b/website/src/pages/monitoring/SystemHealthPage.jsx
@@ -352,7 +352,7 @@ export default function SystemHealthPage() {
               }}
             >
               {system.cpu.perCore.map((usage, i) => (
-                <div key={i} style={{ textAlign: 'center' }}>
+                <div key={`core-${i}`} style={{ textAlign: 'center' }}>
                   <div style={{ fontSize: '12px', color: '#9CA3AF', marginBottom: '4px' }}>
                     Core {i}
                   </div>


### PR DESCRIPTION
## Description
`SystemHealthPage.jsx` rendered CPU perCore chart items with `key={i}` (plain array index). While core index is stable identity here, using a plain `i` provides no semantic context and is inconsistent with descriptive key patterns used elsewhere in the codebase.

Changes made:
- Replaced `key={i}` with `` key={`core-${i}`} `` using a descriptive prefix for clarity and consistency
- Zero new TypeScript errors introduced

Fixes #3243

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings