### PR TITLE
fix: guard state updates after artificial delay on unmount in SubscriptionPage.jsx

### DIFF
--- a/website/src/pages/subscription/SubscriptionPage.jsx
+++ b/website/src/pages/subscription/SubscriptionPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useStudentAuth } from '../../context/StudentAuthContext';
 
 const TIERS = [
@@ -57,6 +57,13 @@ export default function SubscriptionPage({ onBack }) {
   const [showInvoice, setShowInvoice] = useState(false);
   const [lastInvoice, setLastInvoice] = useState(null);
   const [loading, setLoading] = useState(false);
+  const isMountedRef = useRef(true);
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const handleSubscribe = async (tierId) => {
     if (tierId === 'free') return;
@@ -66,6 +73,7 @@ export default function SubscriptionPage({ onBack }) {
     }
     setLoading(true);
     await new Promise((r) => setTimeout(r, 1000));
+    if (!isMountedRef.current) return;
     setCurrentTier(tierId);
     setLastInvoice({
       id: Date.now().toString(),


### PR DESCRIPTION
## Description
`SubscriptionPage.jsx`'s `handleSubscribe` used `await new Promise((r) => setTimeout(r, 1000))` for an artificial processing delay with no cancellation or unmount guard. If the component unmounted during the 1000ms wait (e.g. user navigates away after clicking subscribe), `setCurrentTier`, `setLastInvoice`, `setShowInvoice`, and `setLoading` all fired on an unmounted component.

Changes made:
- Added `isMountedRef` (via `useRef`) set to `true` on mount and `false` on unmount via `useEffect` cleanup
- Added `isMountedRef.current` guard immediately after the `await` so all subsequent state updates are skipped if the component already unmounted during the delay
- Zero new TypeScript errors introduced

Fixes #3238

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings