### PR TITLE
fix(a11y): add keyboard focus indicators and skip-to-content link

### DIFF
--- a/website/src/App.jsx
+++ b/website/src/App.jsx
@@ -23,6 +23,7 @@ import { useBackToTop } from './hooks/useScrollLogic';
 
 // Shared layout and telemetry widgets
 import Navbar from './shared/Navbar';
+import SkipLink from './components/common/SkipLink';
 import MoveToTop from './shared/MoveToTop';
 import Chatbot from './shared/Chatbot';
 import ScrollProgress from './shared/ScrollProgress';
@@ -449,6 +450,7 @@ function MainRouter({
   return (
     <SessionRecordingProvider sessionId={sessionId}>
       {cinDone && <AmbientOrbs theme={theme} />}
+      <SkipLink />
       {cinDone && (
         <Navbar
           activeTab={activeTab}
@@ -463,7 +465,7 @@ function MainRouter({
 
       <Wipe on={wipeOn} ph={wipePh} />
 
-      <main style={{ paddingTop: nh, position: 'relative', zIndex: 1 }}>
+      <main id="main-content" style={{ paddingTop: nh, position: 'relative', zIndex: 1 }}>
         <Suspense fallback={<PageLoadingSpinner />}>
           <Routes>
             {/* â”€â”€ Home (scrollable sections) â”€â”€ */}

--- a/website/src/styles/chatbot.css
+++ b/website/src/styles/chatbot.css
@@ -242,8 +242,12 @@
   border-color: rgba(99, 102, 241, 0.6);
 }
 
+.workspace-selector-inline:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
+}
+
 .workspace-selector-inline:focus {
-  outline: none;
   background: rgba(255, 255, 255, 0.15);
   border-color: #6366f1;
 }
@@ -260,9 +264,13 @@
   padding: 8px 12px;
   border-radius: 8px;
   color: #fff;
-  outline: none;
   font-size: 13px;
   font-family: inherit;
+}
+
+.chat-input-container input:focus-visible {
+  outline: 2px solid #6366f1;
+  outline-offset: 2px;
 }
 
 .chat-input-container input::placeholder {

--- a/website/src/styles/motion.css
+++ b/website/src/styles/motion.css
@@ -568,7 +568,6 @@
     0 0 0 3px rgba(204, 17, 17, 0.12),
     0 0 20px rgba(204, 17, 17, 0.08) !important;
   transform: scale(1.005) !important;
-  outline: none !important;
 }
 
 @media (max-width: 768px) {

--- a/website/src/styles/portfolio.css
+++ b/website/src/styles/portfolio.css
@@ -157,8 +157,12 @@
   color: var(--t1);
   font-family: 'Rajdhani', sans-serif;
   font-size: 1rem;
-  outline: none;
   transition: all 0.25s ease;
+}
+
+.portfolio-input:focus-visible {
+  outline: 2px solid var(--c1);
+  outline-offset: 2px;
 }
 
 [data-theme='light'] .form-input,

--- a/website/src/styles/projects.css
+++ b/website/src/styles/projects.css
@@ -83,7 +83,6 @@
   border-color: var(--c1b);
   box-shadow: 0 4px 12px rgba(204, 17, 17, 0.15);
   transform: translateY(-2px);
-  outline: none;
 }
 
 [data-theme='light'] .filter-pill:hover {

--- a/website/src/styles/roadmaps.css
+++ b/website/src/styles/roadmaps.css
@@ -77,7 +77,11 @@
   align-items: center;
   gap: 12px;
   transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
-  outline: none;
+}
+
+.domain-card-tab:focus-visible {
+  outline: 2px solid var(--c1);
+  outline-offset: 2px;
 }
 
 [data-theme='light'] .domain-card-tab {
@@ -513,7 +517,6 @@
   padding: 14px 18px;
   text-decoration: none;
   transition: all 0.25s ease;
-  outline: none;
 }
 
 [data-theme='light'] .resource-card-link {
@@ -837,7 +840,11 @@
   padding: 10px 14px;
   color: var(--t1);
   transition: border-color 0.2s;
-  outline: none;
+}
+
+.glass-input:focus-visible {
+  outline: 2px solid var(--c1);
+  outline-offset: 2px;
 }
 
 [data-theme='light'] .glass-input {


### PR DESCRIPTION
## Summary
Closes #3295

Adds visible keyboard focus indicators across the site and wires up the existing (but unused) SkipLink component.

## Changes

### Skip-to-content link
- **App.jsx**: Import and render `<SkipLink />` before the Navbar
- **App.jsx**: Add `id="main-content"` to the `<main>` element so the skip link has a target
- The `SkipLink` component and its CSS already existed in the codebase but were never imported or used

### Focus-visible fixes
Removed `outline: none` from 8 locations where it was suppressing the global `:focus-visible` rule, and added explicit `:focus-visible` styles:

| File | Selector | Change |
|------|----------|--------|
| `motion.css` | `.ns-input:focus`, `.ns-textarea:focus`, `.ns-select:focus` | Removed `outline: none !important` |
| `projects.css` | `.filter-pill:hover, :focus-visible` | Removed `outline: none` |
| `roadmaps.css` | `.domain-card-tab` | Removed `outline: none`, added `:focus-visible` rule |
| `roadmaps.css` | `.resource-card-link` | Removed `outline: none` |
| `roadmaps.css` | `.glass-input` | Removed `outline: none`, added `:focus-visible` rule |
| `chatbot.css` | `.workspace-selector-inline` | Removed `outline: none`, added `:focus-visible` rule |
| `chatbot.css` | `.chat-input-container input` | Added `:focus-visible` rule |
| `portfolio.css` | `.portfolio-input` | Removed `outline: none`, added `:focus-visible` rule |

### Focus-visible style used
All new `:focus-visible` rules use:
```css
outline: 2px solid var(--c1);
outline-offset: 2px;
```
This is consistent with the global `:focus-visible` rule already in `globals.css` and the existing `.project-card:focus-visible` rule.

## Testing
- Tab through the navbar — focus indicator visible on each tab
- Tab past the navbar into main content — skip link appears on first Tab press
- Tab through filter pills, project cards, roadmap tabs — all show visible focus outlines
- Tab through chatbot input, workspace selector — visible focus outlines
- Tab through recruitment form inputs — visible focus outlines (no longer suppressed by motion.css)