### PR TITLE
fix: guard JSON.parse in photo upload response

### DIFF
--- a/components/Gallery/PhotoUpload.jsx
+++ b/components/Gallery/PhotoUpload.jsx
@@ -84,7 +84,11 @@ export default function PhotoUpload({ eventId, albumId, onUploadComplete }) {
 
       xhr.addEventListener('load', () => {
         if (xhr.status >= 200 && xhr.status < 300) {
-          resolve(JSON.parse(xhr.responseText));
+          try {
+            resolve(JSON.parse(xhr.responseText));
+          } catch (e) {
+            reject(new Error('Upload failed: Invalid server response'));
+          }
         } else {
           reject(new Error(`Upload failed: ${xhr.statusText}`));
         }


### PR DESCRIPTION
## Description

This PR fixes an issue where the photo upload flow could crash if the server returned a malformed or non-JSON response.

Previously, the upload success handler directly called:

```js
JSON.parse(xhr.responseText)
```

If the server responded with an HTML error page or invalid JSON, a `SyntaxError` was thrown, causing the upload process to fail unexpectedly.

This PR wraps the parsing logic in a `try...catch` block and rejects the upload with a meaningful error message when the response cannot be parsed.

---

## Changes Made

- Wrapped `JSON.parse(xhr.responseText)` in a `try...catch` block.
- Rejected the upload with a descriptive error when parsing fails.
- Prevented upload flow crashes caused by malformed server responses.
- Preserved the existing behavior for valid JSON responses.

---

## Testing

- Simulated a malformed server response.
- Verified that the upload no longer crashes with a `SyntaxError`.
- Confirmed that a meaningful error is returned to the caller.
- Ensured valid JSON responses continue to work correctly.

---

## Related Issue

Closes #3732

---

## Type of Change

- [x] Bug fix

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.