### PR TITLE
fix: prevent maintenance ID collisions and validate maintenance windows

### DIFF
--- a/server/services/maintenanceService.js
+++ b/server/services/maintenanceService.js
@@ -40,8 +40,13 @@ const getMaintenanceById = async (id) =>
 
 // Create
 const createMaintenance = async (data) => {
+  if (data.startTime && data.endTime && new Date(data.startTime) >= new Date(data.endTime)) {
+    throw new Error('Invalid maintenance window: startTime must be before endTime');
+  }
+
+  const nextId = maintenanceList.length > 0 ? Math.max(...maintenanceList.map((m) => m.id)) + 1 : 1;
   const maintenance = {
-    id: maintenanceList.length + 1,
+    id: nextId,
     status: "Scheduled",
     createdAt: new Date().toISOString(),
     ...data,
@@ -58,6 +63,12 @@ const updateMaintenance = async (id, data) => {
   );
 
   if (index === -1) return null;
+
+  const startTime = data.startTime || maintenanceList[index].startTime;
+  const endTime = data.endTime || maintenanceList[index].endTime;
+  if (startTime && endTime && new Date(startTime) >= new Date(endTime)) {
+    throw new Error('Invalid maintenance window: startTime must be before endTime');
+  }
 
   maintenanceList[index] = {
     ...maintenanceList[index],


### PR DESCRIPTION
# Summary

Updated maintenance record creation to generate monotonic IDs and added validation to ensure maintenance windows have a valid time range.

## Related Issue

Fixes #3891

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Replaced `length + 1` ID generation with a monotonic `max(id) + 1` strategy.
- Added validation to ensure `startTime` is before `endTime` during creation.
- Added the same validation for maintenance updates.

## Technical Details

### Backend

- Updated `server/services/maintenanceService.js` to prevent ID reuse after deletions and reject invalid maintenance windows.

## Testing

### Manual Testing

- [x] Verified newly created records receive unique IDs after deletions.
- [x] Verified invalid maintenance windows are rejected on create and update.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review