### PR TITLE
fix: prevent reverse tabnabbing in EventCalendarView

### DIFF
--- a/src/components/calendar/EventCalendarView.jsx
+++ b/src/components/calendar/EventCalendarView.jsx
@@ -64,7 +64,7 @@ export default function EventCalendarView({ events, onEventClick }) {
     const start = event.start?.toISOString().replace(/-|:|\.\d+/g, '');
     const end = event.end?.toISOString().replace(/-|:|\.\d+/g, '');
     const url = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(event.title)}&dates=${start}/${end}&details=${encodeURIComponent(event.extendedProps?.description || '')}&location=${encodeURIComponent(event.extendedProps?.location || '')}`;
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   const downloadICS = (event) => {


### PR DESCRIPTION
## Description

This PR fixes a reverse tabnabbing vulnerability in the `EventCalendarView` component.

Previously, the "Add to Google Calendar" action opened an external URL using:

```js
window.open(url, "_blank");
```

This allowed the newly opened page to access `window.opener`, potentially enabling reverse tabnabbing attacks.

This PR updates the `window.open()` call to include the `noopener,noreferrer` window features, preventing access to the originating window while preserving the existing calendar integration.

---

## Changes Made

- Updated `window.open()` to include `noopener,noreferrer`.
- Prevented access to `window.opener` from the newly opened tab.
- Preserved the existing "Add to Google Calendar" functionality.

---

## Testing

- Opened the "Add to Google Calendar" action.
- Verified that the Google Calendar page still opens in a new tab.
- Confirmed that the opened page cannot access `window.opener`.
- Ensured no regressions in calendar functionality.

---

## Related Issue

Fixes #3734

---

## Type of Change

- [x] Bug fix

---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.