### PR TITLE
fix : added price validation in setTiers before processing

### DIFF
--- a/server/controllers/eventPricingController.js
+++ b/server/controllers/eventPricingController.js
@@ -19,6 +19,14 @@ export const setTiers = async (req, res) => {
       return res.status(400).json({ error: 'tiers must be an array' });
     }
     
+    // Validate all tier prices are valid non-negative numbers
+    for (const tier of tiers) {
+      const price = parseFloat(tier.price);
+      if (isNaN(price) || price < 0) {
+        return res.status(400).json({ error: 'Each tier must have a valid non-negative price' });
+      }
+    }
+
     // Ensure tiers don't decrease in price as capacity increases (prevent price decrease mid-event)
     const sortedTiers = [...tiers].sort((a, b) => a.capacityThresholdPercent - b.capacityThresholdPercent);
     for (let i = 1; i < sortedTiers.length; i++) {


### PR DESCRIPTION
## Summary of What Has Been Done

Added explicit validation that each tier price is a valid non-negative number before processing in `server/controllers/eventPricingController.js`. Previously, `parseFloat(tier.price)` returning `NaN` would silently pass the price-ordering check (since `NaN < NaN` is `false`), allowing invalid prices to be stored in the database.

Added a pre-validation loop that rejects any tier with `NaN` or negative price before the existing price-monotonicity check.

## Changes Made

- `server/controllers/eventPricingController.js`: Added price validation loop before the ordering check in `setTiers`

## Impact it Made

- Invalid prices (NaN, negative, non-numeric) are rejected with a clear 400 error
- Database integrity for event pricing tiers is preserved
- Clear error messages for API consumers

Closes #3979

## Note: please assign this PR to the `tmdeveloper007` account.