### PR TITLE
fix : guarded timeAgo against null and NaN in NotificationBell

### DIFF
--- a/src/components/NotificationBell.jsx
+++ b/src/components/NotificationBell.jsx
@@ -47,8 +47,15 @@ const TYPE_CONFIG = {
 };
 
 function timeAgo(isoString) {
-  const diff = Math.floor((Date.now() - new Date(isoString)) / 1000);
   if (!isoString) return 'just now';
+  const date = new Date(isoString);
+  if (isNaN(date.getTime())) return 'just now';
+  const diff = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
 import { useEffect, useRef } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed the first `timeAgo()` function in `src/components/NotificationBell.jsx` which had two bugs: (1) it computed the time difference before checking for falsy/null input, so `null` input resulted in a huge diff instead of `'just now'`, and (2) it lacked an `isNaN` guard, so invalid date strings produced `'NaNd ago'`.

## Changes Made

- Moved the `if (!isoString) return 'just now'` check to the top of the function, before date parsing.
- Added `if (isNaN(date.getTime())) return 'just now'` guard after `new Date(isoString)`.
- Added full time-unit return statements (`diff < 60`, `< 3600`, `< 86400`) to the first function for consistency with the second `timeAgo` definition in the same file.

## Impact it Made

- Notification timestamps with null or malformed `createdAt` now render `'just now'` instead of `'NaNd ago'`.
- Consistent behavior with the second `timeAgo` definition in the same file.

Closes #3987

## Note: Please assign this PR to the `tmdeveloper007` account.