### PR TITLE
fix: safely parse localStorage data in userInterestTracker

### DIFF
--- a/src/services/recommendation/userInterestTracker.js
+++ b/src/services/recommendation/userInterestTracker.js
@@ -6,6 +6,16 @@ const STORAGE_KEYS = {
   USER_PREFERENCES: 'user_preferences',
 };
 
+function safeParse(str, fallback) {
+  if (!str) return fallback;
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    console.error('[UserInterestTracker] Failed to parse localStorage key:', e);
+    return fallback;
+  }
+}
+
 class UserInterestTracker {
   constructor() {
     this.interests = this.loadInterests();
@@ -15,30 +25,26 @@ class UserInterestTracker {
 
   loadInterests() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_INTERESTS);
-    return stored
-      ? JSON.parse(stored)
-      : {
-          categories: {},
-          tags: {},
-          events: {},
-        };
+    return safeParse(stored, {
+      categories: {},
+      tags: {},
+      events: {},
+    });
   }
 
   loadHistory() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_HISTORY);
-    return stored ? JSON.parse(stored) : [];
+    return safeParse(stored, []);
   }
 
   loadPreferences() {
     const stored = localStorage.getItem(STORAGE_KEYS.USER_PREFERENCES);
-    return stored
-      ? JSON.parse(stored)
-      : {
-          preferredCategories: [],
-          preferredTags: [],
-          preferredTimeSlots: [],
-          preferredLocations: [],
-        };
+    return safeParse(stored, {
+      preferredCategories: [],
+      preferredTags: [],
+      preferredTimeSlots: [],
+      preferredLocations: [],
+    });
   }
 
   trackEventInteraction(eventId, action, metadata = {}) {


### PR DESCRIPTION
## Description

This PR fixes application crashes caused by unguarded `JSON.parse()` calls in `userInterestTracker`.

Previously, if any of the tracker's localStorage entries contained malformed JSON, the application could fail during initialization because `JSON.parse()` threw a `SyntaxError`.

This PR introduces a reusable `safeParse()` helper that safely parses stored data and falls back to sensible default values when parsing fails.

---

## Changes Made

- Added a reusable `safeParse()` helper for localStorage parsing.
- Replaced direct `JSON.parse()` calls in `loadInterests()`.
- Replaced direct `JSON.parse()` calls in `loadHistory()`.
- Replaced direct `JSON.parse()` calls in `loadPreferences()`.
- Added appropriate fallback values for corrupted or invalid localStorage data.
- Prevented application crashes caused by malformed localStorage entries.

---

## Testing

- Simulated corrupted localStorage values.
- Verified that the application initializes successfully without crashing.
- Confirmed that default values are used when parsing fails.
- Ensured valid localStorage data continues to be parsed correctly.

---

## Related Issue

Fixes #3735

---

## Type of Change

- [x] Bug fix


---

## Checklist

- [x] Code follows the project's coding style.
- [x] Self-reviewed the changes.
- [x] Tested the fix locally.
- [x] No unrelated files were modified.