### PR TITLE
fix : added NaN guard for quiz_score in advanced profile skills mapping

### DIFF
--- a/server/controllers/advancedProfileController.js
+++ b/server/controllers/advancedProfileController.js
@@ -76,7 +76,7 @@ export async function getAdvancedProfile(req, res) {
           skillKey: r.skill_key,
           computedLevel: Number(r.computed_level),
           selfLevel: Number(r.self_level),
-          quizScore: r.quiz_score !== null ? Number(r.quiz_score) : null,
+          quizScore: r.quiz_score != null && !isNaN(Number(r.quiz_score)) ? Number(r.quiz_score) : null,
           endorsementScore: Number(r.endorsement_score),
           eventAttendanceScore: Number(r.event_attendance_score),
         });


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a potential NaN leak in `server/controllers/advancedProfileController.js`. When the database `quiz_score` column contains a non-numeric value, `Number()` would return `NaN`, which would be passed through to the API response, breaking the frontend's expectation of a numeric or null value.

Added `&& !isNaN(Number(r.quiz_score))` check to the ternary, ensuring only valid numeric values are returned.

## Changes Made

- `server/controllers/advancedProfileController.js`: Added `!isNaN()` check for `quizScore` mapping in skill profile response

## Impact it Made

- API responses no longer contain NaN values for quiz scores
- Guarantees consistent response shape regardless of database data quality
- Improves frontend reliability

Closes #3977

## Note: please assign this PR to the `tmdeveloper007` account.