### PR TITLE
fix: add noopener noreferrer to portfolio export links

### DIFF
--- a/server/services/portfolioExportService.js
+++ b/server/services/portfolioExportService.js
@@ -205,7 +205,7 @@ const PDF_TEMPLATE = `<!DOCTYPE html>
       {{#if social_links}}
       <div class="social-links">
         {{#each social_links}}
-        <a href="{{this}}" class="social-link" target="_blank">{{@key}}</a>
+        <a href="{{this}}" class="social-link" target="_blank" rel="noopener noreferrer">{{@key}}</a>
         {{/each}}
       </div>
       {{/if}}
@@ -436,7 +436,7 @@ export const portfolioExportService = {
           ? `
       <div class="social-links">
         ${Object.entries(portfolio.social_links)
-          .map(([key, url]) => `<a href="${url}" class="social-link" target="_blank">${key}</a>`)
+          .map(([key, url]) => `<a href="${url}" class="social-link" target="_blank" rel="noopener noreferrer">${key}</a>`)
           .join('\n        ')}
       </div>`
           : ''


### PR DESCRIPTION
Closes #3738

## Description

This PR fixes a reverse tabnabbing vulnerability in `server/services/portfolioExportService.js`.

Previously, social links generated in the exported portfolio HTML and PDF used `target="_blank"` without the required `rel="noopener noreferrer"` attribute. This allowed the newly opened page to access `window.opener`, exposing users to reverse tabnabbing attacks.

This PR updates all external social links to include the appropriate security attributes while preserving the existing functionality.

### Changes Made

- Added `rel="noopener noreferrer"` to social links in the HTML export template.
- Added `rel="noopener noreferrer"` to social links in the PDF export template.
- Preserved the existing link behavior and export functionality.

### Testing

- ✅ Verified exported HTML contains `rel="noopener noreferrer"` on external links.
- ✅ Verified exported PDF template includes the security attributes.
- ✅ Confirmed links still open correctly in a new tab.

