### PR TITLE
fix: avoid full page skeleton reload in StreamManager

### DIFF
--- a/admin-dashboard/src/pages/StreamManager.jsx
+++ b/admin-dashboard/src/pages/StreamManager.jsx
@@ -69,7 +69,7 @@ export function StreamManager() {
         method: 'PATCH',
         body: JSON.stringify({ status }),
       });
-      await load();
+      setStreams((prev) => prev.map((s) => (s.id === id ? { ...s, status } : s)));
     } catch (e) {
       setError(e.message);
     }
@@ -79,7 +79,7 @@ export function StreamManager() {
     if (!window.confirm('Delete this stream?')) return;
     try {
       await fetchWithAuth(`/api/streams/${id}`, { method: 'DELETE' });
-      await load();
+      setStreams((prev) => prev.filter((s) => s.id !== id));
     } catch (e) {
       setError(e.message);
     }


### PR DESCRIPTION
# Summary

Replaced full page reloads with local state updates when updating or deleting streams, preventing the skeleton loader from flashing.

## Related Issue

Closes #3821

## Type of Change

- [x] Bug Fix


## Changes Implemented

- Removed `load()` calls after status updates and deletions.
- Updated the affected stream locally using state updates.
- Prevented unnecessary full page skeleton reloads.

## Technical Details

### Frontend

- Updated `admin-dashboard/src/pages/StreamManager.jsx` to use local state updates instead of reloading all streams.

## Testing

### Manual Testing

- [x] Verified status updates no longer trigger a full page skeleton.
- [x] Verified deleting a stream updates the list immediately.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review