### PR TITLE
fix: use strict equality and handle position 0 in estimateWait in WaitingRoom.jsx

### DIFF
--- a/website/src/pages/events/WaitingRoom.jsx
+++ b/website/src/pages/events/WaitingRoom.jsx
@@ -74,8 +74,9 @@ export default function WaitingRoom({ eventId, fullName, email, onJoinEvent }) {
   }, [eventId, fullName, email, onJoinEvent, position]);
 
   const estimateWait = (pos) => {
-    if (pos == null) return;
-    const mins = Math.max(1, Math.round(pos * 2));
+    if (pos === null || pos === undefined) return;
+    // Position 0 means front of queue — wait time is 0, not forced to 1
+    const mins = pos === 0 ? 0 : Math.max(1, Math.round(pos * 2));
     setWaitTime(mins);
   };
 


### PR DESCRIPTION
## Description
`WaitingRoom.jsx`'s `estimateWait` had two issues:
1. Used loose equality `pos == null` instead of strict equality — inconsistent with TypeScript/ESLint best practices
2. `Math.max(1, Math.round(pos * 2))` forced a minimum wait time of 1 minute even for position `0` (front of queue) — a user at the very front incorrectly saw "1 minute wait" instead of an immediate or zero wait time

Changes made:
- Replaced `pos == null` with `pos === null || pos === undefined` for strict equality
- Added an explicit `pos === 0` check that sets wait time to `0` so users at the front of the queue see the correct wait time
- Zero new TypeScript errors introduced

Fixes #3241

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings