### PR TITLE
fix : removed duplicate ThemeProvider definition and merged imports

### DIFF
--- a/src/context/theme/ThemeProvider.tsx
+++ b/src/context/theme/ThemeProvider.tsx
@@ -1,4 +1,3 @@
-import React, { createContext, useState, useEffect } from "react";
 import React, { createContext, useState, useEffect, useLayoutEffect } from 'react';
 
 export type Theme = "light" | "dark" | "system";
@@ -15,13 +14,6 @@ export const ThemeContext = createContext<ThemeContextType | undefined>(
   undefined
 );
 
-export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
-  children,
-}) => {
-  const [theme, setThemeState] = useState<Theme>(() => {
-    // Check if user has explicitly set a preference
-    const stored = localStorage.getItem("ns-theme") as Theme | null;
-    return stored || "system";
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [theme, setThemeState] = useState<Theme | null>(() => {
     // Priority a: check localStorage
@@ -65,8 +57,8 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   // Listen for storage changes across tabs to synchronize theme state
   useEffect(() => {
     const syncTheme = (e: StorageEvent) => {
-      if (e.key === "ns-theme") {
-        const nextTheme = (e.newValue as Theme) || "system";
+      if (e.key === 'nexasphere-theme') {
+        const nextTheme = (e.newValue as Theme) || 'system';
         setThemeState(nextTheme);
       }
     };
@@ -77,9 +69,6 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
   const resolvedTheme = theme === "system" ? systemTheme : theme;
   const isDark = resolvedTheme === "dark";
 
-  useEffect(() => {
-    // Apply the resolved theme to documentElement
-    document.documentElement.setAttribute("data-theme", resolvedTheme);
   useLayoutEffect(() => {
     // Apply the resolved theme to documentElement synchronously before paint
     document.documentElement.setAttribute('data-theme', resolvedTheme);
@@ -87,7 +76,6 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ childre
 
   const setTheme = (newTheme: Theme) => {
     setThemeState(newTheme);
-    localStorage.setItem("ns-theme", newTheme);
     localStorage.setItem('nexasphere-theme', newTheme);
   };
 


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed `src/context/theme/ThemeProvider.tsx` which had duplicate imports, two incomplete/duplicate `export const ThemeProvider` definitions, and mismatched localStorage keys.

## Changes Made

- Merged duplicate React imports into one line including `useLayoutEffect`.
- Removed the first incomplete `ThemeProvider` definition (which was missing its closing `})` and would never have been active).
- Kept the second complete `ThemeProvider` definition.
- Updated the storage sync listener to watch `nexasphere-theme` instead of `ns-theme` (matching the active provider's storage key).
- Removed the duplicate `useEffect` that set `data-theme`; kept only `useLayoutEffect` for synchronous paint-time application.
- Updated `setTheme` to write only to `nexasphere-theme` (removed the orphaned `ns-theme` write).

## Impact it Made

- Fixes theme preference resetting on browser refresh (previously reading from wrong localStorage key).
- Removes dead code from the incomplete first definition.
- Ensures consistent localStorage key (`nexasphere-theme`) across all theme operations.
- Synchronous `useLayoutEffect` prevents flash of wrong theme on initial paint.

Closes #3989

## Note: please assign this PR to the `tmdeveloper007` account.