### PR TITLE
fix: derive certificate IDs with HMAC instead of a plain hash

### DIFF
--- a/server-python/.env.example
+++ b/server-python/.env.example
@@ -12,5 +12,9 @@ CORS_ORIGIN=http://localhost:5173,https://nexasphere-glbajaj.vercel.app
 # Admin secret for certificate generation API — set a strong random value
 ADMIN_SECRET=your-strong-random-secret
 
+# Secret used to derive certificate IDs (HMAC key) — set a strong random
+# value, and keep it different from ADMIN_SECRET
+CERT_ID_SECRET=your-strong-random-secret
+
 # Get your free Gemini API Key from: https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here

--- a/server-python/routers/certificates.py
+++ b/server-python/routers/certificates.py
@@ -45,6 +45,16 @@ if not ADMIN_SECRET:
         "Set it in your .env file or environment before starting the server."
     )
 
+# Secret used to derive certificate IDs. Must be kept server-side only —
+# anyone with this value could compute valid certificate IDs offline, so it
+# must never be the same value as ADMIN_SECRET or reused elsewhere.
+CERT_ID_SECRET = os.getenv("CERT_ID_SECRET")
+if not CERT_ID_SECRET:
+    raise RuntimeError(
+        "CERT_ID_SECRET environment variable is required to derive certificate IDs. "
+        "Set it in your .env file or environment before starting the server."
+    )
+
 
 def _require_admin(x_admin_secret: Optional[str] = Header(default=None)) -> None:
     """Dependency that enforces admin authentication via X-Admin-Secret header."""
@@ -102,9 +112,22 @@ class VerifyResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 def _make_certificate_id(student_id: str, event_id: str) -> str:
-    """Deterministic, collision-resistant certificate ID based on student+event."""
+    """
+    Deterministic, collision-resistant certificate ID based on student+event.
+
+    Uses HMAC-SHA256 keyed with a server-side secret (CERT_ID_SECRET) rather
+    than a plain hash. A plain sha256(student_id:event_id) hash is computable
+    by anyone who knows or guesses the pair, which would let a third party
+    predict a certificate ID (and hit the public verify/download endpoints)
+    without ever having been issued that certificate. Keying the digest with
+    a secret only the server holds keeps the ID deterministic for the
+    generation flow's dedup logic, while making it infeasible to compute
+    without server access.
+    """
     seed = f"{student_id}:{event_id}"
-    digest = hashlib.sha256(seed.encode()).hexdigest()[:16]
+    digest = hmac.new(
+        CERT_ID_SECRET.encode(), seed.encode(), hashlib.sha256
+    ).hexdigest()[:16]
     return f"NS-CERT-{digest.upper()}"
 
 


### PR DESCRIPTION
## Description
Certificate IDs were generated using a plain sha256 hash of student_id and event_id, with no server-side secret. Since the verify and download endpoints are public and unauthenticated, anyone who knew or guessed a student_id and event_id pair could compute the same certificate ID offline and look up or download that student's certificate without ever having been issued it.

## Related Issue
Fixes #3453

## Type of Change
- [x] Security Enhancement

## Changes Implemented
_make_certificate_id now derives the certificate ID using HMAC-SHA256 keyed with a new CERT_ID_SECRET environment variable, instead of an unkeyed hash. The ID stays deterministic, so the existing dedup logic in generate_certificates is unaffected, but it can no longer be computed without access to the server's secret. Also documented CERT_ID_SECRET in .env.example and README.md, following the same required-at-startup pattern already used for ADMIN_SECRET.

## Technical Details

### Backend
Updated server-python/routers/certificates.py to use hmac.new keyed with CERT_ID_SECRET instead of hashlib.sha256 directly. Server now raises a RuntimeError on startup if CERT_ID_SECRET is not set, matching the existing ADMIN_SECRET check.

## Testing

### Manual Testing
- [x] Verified the file parses correctly and the same student_id/event_id pair still produces a consistent certificate ID across calls, so the generate endpoint's dedup check is unaffected.

## Security Review
Certificate IDs can no longer be computed offline without knowledge of the server-side CERT_ID_SECRET.

## Breaking Changes
- [x] Breaking Changes Documented

Deployments must set CERT_ID_SECRET as a new required environment variable, or the server-python service will fail to start.

## Checklist
- [x] Code follows project standards
- [ ] Tests added or updated
- [x] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [ ] CI/CD passing
- [ ] Ready for review