### PR TITLE
Show an error state when pinned chats fail to load

### DIFF
--- a/website/src/components/history/PinnedChats.jsx
+++ b/website/src/components/history/PinnedChats.jsx
@@ -5,13 +5,17 @@ import './PinnedChats.css';
 const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
   const [pinnedPrompts, setPinnedPrompts] = useState([]);
   const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState('');
 
   const loadPinnedPrompts = async () => {
     setLoading(true);
+    setLoadError('');
     try {
-      const pinned = await getPinnedPrompts(workspace);
+      const pinned = await getPinnedPrompts(workspace, { throwOnError: true });
       setPinnedPrompts(pinned);
     } catch (error) {
+      setPinnedPrompts([]);
+      setLoadError('Pinned conversations could not be loaded.');
       if (import.meta.env.DEV) {
         console.error('[PinnedChats] Error loading pinned prompts:', error.message);
       }
@@ -33,6 +37,23 @@ const PinnedChats = ({ onSelectPrompt, workspace = 'default' }) => {
   const handleSelectPrompt = (prompt) => {
     onSelectPrompt(prompt);
   };
+
+  if (loading) {
+    return null;
+  }
+
+  if (loadError) {
+    return (
+      <div className="pinned-chats-container" role="status" aria-live="polite">
+        <div className="pinned-header">
+          <h4>📌 Pinned Conversations</h4>
+        </div>
+        <div style={{ padding: '12px 16px', color: 'var(--text-secondary, #666)' }}>
+          {loadError}
+        </div>
+      </div>
+    );
+  }
 
   if (pinnedPrompts.length === 0) {
     return null;

--- a/website/src/lib/promptStore.js
+++ b/website/src/lib/promptStore.js
@@ -79,7 +79,8 @@ export const savePrompt = async (prompt, response, workspace = 'default') => {
 /**
  * Get all prompts from storage
  */
-export const getAllPrompts = async (workspace = null) => {
+export const getAllPrompts = async (workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
     const database = await initializeDB();
 
@@ -103,16 +104,21 @@ export const getAllPrompts = async (workspace = null) => {
     });
   } catch (error) {
     logger.error('Error retrieving prompts from IndexedDB:', error);
-    return getPromptsFromLocalStorage(workspace);
+    const fallback = getPromptsFromLocalStorage(workspace);
+    if (throwOnError && fallback.length === 0) {
+      throw error;
+    }
+    return fallback;
   }
 };
 
 /**
  * Search prompts by keyword
  */
-export const searchPrompts = async (keyword, workspace = null) => {
+export const searchPrompts = async (keyword, workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
-    const allPrompts = await getAllPrompts(workspace);
+    const allPrompts = await getAllPrompts(workspace, { throwOnError });
     const lowerKeyword = keyword.toLowerCase();
 
     return allPrompts.filter(
@@ -122,6 +128,9 @@ export const searchPrompts = async (keyword, workspace = null) => {
     );
   } catch (error) {
     logger.error('Error searching prompts:', error);
+    if (throwOnError) {
+      throw error;
+    }
     return [];
   }
 };
@@ -129,7 +138,8 @@ export const searchPrompts = async (keyword, workspace = null) => {
 /**
  * Get pinned prompts
  */
-export const getPinnedPrompts = async (workspace = null) => {
+export const getPinnedPrompts = async (workspace = null, options = {}) => {
+  const { throwOnError = false } = options;
   try {
     const database = await initializeDB();
 
@@ -150,7 +160,11 @@ export const getPinnedPrompts = async (workspace = null) => {
     });
   } catch (error) {
     logger.error('Error retrieving pinned prompts:', error);
-    return getPinnedPromptsFromLocalStorage(workspace);
+    const fallback = getPinnedPromptsFromLocalStorage(workspace);
+    if (throwOnError && fallback.length === 0) {
+      throw error;
+    }
+    return fallback;
   }
 };
 


### PR DESCRIPTION
Closes #3425

Summary:
- surface a visible error message when pinned conversations cannot be loaded
- keep the empty state hidden only when there is truly nothing to show

Validation:
- git diff --check
- node --check website/src/lib/promptStore.js
- npx prettier --check website/src/components/history/PinnedChats.jsx website/src/lib/promptStore.js