### PR TITLE
Show a search error state in history SearchBar

### DIFF
--- a/website/src/components/history/SearchBar.jsx
+++ b/website/src/components/history/SearchBar.jsx
@@ -7,10 +7,12 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
   const [results, setResults] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
   const [showResults, setShowResults] = useState(false);
+  const [searchError, setSearchError] = useState('');
 
   const handleSearch = useCallback(
     async (searchQuery) => {
       setQuery(searchQuery);
+      setSearchError('');
 
       if (!searchQuery.trim()) {
         setResults([]);
@@ -20,14 +22,16 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
 
       setIsSearching(true);
       try {
-        const foundPrompts = await searchPrompts(searchQuery, workspace);
+        const foundPrompts = await searchPrompts(searchQuery, workspace, { throwOnError: true });
         setResults(foundPrompts);
         setShowResults(true);
       } catch (error) {
+        setResults([]);
+        setShowResults(true);
+        setSearchError('Search is temporarily unavailable.');
         if (import.meta.env.DEV) {
           console.error('[HistorySearchBar] Search error:', error.message);
         }
-        setResults([]);
       } finally {
         setIsSearching(false);
       }
@@ -64,6 +68,7 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
               setQuery('');
               setResults([]);
               setShowResults(false);
+              setSearchError('');
             }}
           >
             ✕
@@ -89,7 +94,7 @@ const SearchBar = ({ onSelectPrompt, workspace = 'default' }) => {
 
       {showResults && query && results.length === 0 && !isSearching && (
         <div className="search-empty">
-          <p>No results found</p>
+          <p>{searchError || 'No results found'}</p>
         </div>
       )}
     </div>

--- a/website/src/lib/promptStore.js
+++ b/website/src/lib/promptStore.js
@@ -79,7 +79,8 @@ export const savePrompt = async (prompt, response, workspace = 'default') => {
 /**
  * Get all prompts from storage
  */
-export const getAllPrompts = async (workspace = null) => {
+export const getAllPrompts = async (workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
     const database = await initializeDB();
 
@@ -103,16 +104,21 @@ export const getAllPrompts = async (workspace = null) => {
     });
   } catch (error) {
     logger.error('Error retrieving prompts from IndexedDB:', error);
-    return getPromptsFromLocalStorage(workspace);
+    const fallback = getPromptsFromLocalStorage(workspace);
+    if (throwOnError && fallback.length === 0) {
+      throw error;
+    }
+    return fallback;
   }
 };
 
 /**
  * Search prompts by keyword
  */
-export const searchPrompts = async (keyword, workspace = null) => {
+export const searchPrompts = async (keyword, workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
-    const allPrompts = await getAllPrompts(workspace);
+    const allPrompts = await getAllPrompts(workspace, { throwOnError });
     const lowerKeyword = keyword.toLowerCase();
 
     return allPrompts.filter(
@@ -122,6 +128,9 @@ export const searchPrompts = async (keyword, workspace = null) => {
     );
   } catch (error) {
     logger.error('Error searching prompts:', error);
+    if (throwOnError) {
+      throw error;
+    }
     return [];
   }
 };
@@ -129,7 +138,8 @@ export const searchPrompts = async (keyword, workspace = null) => {
 /**
  * Get pinned prompts
  */
-export const getPinnedPrompts = async (workspace = null) => {
+export const getPinnedPrompts = async (workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
     const database = await initializeDB();
 
@@ -150,7 +160,11 @@ export const getPinnedPrompts = async (workspace = null) => {
     });
   } catch (error) {
     logger.error('Error retrieving pinned prompts:', error);
-    return getPinnedPromptsFromLocalStorage(workspace);
+    const fallback = getPinnedPromptsFromLocalStorage(workspace);
+    if (throwOnError && fallback.length === 0) {
+      throw error;
+    }
+    return fallback;
   }
 };
 


### PR DESCRIPTION
Closes #3424

Summary:
- show a visible error message when the history search storage lookup fails
- avoid rendering a false no-results state for real failures

Validation:
- git diff --check
- node --check website/src/lib/promptStore.js
- npx prettier --check website/src/components/history/SearchBar.jsx website/src/lib/promptStore.js