### PR TITLE
fix: apply status filter in ForumManager filteredThreads

### DIFF
--- a/admin-dashboard/src/pages/ForumManager.jsx
+++ b/admin-dashboard/src/pages/ForumManager.jsx
@@ -38,12 +38,16 @@ export function ForumManager() {
   }, [statusFilter]);
 
   const filteredThreads = useMemo(() => {
-    if (!searchQuery.trim()) return threads;
+    let result = threads;
+    if (statusFilter) {
+      result = result.filter((t) => t.status === statusFilter);
+    }
+    if (!searchQuery.trim()) return result;
     const q = searchQuery.toLowerCase();
-    return threads.filter(
+    return result.filter(
       (t) => t.title?.toLowerCase().includes(q) || t.content?.toLowerCase().includes(q)
     );
-  }, [threads, searchQuery]);
+  }, [threads, searchQuery, statusFilter]);
 
   const handleModerate = async (id, status) => {
     setModerating(id);


### PR DESCRIPTION
# Summary

Applied `statusFilter` to `filteredThreads` and added it to the `useMemo` dependency array so the status dropdown correctly filters forum threads.

## Related Issue

Closes #3820

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Applied `statusFilter` before search filtering.
- Added `statusFilter` to the `useMemo` dependency array.
- Preserved existing search functionality.

## Technical Details

### Frontend

- Updated `admin-dashboard/src/pages/ForumManager.jsx` to correctly filter threads based on the selected status.

## Testing

### Manual Testing

- [x] Verified the status dropdown filters threads correctly.
- [x] Verified search continues to work with the selected status filter.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review