### PR TITLE
fix: remove duplicate rows declaration in upsertFromOAuth

### DIFF
--- a/server/repositories/studentUsersRepository.js
+++ b/server/repositories/studentUsersRepository.js
@@ -142,18 +142,6 @@ export const studentUsersRepository = {
         }
       }
 
-      const { rows } = await client.query(
-        `INSERT INTO student_users (provider, provider_id, email, full_name, avatar_url, last_login_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-         ON CONFLICT (provider, provider_id) DO UPDATE SET
-           email = EXCLUDED.email,
-           full_name = COALESCE(NULLIF(EXCLUDED.full_name, ''), student_users.full_name),
-           avatar_url = COALESCE(NULLIF(EXCLUDED.avatar_url, ''), student_users.avatar_url),
-           last_login_at = NOW(),
-           updated_at = NOW()
-         RETURNING *`,
-        [provider, providerId, email, fullName || null, avatarUrl || null]
-      );
       return rows[0];
     });
   },


### PR DESCRIPTION
# Summary

Removed the duplicate `const { rows }` declaration in `upsertFromOAuth` to prevent a `SyntaxError` during OAuth login.

## Related Issue

Fixes #3885

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Removed the duplicate `const { rows }` declaration.
- Kept a single `INSERT ... ON CONFLICT DO UPDATE ... RETURNING *` query.
- Preserved the existing OAuth upsert functionality.

## Technical Details

### Backend

- Updated `server/repositories/studentUsersRepository.js` to eliminate the duplicate variable declaration.

## Testing

### Manual Testing

- [x] Verified the file compiles without duplicate declaration errors.
- [x] Verified the OAuth upsert logic remains intact.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review