### PR TITLE
fix: safely parse malformed forum tags JSON in forumRepository

### DIFF
--- a/server/repositories/forumRepository.js
+++ b/server/repositories/forumRepository.js
@@ -1,5 +1,13 @@
 import { withDb } from './db.js';
 
+function safeParseJSON(str, fallback = []) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return fallback;
+  }
+}
+
 function mapThreadRow(row) {
   return {
     id: row.id,
@@ -14,7 +22,7 @@ function mapThreadRow(row) {
     isLocked: row.is_locked,
     isAnswered: row.is_answered,
     acceptedReplyId: row.accepted_reply_id,
-    tags: typeof row.tags === 'string' ? JSON.parse(row.tags) : row.tags,
+    tags: typeof row.tags === 'string' ? safeParseJSON(row.tags, []) : (row.tags || []),
     upvotes: row.upvotes,
     replyCount: row.reply_count,
     viewCount: row.view_count,


### PR DESCRIPTION
Closes #3737

## Description

This PR fixes a crash in `server/repositories/forumRepository.js` caused by unguarded `JSON.parse()` calls when parsing forum thread tags.

Previously, if the `tags` column contained malformed JSON, `JSON.parse()` would throw a `SyntaxError`, causing the forum listing endpoint to fail.

This PR introduces safe JSON parsing with a fallback to an empty array, ensuring the API remains stable even when invalid data is encountered.

### Changes Made

- Added a `safeParseJSON()` helper.
- Replaced direct `JSON.parse()` calls with `safeParseJSON()`.
- Added an empty array (`[]`) fallback for malformed JSON.
- Preserved existing behavior for valid JSON.

### Testing

- ✅ Verified valid JSON is parsed correctly.
- ✅ Verified malformed JSON no longer crashes the endpoint.
- ✅ Confirmed invalid `tags` values fall back to an empty array.

