### PR TITLE
fix: validate unlockedAt before formatting in GamificationDashboard.jsx

### DIFF
--- a/website/src/components/gamification/GamificationDashboard.jsx
+++ b/website/src/components/gamification/GamificationDashboard.jsx
@@ -1,4 +1,13 @@
 import { useState, useEffect, useRef } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatAchievementDate(value) {
+  if (!value) return 'Unknown date';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown date';
+  return d.toLocaleDateString();
+}
 import { gamificationService, ACHIEVEMENTS } from '../../services/gamification/gamificationService';
 import { DynamicIcon } from '../../shared/Icons';
 
@@ -329,7 +338,7 @@ export default function GamificationDashboard() {
                     <div style={{ fontSize: '13px', color: '#9CA3AF' }}>{ach.description}</div>
                   </div>
                   <div style={{ fontSize: '12px', color: '#6B7280' }}>
-                    {new Date(ach.unlockedAt).toLocaleDateString()}
+                    {formatAchievementDate(ach.unlockedAt)}
                   </div>
                 </div>
               ))}


### PR DESCRIPTION
## Description
`GamificationDashboard.jsx` line 332 passed `ach.unlockedAt` directly into `new Date(...).toLocaleDateString()` with no validation. If `unlockedAt` was `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the achievements list.

Changes made:
- Added a `formatAchievementDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown date"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #3232

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings