### PR TITLE
fix: validate receivedAt before formatting in EventBudgetPage.jsx

### DIFF
--- a/website/src/pages/finance/EventBudgetPage.jsx
+++ b/website/src/pages/finance/EventBudgetPage.jsx
@@ -1,4 +1,13 @@
 import React, { useState, useEffect, useCallback } from 'react';
+
+// Validates a date value before formatting — avoids rendering literal
+// "Invalid Date" text when the API returns a null or malformed timestamp.
+function formatRevDate(value) {
+  if (!value) return 'Unknown';
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return 'Unknown';
+  return d.toLocaleDateString();
+}
 import { buildUrl } from '../../utils/runtimeConfig';
 
 const pageStyle = {
@@ -807,7 +816,7 @@ export default function EventBudgetPage() {
                     <td style={tdStyle}>{revenue.source}</td>
                     <td style={tdStyle}>{revenue.description || '-'}</td>
                     <td style={tdStyle}>{formatCurrency(revenue.amount)}</td>
-                    <td style={tdStyle}>{new Date(revenue.receivedAt).toLocaleDateString()}</td>
+                    <td style={tdStyle}>{formatRevDate(revenue.receivedAt)}</td>
                     <td style={tdStyle}>
                       <button
                         style={{ ...buttonStyle('danger'), padding: '6px 12px', fontSize: '12px' }}


### PR DESCRIPTION
## Description
`EventBudgetPage.jsx` line 810 passed `revenue.receivedAt` directly into `new Date(...).toLocaleDateString()` with no validation. If `receivedAt` was `null`, missing, or malformed in the API response, the literal text `"Invalid Date"` rendered in the revenue table.

Changes made:
- Added a `formatRevDate()` helper that checks for a falsy value and validates via `Number.isNaN(d.getTime())` before formatting, falling back to `"Unknown"` otherwise
- Replaced the unguarded inline call with the helper
- Zero new TypeScript errors introduced

Fixes #3233

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings