### PR TITLE
fix : added null guard for graduation year comparison in listActiveForUser

### DIFF
--- a/server/repositories/announcementsRepository.js
+++ b/server/repositories/announcementsRepository.js
@@ -76,6 +76,7 @@ export const announcementsRepository = {
           }
           if (
             ann.target_graduation_year &&
+            user.graduationYear != null &&
             Number(ann.target_graduation_year) !== Number(user.graduationYear)
           ) {
             return false;


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a NaN comparison bug in `server/repositories/announcementsRepository.js`. When `user.graduationYear` is `undefined`, `Number(undefined)` returns `NaN`, and `NaN !== NaN` evaluates to `true`. This caused announcements to be incorrectly filtered out for users without a graduation year set.

Added `user.graduationYear != null &&` guard before the comparison to skip the graduation year filter when the user has no graduation year set.

## Changes Made

- `server/repositories/announcementsRepository.js`: Added null/undefined guard before graduation year comparison in `listActiveForUser` function

## Impact it Made

- Users without a graduation year now correctly see all announcements
- Eliminates false-negative filtering for a subset of users
- Prevents unpredictable NaN comparison behavior

Closes #3976

## Note: please assign this PR to the `tmdeveloper007` account.