### PR TITLE
fix: add DEV-guarded logging to silent catch blocks in useFormMemory.js

### DIFF
--- a/website/src/hooks/useFormMemory.js
+++ b/website/src/hooks/useFormMemory.js
@@ -39,7 +39,10 @@ function readStorage(key) {
   try {
     const raw = sessionStorage.getItem(STORAGE_PREFIX + key);
     return raw ? JSON.parse(raw) : {};
-  } catch {
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('[useFormMemory] Failed to read from sessionStorage:', err.message);
+    }
     return {};
   }
 }
@@ -47,15 +50,21 @@ function readStorage(key) {
 function writeStorage(key, data) {
   try {
     sessionStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(data));
-  } catch {
-    // sessionStorage unavailable — degrade silently
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('[useFormMemory] Failed to write to sessionStorage:', err.message);
+    }
   }
 }
 
 function clearStorage(key) {
   try {
     sessionStorage.removeItem(STORAGE_PREFIX + key);
-  } catch {}
+  } catch (err) {
+    if (import.meta.env.DEV) {
+      console.warn('[useFormMemory] Failed to clear sessionStorage:', err.message);
+    }
+  }
 }
 
 /* ── Main Hook ── */


### PR DESCRIPTION
## Description
`useFormMemory.js`'s `readStorage`, `writeStorage`, and `clearStorage` helpers all had bare `catch {}` blocks that completely discarded `sessionStorage` errors with no feedback. Failures were invisible even in development — nothing was logged to the console, making it impossible to diagnose storage issues such as `QuotaExceededError`, `SecurityError`, or `JSON.parse` failures on malformed stored data.

Changes made:
- Added `import.meta.env.DEV`-guarded `console.warn` calls with `[useFormMemory]` prefix and `err.message` to all three catch blocks
- Storage errors now surface during development so they can be diagnosed without affecting production users
- Zero new TypeScript errors introduced

Fixes #3234

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings