### PR TITLE
fix: prevent reverse tabnabbing in UserTimelineModal

### DIFF
--- a/admin-dashboard/src/components/UserTimelineModal.jsx
+++ b/admin-dashboard/src/components/UserTimelineModal.jsx
@@ -44,7 +44,7 @@ export default function UserTimelineModal({ user, onClose }) {
     const params = new URLSearchParams();
     if (user.email) params.append('email', user.email);
     if (usernameInput) params.append('username', usernameInput);
-    window.open(`/api/admin/users/timeline/export?${params.toString()}`, '_blank');
+    window.open(`/api/admin/users/timeline/export?${params.toString()}`, '_blank', 'noopener,noreferrer');
   };
 
   return (


### PR DESCRIPTION
## Description

This PR fixes a reverse tabnabbing vulnerability in the `UserTimelineModal` component.

Previously, the timeline export functionality opened a new tab using:

```js
window.open(url, "_blank");
```

This allowed the newly opened page to access `window.opener`, potentially enabling reverse tabnabbing attacks.

This PR updates the `window.open()` call to use the `noopener,noreferrer` window features, preventing the new page from accessing the originating window while preserving the existing export functionality.

---

## Changes Made

- Updated `window.open()` to include `noopener,noreferrer`.
- Prevented access to `window.opener` from the newly opened tab.
- Preserved the existing timeline export behavior.

---

## Testing

- Opened the User Timeline export.
- Verified that the export still opens in a new tab.
- Confirmed that the opened page cannot access `window.opener`.
- Ensured no regressions in export functionality.

---

## Related Issue

Closes #3731

---

## Type of Change

- [x] Bug fix

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.