### PR TITLE
fix: handle localStorage save failures in EventDetailPage

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -951,7 +951,10 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
           stored.push(localTicket);
           localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch {}
+        } catch (err) {
+          console.error('Failed to save ticket locally:', err);
+          setRegError('Warning: Could not save ticket to your device. Please take a screenshot.');
+        }
       }
     } catch (err) {
       if (err.message?.includes('waitlist')) {


### PR DESCRIPTION
# Summary

Added error handling and user feedback when saving event tickets to `localStorage` fails.

## Related Issue

Closes #3760

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Replaced the empty `catch` block with proper error handling.
- Logged the error for debugging.
- Displayed a warning message to inform users that the ticket could not be saved locally.

## Technical Details

### Frontend

- Updated `website/src/pages/events/EventDetailPage.jsx` to handle `localStorage` save failures gracefully.

## Testing

### Manual Testing

- [x] Verified tickets are saved successfully under normal conditions.
- [x] Verified an error message is shown when `localStorage` saving fails.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review