### PR TITLE
fix: prevent reverse tabnabbing in ScheduledReports

### DIFF
--- a/admin-dashboard/src/pages/dashboard/ScheduledReports.jsx
+++ b/admin-dashboard/src/pages/dashboard/ScheduledReports.jsx
@@ -281,7 +281,7 @@ function ArchiveTab() {
   }, [load]);
 
   function handleDownload(id, filename) {
-    window.open(`${API}/archive/${id}/download`, '_blank');
+    window.open(`${API}/archive/${id}/download`, '_blank', 'noopener,noreferrer');
   }
 
   return (


### PR DESCRIPTION
# Summary

Added `noopener,noreferrer` to the `window.open()` call in `ScheduledReports` to prevent reverse tabnabbing.

## Related Issue

Closes #3758

## Type of Change

- [x] Bug Fix
- [x] Security Enhancement

## Changes Implemented

- Added `noopener,noreferrer` to the `window.open()` call in `ScheduledReports.jsx`.

## Technical Details

### Frontend

- Updated `admin-dashboard/src/pages/dashboard/ScheduledReports.jsx` to open download links securely.

## Testing

### Manual Testing

- [x] Verified the download still opens in a new tab.
- [x] Verified `window.opener` is no longer accessible.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Security reviewed
- [x] Ready for review