### PR TITLE
fix: handle invalid JSON parsing in financialController export endpoint

### DIFF
--- a/server/controllers/financialController.js
+++ b/server/controllers/financialController.js
@@ -162,7 +162,11 @@ export const exportReport = wrapAsync(async (req, res) => {
     return res.status(200).send(result);
   }
 
-  return sendSuccess(res, JSON.parse(result));
+  try {
+    return sendSuccess(res, JSON.parse(result));
+  } catch (error) {
+    return sendError(res, 500, 'Failed to parse report data as JSON');
+  }
 });
 
 export const getRevenueReport = wrapAsync(async (req, res) => {


### PR DESCRIPTION
# Summary

Wrapped `JSON.parse()` in a `try/catch` block in the financial export endpoint to prevent crashes when invalid JSON is returned.

## Related Issue

Closes #3759

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Wrapped `JSON.parse(result)` in a `try/catch`.
- Returns a proper error response when parsing fails.

## Technical Details

### Backend

- Updated `server/controllers/financialController.js` to safely handle invalid JSON returned by `exportReport()`.

## Testing

### Manual Testing

- [x] Verified valid JSON is parsed successfully.
- [x] Verified invalid JSON returns a 500 error instead of crashing.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review