### PR TITLE
fix: guard JSON.parse in custom event CSV export

### DIFF
--- a/server/controllers/customEventController.js
+++ b/server/controllers/customEventController.js
@@ -149,8 +149,14 @@ export const exportEventData = wrapAsync(async (req, res) => {
   const csvRows = [
     headerCols.join(','),
     ...logs.map((log) => {
-      const props =
-        typeof log.properties === 'string' ? JSON.parse(log.properties) : log.properties || {};
+      let props = log.properties || {};
+      if (typeof props === 'string') {
+        try {
+          props = JSON.parse(props);
+        } catch (e) {
+          props = {};
+        }
+      }
       return [
         log.id,
         log.user_id || '',


### PR DESCRIPTION
## Description

This PR fixes a backend issue where CSV export could fail if a custom event contained malformed JSON in the `properties` field.

Previously, the export logic directly called:

```js
JSON.parse(log.properties)
```

If `log.properties` contained invalid JSON, a `SyntaxError` was thrown, causing the entire CSV export request to fail.

This PR wraps the parsing logic in a `try...catch` block and safely falls back to an empty object when parsing fails, allowing the export to continue successfully.

---

## Changes Made

- Wrapped `JSON.parse(log.properties)` in a `try...catch` block.
- Added a safe fallback to an empty object when parsing fails.
- Prevented CSV export failures caused by malformed log properties.
- Preserved existing behavior for valid JSON values.

---

## Testing

- Simulated malformed JSON in the `properties` field.
- Verified that CSV export no longer throws a `SyntaxError`.
- Confirmed the export completes successfully using an empty object fallback.
- Ensured valid JSON is parsed correctly.

---

## Related Issue

Fixes #3733

---

## Type of Change

- [x] Bug fix

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.