### PR TITLE
fix : replace console.warn with structured logger in emailService

### DIFF
--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -4,6 +4,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import fs from 'fs/promises';
 import { CircuitBreaker, circuitBreakerRegistry } from '../utils/circuitBreaker.js';
+import logger from '../utils/logger.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -14,7 +15,7 @@ if (isProduction) {
   const requiredEnvVars = ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASS'];
   const missingVars = requiredEnvVars.filter((key) => !process.env[key]);
   if (missingVars.length > 0) {
-    console.warn(
+    logger.warn(
       `[Email Service] Warning: Missing email environment variables in production: ${missingVars.join(', ')}`
     );
   }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced `console.warn()` with the project's structured `logger.warn()` in `server/services/emailService.js`. Added the logger import.

## Changes Made

1. Added `import logger from '../utils/logger.js'` at the top of `server/services/emailService.js`.
2. Replaced `console.warn()` in the production environment variable validation block with `logger.warn()`.

## Impact it Made

- Consistent structured logging across all services
- Better log filtering and formatting in production
- Follows the established pattern used in other services

Closes #3970

## Note: Please assign this PR to the `tmdeveloper007` account.
