### PR TITLE
security: enforce room membership validation before broadcasting (#3705)

### DIFF
--- a/server/sockets/workspaceSocket.js
+++ b/server/sockets/workspaceSocket.js
@@ -47,9 +47,16 @@ export function setupWorkspaceSocket(io) {
       if (typeof ack === 'function') ack({ success: true, roomId });
     });
 
+    //  RECTIFIED BLOCK (leave_room)
     socket.on('leave_room', (roomId, ack) => {
       if (!isValidRoomId(roomId)) {
         if (typeof ack === 'function') ack({ success: false, error: 'Invalid roomId' });
+        return;
+      }
+
+      // Security Check: Verify socket is actually in the room
+      if (!socket.rooms || !socket.rooms.has(roomId)) {
+        if (typeof ack === 'function') ack({ success: false, error: 'Unauthorized: Not a member of this room' });
         return;
       }
 
@@ -64,12 +71,19 @@ export function setupWorkspaceSocket(io) {
       if (typeof ack === 'function') ack({ success: true, roomId });
     });
 
+    //  RECTIFIED BLOCK (task_create)
     socket.on('task_create', async (data, ack) => {
       try {
         const { roomId, task } = data || {};
 
         if (!isValidRoomId(roomId)) {
           if (typeof ack === 'function') ack({ success: false, error: 'Invalid roomId' });
+          return;
+        }
+
+        // Security Check: Verify socket is actually in the room
+        if (!socket.rooms || !socket.rooms.has(roomId)) {
+          if (typeof ack === 'function') ack({ success: false, error: 'Unauthorized: Not a member of this room' });
           return;
         }
 
@@ -97,12 +111,19 @@ export function setupWorkspaceSocket(io) {
       }
     });
 
+    //  RECTIFIED BLOCK (task_update_status)
     socket.on('task_update_status', async (data, ack) => {
       try {
         const { roomId, taskId, status, previousStatus, updatedBy } = data || {};
 
         if (!isValidRoomId(roomId)) {
           if (typeof ack === 'function') ack({ success: false, error: 'Invalid roomId' });
+          return;
+        }
+
+        // Security Check: Verify socket is actually in the room
+        if (!socket.rooms || !socket.rooms.has(roomId)) {
+          if (typeof ack === 'function') ack({ success: false, error: 'Unauthorized: Not a member of this room' });
           return;
         }
 
@@ -137,9 +158,10 @@ export function setupWorkspaceSocket(io) {
       }
     });
 
+    //  RECTIFIED BLOCK (typing_start & typing_stop)
     socket.on('typing_start', (data) => {
       const { roomId, user } = data || {};
-      if (!isValidRoomId(roomId)) return;
+      if (!isValidRoomId(roomId) || !socket.rooms || !socket.rooms.has(roomId)) return;
 
       socket.to(roomId).emit('typing_start', {
         socketId: socket.id,
@@ -152,7 +174,7 @@ export function setupWorkspaceSocket(io) {
 
     socket.on('typing_stop', (data) => {
       const { roomId } = data || {};
-      if (!isValidRoomId(roomId)) return;
+      if (!isValidRoomId(roomId) || !socket.rooms || !socket.rooms.has(roomId)) return;
 
       socket.to(roomId).emit('typing_stop', { socketId: socket.id });
     });


### PR DESCRIPTION
# Summary

## Related Issue

Fixes #3705

## Type of Change

- [ ] Feature
- [ ] Bug Fix
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [ ] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented
- Added strict `socket.rooms.has(roomId)` membership checks across multiple event handlers (`leave_room`, `task_create`, `task_update_status`, `typing_start`, `typing_stop`).
- Blocked unauthorized socket connections from spoofing or broadcasting event payloads to channels they haven't explicitly joined.
- Updated acknowledgment callbacks to return an explicit `Unauthorized: Not a member of this room` error string when verification checks fail.

## Technical Details

### Frontend
*No changes.*

### Backend
- Upgraded the event verification pipeline inside `setupWorkspaceSocket` to check room existence boundaries within the native `socket.rooms` Set.
- Short-circuited the telemetry streams (`typing_start`, `typing_stop`) to silently exit if a client attempts to emit data to an unjoined room.
- Prevented malicious payload routing and cross-room spamming vulnerabilities.

### Database
*No changes.*

### API
*No changes.*

### Infrastructure
*No changes.*

## Screenshots

### Before
*(Security optimization; no functional layout components or frontend screens altered.)*

### After
*(Security optimization; no functional layout components or frontend screens altered.)*

## Testing

### Unit Tests

- [ ]

### Integration Tests

- [ ]

### E2E Tests

- [ ]

### Manual Testing

- [x] Established a raw connection using a mock socket client without executing a `join_room` invocation.
- [x] Attempted to dispatch `task_create` and `typing_start` payloads targeting private workspace channels.
- [x] Verified that the server rejected the commands, caught unauthorized access attempts, and successfully protected room members from receiving rogue broadcasts.

## Security Review
*CRITICAL: Closes an arbitrary message-broadcasting vulnerability where a connected socket could spoof communications to any workspace channel purely by guessing its string regex pattern.*

## Accessibility Review
*Not applicable.*

## Performance Impact
*Negligible overhead. Leverages native JavaScript `Set.prototype.has()` structure to validate access metrics efficiently in $O(1)$ constant time.*

## Breaking Changes

- [x] No Breaking Changes
- [ ] Breaking Changes Documented

## Deployment Notes
*Standard deployment flow. Safe for immediate production release.*

## Rollback Plan
*Revert the security verification blocks integrated within the core event handlers inside the workspace socket manager file.*

## Checklist

- [x] Code follows project standards
- [ ] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [ ] CI/CD passing
- [x] Ready for review