### PR TITLE
fix: safely parse malformed JSON in financialRepository

### DIFF
--- a/server/repositories/financialRepository.js
+++ b/server/repositories/financialRepository.js
@@ -1,5 +1,13 @@
 import { withDb } from './db.js';
 
+function safeParseJSON(str, fallback = {}) {
+  try {
+    return JSON.parse(str);
+  } catch (e) {
+    return fallback;
+  }
+}
+
 function mapBudgetRow(row) {
   if (!row) return null;
   return {
@@ -11,7 +19,7 @@ function mapBudgetRow(row) {
     endDate: row.end_date,
     categoryAllocations:
       typeof row.category_allocations === 'string'
-        ? JSON.parse(row.category_allocations)
+        ? safeParseJSON(row.category_allocations)
         : (row.category_allocations ?? {}),
     createdBy: row.created_by,
     createdAt: row.created_at,
@@ -65,7 +73,7 @@ function mapAuditRow(row) {
     recordType: row.record_type,
     recordId: row.record_id,
     userId: row.user_id,
-    changes: typeof row.changes === 'string' ? JSON.parse(row.changes) : (row.changes ?? {}),
+    changes: typeof row.changes === 'string' ? safeParseJSON(row.changes) : (row.changes ?? {}),
     createdAt: row.created_at,
   };
 }


### PR DESCRIPTION
Closes #3736

## Description

This PR fixes crashes in `server/repositories/financialRepository.js` caused by unguarded `JSON.parse()` calls when parsing financial record fields.

Previously, malformed JSON stored in the `category_allocations` or `changes` columns would throw a `SyntaxError`, causing the financial API endpoints to fail.

This PR introduces safe JSON parsing with appropriate fallbacks to ensure the API remains stable even when invalid data is encountered.

### Changes Made

- Added a reusable `safeParseJSON()` helper.
- Replaced direct `JSON.parse()` calls for `category_allocations`.
- Replaced direct `JSON.parse()` calls for `changes`.
- Preserved existing fallback behavior by returning an empty object (`{}`) when parsing fails.

### Testing

- ✅ Verified valid JSON is parsed correctly.
- ✅ Verified malformed JSON no longer crashes the endpoint.
- ✅ Confirmed invalid values fall back to an empty object.

