### PR TITLE
fix : nullish defaults in createFlag and fix getStaleFlags interval casting

### DIFF
--- a/server/repositories/featureFlagsRepository.js
+++ b/server/repositories/featureFlagsRepository.js
@@ -42,14 +42,14 @@ export const featureFlagsRepository = {
           name,
           description || '',
           type,
-          is_active !== undefined ? is_active : true,
-          rollout_percentage !== undefined ? rollout_percentage : 100,
+          is_active ?? true,
+          rollout_percentage ?? 100,
           JSON.stringify(target_users || []),
           JSON.stringify(target_roles || []),
           JSON.stringify(environments || []),
           start_time || null,
           end_time || null,
-          fallback_value !== undefined ? fallback_value : false,
+          fallback_value ?? false,
         ]
       );
       return rows[0];
@@ -189,7 +189,7 @@ export const featureFlagsRepository = {
     return withDb(async (client) => {
       const { rows } = await client.query(
         `SELECT * FROM feature_flags 
-         WHERE updated_at < NOW() - CAST($1 || ' days' AS INTERVAL)`,
+         WHERE updated_at < NOW() - make_interval(days => $1::double precision)`,
         [staleThresholdDays]
       );
       return rows;


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed two bugs in `server/repositories/featureFlagsRepository.js`:

1. **`createFlag`** (issue #3943): Replaced `!== undefined` ternary checks with nullish coalescing (`??`) for `is_active`, `rollout_percentage`, and `fallback_value`. This ensures that explicit `null` values in API requests trigger the default values (`true`, `100`, `false`) instead of bypassing the defaults and causing `NOT NULL` constraint violations.

2. **`getStaleFlags`** (issue #3944): Replaced the problematic `CAST($1 || ' days' AS INTERVAL)` expression with the PostgreSQL-native `make_interval(days => $1::double precision)`, which accepts a numeric parameter directly without requiring implicit type coercion from number to text.

## Changes Made

- `server/repositories/featureFlagsRepository.js`: Both fixes applied.

## Impact it Made

- Prevents `NOT NULL` constraint violations when callers pass `null` for flag boolean or numeric fields.
- Fixes a runtime database error in the stale flag detection workflow.
- Reduces 500 errors on feature flag creation and stale-flag admin endpoints.

## Note: please assign this PR to the `tmdeveloper007` account.
