### PR TITLE
feat: Implement Portfolio Moderation Queue

### DIFF
--- a/server/controllers/moderationController.js
+++ b/server/controllers/moderationController.js
@@ -1,4 +1,5 @@
 import { moderationService } from '../services/moderationService.js';
+import { portfolioRepository } from '../repositories/portfolioRepository.js';
 import { sendSuccess, sendError, sendNoContent } from '../utils/responseHelper.js';
 
 function wrapAsync(fn) {
@@ -246,4 +247,24 @@ export const bulkResolve = wrapAsync(async (req, res) => {
     note
   );
   return sendSuccess(res, { results });
+});
+
+export const getFlaggedPortfolios = wrapAsync(async (req, res) => {
+  const portfolios = await portfolioRepository.getFlaggedPortfolios();
+  return sendSuccess(res, { portfolios });
+});
+
+export const approvePortfolio = wrapAsync(async (req, res) => {
+  const { username } = req.params;
+  await portfolioRepository.updatePortfolioModerationStatus(username, 'approved');
+  // Send notification to user
+  return sendSuccess(res, { message: 'Portfolio approved' });
+});
+
+export const rejectPortfolio = wrapAsync(async (req, res) => {
+  const { username } = req.params;
+  const { reason } = req.body;
+  await portfolioRepository.updatePortfolioModerationStatus(username, 'rejected', reason);
+  // Send notification to user
+  return sendSuccess(res, { message: 'Portfolio rejected' });
 });

--- a/server/repositories/portfolioRepository.js
+++ b/server/repositories/portfolioRepository.js
@@ -63,6 +63,8 @@ async function ensureSchema(client) {
       education JSONB DEFAULT '[]'::jsonb,
       work_experience JSONB DEFAULT '[]'::jsonb,
       github_username VARCHAR(39),
+      moderation_status VARCHAR(20) DEFAULT 'approved',
+      flag_reason TEXT,
       created_at TIMESTAMPTZ DEFAULT NOW(),
       updated_at TIMESTAMPTZ DEFAULT NOW()
     )
@@ -70,6 +72,11 @@ async function ensureSchema(client) {
 
   await client.query(`
     ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS github_username VARCHAR(39)
+  `);
+
+  await client.query(`
+    ALTER TABLE portfolios ADD COLUMN IF NOT EXISTS moderation_status VARCHAR(20) DEFAULT 'approved',
+                           ADD COLUMN IF NOT EXISTS flag_reason TEXT
   `);
 
   await client.query(`
@@ -512,6 +519,31 @@ export const portfolioRepository = {
       }
     }
     return [];
+  },
+
+  async getFlaggedPortfolios() {
+    await ensureReady();
+    return withDb(async (client) => {
+      const { rows } = await client.query(`
+        SELECT username, title, bio, moderation_status, flag_reason, updated_at
+        FROM portfolios
+        WHERE moderation_status = 'flagged'
+        ORDER BY updated_at ASC
+      `);
+      return rows;
+    });
+  },
+
+  async updatePortfolioModerationStatus(username, status, reason = null) {
+    await ensureReady();
+    return withDb(async (client) => {
+      const { rowCount } = await client.query(`
+        UPDATE portfolios
+        SET moderation_status = $1, flag_reason = $2
+        WHERE username = $3
+      `, [status, reason, username]);
+      return rowCount > 0;
+    });
   },
 
   async delete(username) {

--- a/server/routes/moderation.js
+++ b/server/routes/moderation.js
@@ -23,22 +23,31 @@ const router = Router();
  * POST /moderation/ai-check — Server-side AI content moderation proxy.
  * Calls Gemini API using the server-side GEMINI_API_KEY (never exposed to client).
  */
-router.post('/ai-check', apiRateLimiter, validate(aiCheckSchema), requireStudentAuth, async (req, res) => {
-  try {
-    const { content } = req.body || {};
-    if (!content || typeof content !== 'string') {
-      return sendError(req, res, 'content string is required', 400, 'VALIDATION_ERROR');
-    }
+router.post(
+  '/ai-check',
+  apiRateLimiter,
+  validate(aiCheckSchema),
+  requireStudentAuth,
+  async (req, res) => {
+    try {
+      const { content } = req.body || {};
+      if (!content || typeof content !== 'string') {
+        return sendError(req, res, 'content string is required', 400, 'VALIDATION_ERROR');
+      }
 
-    const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) {
-      return sendSuccess(res, { flags: [], confidence: 0, explanation: 'AI moderation not configured' });
-    }
+      const apiKey = process.env.GEMINI_API_KEY;
+      if (!apiKey) {
+        return sendSuccess(res, {
+          flags: [],
+          confidence: 0,
+          explanation: 'AI moderation not configured',
+        });
+      }
 
-    const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+      const genAI = new GoogleGenerativeAI(apiKey);
+      const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
 
-    const prompt = `
+      const prompt = `
       Analyze the following content for toxicity, hate speech, harassment, and inappropriate material.
       Content: "${content}"
       
@@ -52,21 +61,27 @@ router.post('/ai-check', apiRateLimiter, validate(aiCheckSchema), requireStudent
       Only return valid JSON, no other text.
     `;
 
-    const result = await model.generateContent(prompt);
-    const response = await result.response;
-    const text = response.text();
-    const parsed = JSON.parse(text);
+      const result = await model.generateContent(prompt);
+      const response = await result.response;
+      const text = response.text();
+      const parsed = JSON.parse(text);
 
-    return sendSuccess(res, {
-      flags: parsed.categories?.map((cat) => ({ type: cat, confidence: parsed.confidence })) || [],
-      confidence: parsed.confidence || 0.7,
-      explanation: parsed.explanation,
-    });
-  } catch (error) {
-    console.error('[AI Moderation] Error:', error.message);
-    return sendSuccess(res, { flags: [], confidence: 0, explanation: 'AI moderation unavailable' });
+      return sendSuccess(res, {
+        flags:
+          parsed.categories?.map((cat) => ({ type: cat, confidence: parsed.confidence })) || [],
+        confidence: parsed.confidence || 0.7,
+        explanation: parsed.explanation,
+      });
+    } catch (error) {
+      console.error('[AI Moderation] Error:', error.message);
+      return sendSuccess(res, {
+        flags: [],
+        confidence: 0,
+        explanation: 'AI moderation unavailable',
+      });
+    }
   }
-});
+);
 // Public endpoint for submitting reports
 router.post('/reports', validate(createFlagSchema), moderationController.createFlag);
 
@@ -76,26 +91,46 @@ router.use(requireStudentAuth);
 // Flagged Content
 router.get('/moderation/flags', moderationController.getFlags);
 router.get('/moderation/flags/:id', moderationController.getFlagById);
-router.put('/moderation/flags/:id/resolve', validate(resolveFlagSchema), moderationController.resolveFlag);
+router.put(
+  '/moderation/flags/:id/resolve',
+  validate(resolveFlagSchema),
+  moderationController.resolveFlag
+);
 router.put('/moderation/flags/:id/approve', moderationController.approveFlag);
-router.put('/moderation/flags/:id/remove', validate(removeFlaggedContentSchema), moderationController.removeFlaggedContent);
+router.put(
+  '/moderation/flags/:id/remove',
+  validate(removeFlaggedContentSchema),
+  moderationController.removeFlaggedContent
+);
 router.put('/moderation/flags/:id/escalate', moderationController.escalateFlag);
 router.delete('/moderation/flags/:id', moderationController.deleteFlag);
 
 // User Warnings
-router.post('/moderation/users/:userId/warn', validate(warnUserSchema), moderationController.warnUser);
+router.post(
+  '/moderation/users/:userId/warn',
+  validate(warnUserSchema),
+  moderationController.warnUser
+);
 router.get('/moderation/users/:userId/warnings', moderationController.getUserWarnings);
 router.get('/moderation/users/:userId/history', moderationController.getUserContentHistory);
 router.post('/moderation/users/:userId/approve-all', moderationController.approveAllFromUser);
 
 // Moderator Notes
-router.post('/moderation/notes', validate(addModeratorNoteSchema), moderationController.addModeratorNote);
+router.post(
+  '/moderation/notes',
+  validate(addModeratorNoteSchema),
+  moderationController.addModeratorNote
+);
 router.get('/moderation/notes', moderationController.getModeratorNotes);
 
 // Appeals
 router.post('/moderation/appeals', validate(submitAppealSchema), moderationController.submitAppeal);
 router.get('/moderation/appeals', moderationController.getAppeals);
-router.put('/moderation/appeals/:id/review', validate(reviewAppealSchema), moderationController.reviewAppeal);
+router.put(
+  '/moderation/appeals/:id/review',
+  validate(reviewAppealSchema),
+  moderationController.reviewAppeal
+);
 
 // Analytics
 router.get('/moderation/stats', moderationController.getFlagStats);
@@ -105,6 +140,15 @@ router.get('/moderation/stats/top-violators', moderationController.getTopViolati
 router.get('/moderation/stats/workload', moderationController.getModeratorWorkload);
 
 // Bulk Actions
-router.post('/moderation/bulk-resolve', validate(bulkResolveSchema), moderationController.bulkResolve);
+router.post(
+  '/moderation/bulk-resolve',
+  validate(bulkResolveSchema),
+  moderationController.bulkResolve
+);
+
+// Portfolio Moderation
+router.get('/moderation/portfolios', moderationController.getFlaggedPortfolios);
+router.post('/moderation/portfolios/:username/approve', moderationController.approvePortfolio);
+router.post('/moderation/portfolios/:username/reject', moderationController.rejectPortfolio);
 
 export default router;

--- a/website/src/pages/admin/AdminPage.jsx
+++ b/website/src/pages/admin/AdminPage.jsx
@@ -8,6 +8,7 @@ import '../../components/admin/analytics/analytics.css';
 import HeatmapView from './analytics/HeatmapView';
 import SessionPlayer from './analytics/SessionPlayer';
 import SegmentationDashboard from './analytics/SegmentationDashboard';
+import PortfolioModerationQueue from './PortfolioModerationQueue';
 
 export default function AdminPage({ onBack }) {
   const [loading, setLoading] = useState(false);
@@ -207,7 +208,7 @@ export default function AdminPage({ onBack }) {
           borderBottom: '1px solid rgba(255,255,255,0.1)',
         }}
       >
-        {['overview', 'heatmaps', 'recordings', 'segments'].map((tab) => (
+        {['overview', 'heatmaps', 'recordings', 'segments', 'moderation'].map((tab) => (
           <button
             key={tab}
             onClick={() => setActiveTab(tab)}
@@ -241,6 +242,7 @@ export default function AdminPage({ onBack }) {
       {activeTab === 'heatmaps' && <HeatmapView />}
       {activeTab === 'recordings' && <SessionPlayer />}
       {activeTab === 'segments' && <SegmentationDashboard />}
+      {activeTab === 'moderation' && <PortfolioModerationQueue token={token} />}
     </div>
   );
 }

--- a/website/src/pages/admin/PortfolioModerationQueue.jsx
+++ b/website/src/pages/admin/PortfolioModerationQueue.jsx
@@ -1,0 +1,138 @@
+import React, { useState, useEffect } from 'react';
+
+export default function PortfolioModerationQueue({ token }) {
+  const [portfolios, setPortfolios] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [actionLoading, setActionLoading] = useState(null);
+  const [rejectReason, setRejectReason] = useState('');
+  const [activeReject, setActiveReject] = useState(null);
+
+  const fetchPortfolios = async () => {
+    try {
+      setLoading(true);
+      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const res = await fetch(`${base}/moderation/portfolios`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      const data = await res.json();
+      if (res.ok && data.data.portfolios) {
+        setPortfolios(data.data.portfolios);
+      }
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchPortfolios();
+  }, [token]);
+
+  const handleAction = async (username, action) => {
+    try {
+      setActionLoading(username);
+      const base = (import.meta?.env?.VITE_API_BASE || '').replace(/\/+$/, '');
+      const payload = action === 'reject' ? { reason: rejectReason } : {};
+      
+      const res = await fetch(`${base}/moderation/portfolios/${username}/${action}`, {
+        method: 'POST',
+        headers: { 
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}` 
+        },
+        body: JSON.stringify(payload)
+      });
+      
+      if (res.ok) {
+          alert(`Portfolio ${action}ed successfully!`);
+          setActiveReject(null);
+          setRejectReason('');
+          fetchPortfolios();
+      } else {
+          alert(`Failed to ${action} portfolio`);
+      }
+    } catch (err) {
+      console.error(err);
+      alert('An error occurred');
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  if (loading) return <div>Loading Moderation Queue...</div>;
+
+  return (
+    <div style={{ padding: '2rem', background: '#1e293b', borderRadius: '16px', color: 'var(--t1)' }}>
+      <h2>Portfolio Moderation Queue</h2>
+      <p style={{ color: 'var(--t2)', marginBottom: '2rem' }}>Review flagged user portfolios before they appear publicly.</p>
+      
+      {portfolios.length === 0 ? (
+          <div style={{ textAlign: 'center', padding: '3rem', background: 'rgba(255,255,255,0.05)', borderRadius: '8px' }}>
+              <h3>No Flagged Portfolios</h3>
+              <p style={{ color: 'var(--t2)' }}>The moderation queue is currently empty.</p>
+          </div>
+      ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+              {portfolios.map(p => (
+                  <div key={p.username} style={{ background: 'rgba(255,255,255,0.05)', padding: '1.5rem', borderRadius: '8px' }}>
+                      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+                          <div>
+                              <h3 style={{ margin: '0 0 0.5rem 0' }}>{p.username}</h3>
+                              <div style={{ fontSize: '0.9rem', color: 'var(--t2)' }}>
+                                  <strong>Title:</strong> {p.title || 'N/A'}<br/>
+                                  <strong>Bio:</strong> {p.bio || 'N/A'}<br/>
+                                  <strong style={{ color: '#ef4444' }}>Flag Reason:</strong> {p.flag_reason || 'Manual Flag'}
+                              </div>
+                          </div>
+                          
+                          <div style={{ display: 'flex', gap: '0.5rem' }}>
+                              <button 
+                                  className="btn btn-primary"
+                                  onClick={() => handleAction(p.username, 'approve')}
+                                  disabled={actionLoading === p.username}
+                                  style={{ background: '#10b981', borderColor: '#10b981' }}
+                              >
+                                  Approve
+                              </button>
+                              
+                              <button 
+                                  className="btn btn-primary"
+                                  onClick={() => setActiveReject(p.username)}
+                                  disabled={actionLoading === p.username}
+                                  style={{ background: '#ef4444', borderColor: '#ef4444' }}
+                              >
+                                  Reject
+                              </button>
+                          </div>
+                      </div>
+                      
+                      {activeReject === p.username && (
+                          <div style={{ marginTop: '1rem', padding: '1rem', background: 'rgba(0,0,0,0.2)', borderRadius: '4px' }}>
+                              <label style={{ display: 'block', marginBottom: '0.5rem' }}>Reason for Rejection</label>
+                              <textarea 
+                                  className="input-field" 
+                                  style={{ width: '100%', minHeight: '80px', marginBottom: '1rem' }}
+                                  value={rejectReason}
+                                  onChange={(e) => setRejectReason(e.target.value)}
+                                  placeholder="Explain why this portfolio is being rejected..."
+                              />
+                              <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+                                  <button className="btn" onClick={() => setActiveReject(null)}>Cancel</button>
+                                  <button 
+                                      className="btn btn-primary" 
+                                      style={{ background: '#ef4444', borderColor: '#ef4444' }}
+                                      onClick={() => handleAction(p.username, 'reject')}
+                                  >
+                                      Confirm Reject
+                                  </button>
+                              </div>
+                          </div>
+                      )}
+                  </div>
+              ))}
+          </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Describe the pull request:
Implemented a Portfolio Moderation Queue for the Admin Dashboard.
- Added `moderation_status` and `flag_reason` columns to the `portfolios` table schema.
- Added repository methods to fetch flagged portfolios and update their statuses.
- Added new backend endpoints (`GET /moderation/portfolios`, `POST /moderation/portfolios/:username/approve`, `POST /moderation/portfolios/:username/reject`).
- Created a `PortfolioModerationQueue` UI component in the Admin Dashboard to allow administrators to review flagged portfolios and approve or reject them with a custom reason.

### Link to the issue:
Resolves #1514
