### PR TITLE
fix : replaced console.warn with structured logger in adminAuditMiddleware

### DIFF
--- a/server/middleware/adminAuditMiddleware.js
+++ b/server/middleware/adminAuditMiddleware.js
@@ -171,7 +171,7 @@ export const attachOldState = (fetcher) => async (req, res, next) => {
   try {
     req.oldState = await fetcher(req);
   } catch (err) {
-    console.warn('[Audit] Failed to fetch old state:', err.message);
+    logger.warn({ err: err.message }, 'Failed to fetch old state for audit');
   }
   next();
 };


### PR DESCRIPTION
Closes #4004.

Summary of What Has Been Done:
Replaced the bare console.warn call in server/middleware/adminAuditMiddleware.js with a structured logger.warn call. The file already imports logger from './utils/logger.js'.

Changes Made:
- Replaced console.warn('[Audit] Failed to fetch old state:', err.message) with logger.warn({ err: err.message }, 'Failed to fetch old state for audit')

Impact it Made:
- Consistent structured logging in the audit middleware
- Audit failures now flow through the observability stack
- Easier to correlate audit failures with other system events

Note: Please assign this PR to the `tmdeveloper007` account.