### PR TITLE
feat: Implement rate limiting for Event Registration API

### DIFF
--- a/server/middleware/rateLimiter.js
+++ b/server/middleware/rateLimiter.js
@@ -10,7 +10,6 @@ import logger from '../utils/logger.js';
 // specific proxy hop count) is explicitly initialized in the main server app entry file.
 // ---------------------------------------------------------------------------
 
-
 // ---------------------------------------------------------------------------
 // Shared env-var config for the general API limiter
 // Override via API_RATE_LIMIT_WINDOW_MS and API_RATE_LIMIT_MAX in .env
@@ -185,25 +184,48 @@ export const syncRateLimiter = rateLimit({
   handler: createLimiterHandler('Sync rate limit exceeded', 'Too many sync requests.'),
 });
 
-// Event registration rate limiter — 10 requests per IP per hour
-export const eventRegistrationLimiter = rateLimit({
+// Event registration rate limiter — 100 requests per IP per hour
+export const eventRegistrationIpLimiter = rateLimit({
   windowMs: 60 * 60 * 1000,
-  max: 10,
+  max: 100,
   standardHeaders: true,
   legacyHeaders: true,
-  store: createRateLimitStore('rate-limit:event-reg:'),
+  store: createRateLimitStore('rate-limit:event-reg-ip:'),
   handler: (req, res, _next, options) => {
-    logger.warn('Event registration rate limit exceeded', {
+    logger.warn('Event registration IP rate limit exceeded', {
       ip: req.ip,
       path: req.originalUrl || req.path,
       method: req.method,
     });
-    res.status(options.statusCode).json({
-      error: 'Too many registration attempts. Please try again later.',
+    res.status(429).json({
+      error: 'Too many registration attempts from this IP. Please try again later.',
     });
   },
 });
 
+// Event registration rate limiter — 5 requests per User per minute
+export const eventRegistrationUserLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 5,
+  standardHeaders: true,
+  legacyHeaders: true,
+  keyGenerator: (req) => {
+    // If user is authenticated, limit by user ID; otherwise fallback to IP
+    return req.user?.id || req.ip;
+  },
+  store: createRateLimitStore('rate-limit:event-reg-user:'),
+  handler: (req, res, _next, options) => {
+    logger.warn('Event registration user rate limit exceeded', {
+      userId: req.user?.id || 'unauthenticated',
+      ip: req.ip,
+      path: req.originalUrl || req.path,
+      method: req.method,
+    });
+    res.status(429).json({
+      error: 'Too many registration attempts. Please try again in a minute.',
+    });
+  },
+});
 
 // Sync rate limiter: 5 requests per minute per IP.
 export const syncRateLimiter = rateLimit({
@@ -250,7 +272,8 @@ export function validateLimiters() {
     activityAuthRateLimiter,
     syncRateLimiter,
     portfolioRateLimiter,
-    eventRegistrationLimiter,
+    eventRegistrationIpLimiter,
+    eventRegistrationUserLimiter,
     searchRateLimiter,
   };
 

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -2,7 +2,6 @@ import { Router } from 'express';
 import { throttleMiddleware } from '../middleware/throttleMiddleware.js';
 import settingsRouter from './settingsRoutes.js';
 import rateLimitAdminRoutes from './rateLimitAdminRoutes.js';
-import settingsRouter from './settingsRoutes.js';
 import { auditLogController } from '../controllers/auditLogController.js';
 import * as eventsController from '../controllers/eventsController.js';
 import * as activityEventsController from '../controllers/activityEventsController.js';
@@ -18,7 +17,7 @@ import { healthRepository } from '../repositories/healthRepository.js';
 import eventCollaboratorRoutes from './eventCollaboratorRoutes.js';
 import { eventsRepository } from '../repositories/eventsRepository.js';
 import { authRateLimiter, protectedActionRateLimiter } from '../middleware/authRateLimiter.js';
-import { eventRegistrationLimiter } from '../middleware/rateLimiter.js';
+import { eventRegistrationIpLimiter, eventRegistrationUserLimiter } from '../middleware/rateLimiter.js';
 import { portfolioRepository } from '../repositories/portfolioRepository.js';
 import { achievementsRepository } from '../repositories/achievementsRepository.js';
 import { portfolioService } from '../services/portfolioService.js';
@@ -164,14 +163,16 @@ router.get('/api/content/events', eventsController.listEvents);
 router.get('/api/content/banners', bannersController.listActiveBanners);
 router.post(
   '/api/content/events/:eventId/register',
-  eventRegistrationLimiter,
+  eventRegistrationIpLimiter,
+  eventRegistrationUserLimiter,
   validate(eventRegistrationSchema),
   eventRegistrationController.registerForEvent
 );
 router.get('/api/content/events/:eventId/calendar', eventRegistrationController.getEventCalendar);
 router.post(
   '/api/content/events/:eventId/cancel',
-  eventRegistrationLimiter,
+  eventRegistrationIpLimiter,
+  eventRegistrationUserLimiter,
   requireStudentAuth,
   validate(emailSchema),
   eventRegistrationController.cancelRegistration
@@ -187,7 +188,8 @@ router.post(
 );
 router.delete(
   '/api/content/events/:eventId/waitlist',
-  eventRegistrationLimiter,
+  eventRegistrationIpLimiter,
+  eventRegistrationUserLimiter,
   validate(emailSchema),
   eventRegistrationController.leaveWaitlist
 );


### PR DESCRIPTION
### What does this PR do?
Implements rate limiting for the event registration API to prevent bot spamming and fake user generation.

### Description of Task to be completed?
- Implemented per-user rate limit (max 5 registrations per minute).
- Implemented per-IP rate limit (max 100 requests per hour).
- Configured 429 (Too Many Requests) response when limits are exceeded.
- Included `Retry-After` header compatibility via standard `express-rate-limit` headers.

### How should this be manually tested?
1. Start the server and send a POST request to `/api/content/events/:eventId/register`.
2. Send more than 5 requests within one minute with the same user ID (or IP if unauthenticated).
3. Observe the `429 Too Many Requests` response.
4. Verify the `Retry-After` headers are correctly present.

### Relevant related issues
Fixes #1524
