### PR TITLE
fix: prevent race condition in payment webhook via idempotency key

### DIFF
--- a/server/migrations/1718791204000_add-idempotency-to-revenue-entries.js
+++ b/server/migrations/1718791204000_add-idempotency-to-revenue-entries.js
@@ -1,0 +1,37 @@
+/* Migration: Add Idempotency Key to Revenue Entries
+   Description: Adds an idempotency_key column with a UNIQUE constraint to the
+                revenue_entries table to prevent duplicate revenue records from
+                concurrent or retried payment webhook deliveries (issue #3844).
+   Version: 1.0.0
+*/
+
+export const up = (pgm) => {
+  // Add an optional idempotency_key column.
+  // Callers (webhook handlers) supply a stable key derived from the external
+  // payment provider's transaction / event ID so that retried or racing
+  // webhook deliveries for the same payment are deduplicated at the DB level.
+  pgm.addColumn('revenue_entries', {
+    idempotency_key: {
+      type: 'text',
+      notNull: false,
+      unique: true,
+      comment:
+        'Externally-supplied key (e.g. payment-provider transaction ID) used to ' +
+        'deduplicate concurrent or retried webhook deliveries.',
+    },
+  });
+
+  pgm.createIndex('revenue_entries', 'idempotency_key', {
+    name: 'idx_revenue_entries_idempotency_key',
+    unique: true,
+    where: 'idempotency_key IS NOT NULL',
+  });
+};
+
+export const down = (pgm) => {
+  pgm.dropIndex('revenue_entries', 'idempotency_key', {
+    name: 'idx_revenue_entries_idempotency_key',
+    ifExists: true,
+  });
+  pgm.dropColumn('revenue_entries', 'idempotency_key', { ifExists: true });
+};

--- a/server/repositories/financialRepository.js
+++ b/server/repositories/financialRepository.js
@@ -54,6 +54,7 @@ function mapRevenueRow(row) {
     isRefunded: row.is_refunded,
     refundAmount: Number(row.refund_amount || 0),
     taxAmount: Number(row.tax_amount || 0),
+    idempotencyKey: row.idempotency_key || null,
   };
 }
 
@@ -216,10 +217,58 @@ export const financialRepository = {
   },
 
   // --- Revenue ---
+  /**
+   * Creates a revenue entry in an idempotent manner.
+   *
+   * When `revenue.idempotencyKey` is provided the INSERT uses an ON CONFLICT
+   * DO NOTHING clause on the unique `idempotency_key` column.  If a row with
+   * that key already exists (i.e. a concurrent or retried webhook already
+   * committed it) the INSERT is a no-op and we fetch and return the existing
+   * record instead of creating a duplicate — preventing double-crediting.
+   */
   async createRevenue(revenue) {
     return withDb(async (client) => {
+      const idempotencyKey = revenue.idempotencyKey || null;
+
+      if (idempotencyKey) {
+        // Idempotent path: attempt insert; silently skip on duplicate key.
+        const { rows } = await client.query(
+          `INSERT INTO revenue_entries
+             (budget_id, event_id, source, amount, description, received_at,
+              created_by, payment_method, is_refunded, refund_amount, tax_amount,
+              idempotency_key)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+           ON CONFLICT (idempotency_key) DO NOTHING
+           RETURNING *`,
+          [
+            revenue.budgetId || null,
+            revenue.eventId || null,
+            revenue.source,
+            revenue.amount,
+            revenue.description || null,
+            revenue.receivedAt || new Date(),
+            revenue.createdBy,
+            revenue.paymentMethod || 'card',
+            revenue.isRefunded !== undefined ? revenue.isRefunded : false,
+            revenue.refundAmount || 0,
+            revenue.taxAmount || 0,
+            idempotencyKey,
+          ]
+        );
+
+        if (rows.length > 0) {
+          return mapRevenueRow(rows[0]);
+        }
+
+        // Row already existed — return the existing record.
+        return this.findRevenueByIdempotencyKey(idempotencyKey, client);
+      }
+
+      // Non-idempotent path (no key supplied): plain insert.
       const { rows } = await client.query(
-        `INSERT INTO revenue_entries (budget_id, event_id, source, amount, description, received_at, created_by, payment_method, is_refunded, refund_amount, tax_amount)
+        `INSERT INTO revenue_entries
+           (budget_id, event_id, source, amount, description, received_at,
+            created_by, payment_method, is_refunded, refund_amount, tax_amount)
          VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          RETURNING *`,
         [
@@ -238,6 +287,22 @@ export const financialRepository = {
       );
       return mapRevenueRow(rows[0]);
     });
+  },
+
+  /**
+   * Looks up an existing revenue entry by its idempotency key.
+   * Accepts an optional already-open `client` to participate in the same
+   * transaction when called from createRevenue.
+   */
+  async findRevenueByIdempotencyKey(idempotencyKey, existingClient = null) {
+    const run = async (client) => {
+      const { rows } = await client.query(
+        'SELECT * FROM revenue_entries WHERE idempotency_key = $1',
+        [idempotencyKey]
+      );
+      return rows.length ? mapRevenueRow(rows[0]) : null;
+    };
+    return existingClient ? run(existingClient) : withDb(run);
   },
 
   async getRevenueById(id) {

--- a/server/services/financialService.js
+++ b/server/services/financialService.js
@@ -224,12 +224,23 @@ export class FinancialService {
   }
 
   // --- Revenue ---
+  /**
+   * Creates a new revenue entry.
+   *
+   * Accepts an optional `idempotencyKey` inside `revenueData` (typically the
+   * payment-provider transaction or webhook event ID).  When present, the
+   * underlying INSERT is idempotent: concurrent or retried webhook deliveries
+   * carrying the same key are deduplicated at the database level and return
+   * the existing record rather than creating a duplicate.
+   */
   async createRevenue(revenueData, user) {
     this.checkAccess(user, 'create_revenue');
 
     const revenue = {
       ...revenueData,
       createdBy: user.id,
+      // Forward the idempotency key to the repository layer unchanged.
+      idempotencyKey: revenueData.idempotencyKey || null,
     };
 
     const newRevenue = await financialRepository.createRevenue(revenue);

--- a/server/test/financials.test.js
+++ b/server/test/financials.test.js
@@ -538,3 +538,122 @@ test('Financial API Endpoints Integration', async (t) => {
 
   server.close();
 });
+
+// --- Idempotency Tests (issue #3844) ---
+
+test('createRevenue with idempotencyKey deduplicates concurrent webhook deliveries', async () => {
+  let insertCallCount = 0;
+
+  const existingRevenueRow = {
+    id: 'rev_idem_1',
+    budget_id: 'b_1',
+    event_id: 'evt_1',
+    source: 'Ticket Sales',
+    amount: '500',
+    description: 'Webhook payment',
+    received_at: new Date().toISOString(),
+    created_by: 'usr_admin',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    payment_method: 'card',
+    is_refunded: false,
+    refund_amount: '0',
+    tax_amount: '0',
+    idempotency_key: 'txn_abc123',
+  };
+
+  setWithDbOverride(async (fn) => {
+    const mockClient = {
+      query: async (sql, params) => {
+        const sqlLower = sql.toLowerCase();
+
+        if (sqlLower.includes('insert into revenue_entries') && sqlLower.includes('on conflict')) {
+          insertCallCount++;
+          // First call inserts successfully; second simulates ON CONFLICT DO NOTHING (empty rows).
+          return { rows: insertCallCount === 1 ? [existingRevenueRow] : [], rowCount: 0 };
+        }
+
+        if (sqlLower.includes('where idempotency_key = $1')) {
+          return { rows: [existingRevenueRow], rowCount: 1 };
+        }
+
+        if (sqlLower.includes('insert into financial_audit_trail')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    return fn(mockClient);
+  });
+
+  const revenueData = {
+    budgetId: 'b_1',
+    eventId: 'evt_1',
+    source: 'Ticket Sales',
+    amount: 500,
+    idempotencyKey: 'txn_abc123',
+  };
+
+  // First webhook delivery — should succeed.
+  const first = await financialService.createRevenue(revenueData, mockAdminUser);
+  assert.equal(first.id, 'rev_idem_1');
+  assert.equal(first.idempotencyKey, 'txn_abc123');
+
+  // Concurrent / retried delivery with the SAME key — must return the same record.
+  const second = await financialService.createRevenue(revenueData, mockAdminUser);
+  assert.equal(second.id, 'rev_idem_1', 'Duplicate webhook must return the existing record');
+  assert.equal(second.idempotencyKey, 'txn_abc123');
+});
+
+test('createRevenue without idempotencyKey creates independent records', async () => {
+  let insertCount = 0;
+
+  setWithDbOverride(async (fn) => {
+    const mockClient = {
+      query: async (sql, params) => {
+        const sqlLower = sql.toLowerCase();
+
+        if (sqlLower.includes('insert into revenue_entries')) {
+          insertCount++;
+          return {
+            rows: [
+              {
+                id: `rev_plain_${insertCount}`,
+                budget_id: 'b_1',
+                event_id: 'evt_1',
+                source: 'Merchandise',
+                amount: '100',
+                description: null,
+                received_at: new Date().toISOString(),
+                created_by: 'usr_admin',
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+                payment_method: 'card',
+                is_refunded: false,
+                refund_amount: '0',
+                tax_amount: '0',
+                idempotency_key: null,
+              },
+            ],
+            rowCount: 1,
+          };
+        }
+
+        if (sqlLower.includes('insert into financial_audit_trail')) {
+          return { rows: [], rowCount: 1 };
+        }
+
+        return { rows: [], rowCount: 0 };
+      },
+    };
+    return fn(mockClient);
+  });
+
+  const base = { budgetId: 'b_1', eventId: 'evt_1', source: 'Merchandise', amount: 100 };
+  const r1 = await financialService.createRevenue(base, mockAdminUser);
+  const r2 = await financialService.createRevenue(base, mockAdminUser);
+
+  assert.notEqual(r1.id, r2.id, 'Without idempotency key each call must produce a distinct record');
+  assert.equal(insertCount, 2);
+});


### PR DESCRIPTION
## Summary

Resolves #3844

Concurrent or retried payment success webhook deliveries for the same transaction ID could race past any in-application duplicate check and both commit to the database, double-crediting the budget. This PR eliminates that window by pushing the deduplication responsibility to the database layer.

## Root Cause

`createRevenue` had no mechanism to detect that an in-flight concurrent call for the same payment event had already (or was about to) insert a record. Any application-level check-then-insert sequence is inherently subject to a time-of-check / time-of-use (TOCTOU) race.

## Solution

Introduce a stable, provider-supplied **idempotency key** (e.g. the payment gateway's transaction ID or webhook event ID) and store it in a new `idempotency_key` column on `revenue_entries` with a `UNIQUE` constraint.

The repository-layer `createRevenue` now uses `INSERT … ON CONFLICT (idempotency_key) DO NOTHING`, which is executed **atomically** by PostgreSQL. The second (and any subsequent) concurrent INSERT for the same key is a silent no-op; the service then fetches and returns the existing record, ensuring exactly-once crediting.

Calls without a key continue to behave as before (plain `INSERT`).

## Files Changed

| File | Change |
|------|--------|
| `server/migrations/1718791204000_add-idempotency-to-revenue-entries.js` | New migration — adds `idempotency_key` column with unique partial index |
| `server/repositories/financialRepository.js` | Idempotent INSERT path; `findRevenueByIdempotencyKey` helper; updated row mapper |
| `server/services/financialService.js` | Threads `idempotencyKey` from request data to the repository |
| `server/test/financials.test.js` | Two new test cases verifying idempotency behaviour |

## Testing

```
# New tests pass (9 & 10)
node --experimental-vm-modules --test server/test/financials.test.js
ok 9 - createRevenue with idempotencyKey deduplicates concurrent webhook deliveries
ok 10 - createRevenue without idempotencyKey creates independent records
# pass 9  (test 8 failure is a pre-existing syntax error in index.js on main)
```

Signed-off-by: atul-upadhyay-7 <atul-upadhyay-7@users.noreply.github.com>