### PR TITLE
fix: validate scheduledAt before formatting in SkillExchangePage.jsx

### DIFF
--- a/website/src/pages/skills/SkillExchangePage.jsx
+++ b/website/src/pages/skills/SkillExchangePage.jsx
@@ -1,4 +1,13 @@
 import { useState, useEffect, useCallback } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatScheduledDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
 import apiClient from '../../utils/apiClient';
 import { getApiBase, buildUrl } from '../../utils/runtimeConfig';
 
@@ -460,7 +469,7 @@ export default function SkillExchangePage({ onBack }) {
                     </div>
                     <div style={{ fontSize: '0.85rem', color: 'var(--t2)' }}>
                       Status: <strong>{s.status}</strong> · Scheduled:{' '}
-                      {new Date(s.scheduledAt).toLocaleDateString()}
+                      {formatScheduledDate(s.scheduledAt)}
                     </div>
                     {s.notes && (
                       <div style={{ fontSize: '0.85rem', color: 'var(--t3)' }}>


### PR DESCRIPTION
## Description
`SkillExchangePage.jsx` line 463 passed `s.scheduledAt` directly into `new Date(...).toLocaleDateString()` with no validation. If `scheduledAt` was `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the session list.

Changes made:
- Added a `formatScheduledDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown date"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #3231

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings