### PR TITLE
fix: restrict JWT verification to HS256

### DIFF
--- a/server/services/studentAuthService.js
+++ b/server/services/studentAuthService.js
@@ -93,15 +93,13 @@ export const studentAuthService = {
       role: user.role,
       scopes: user.scopes?.length ? user.scopes : getScopesForRole(user.role),
     };
-    return jwt.sign(payload, getJwtSecret(), { expiresIn: JWT_EXPIRY });
-    return jwt.sign(payload, JWT_SECRET, { expiresIn: JWT_EXPIRY });
+    return jwt.sign(payload, getJwtSecret(), { expiresIn: JWT_EXPIRY, algorithm: 'HS256' });
   },
 
   verifyToken(token) {
     try {
       if (tokenBlacklist.has(token)) return null;
-      return jwt.verify(token, getJwtSecret());
-      return jwt.verify(token, JWT_SECRET);
+      return jwt.verify(token, getJwtSecret(), { algorithms: ['HS256'] });
     } catch {
       return null;
     }


### PR DESCRIPTION
# Summary

Restricted JWT verification to the expected algorithm and removed duplicate return statements to prevent algorithm confusion attacks.

## Related Issue

Fixes #4019

## Type of Change

- [x] Bug Fix
- [x] Security Enhancement

## Changes Implemented

- Added `algorithms: ['HS256']` to `jwt.verify()`.
- Removed duplicate/unreachable `return` statements.
- Preserved existing authentication behavior.

## Technical Details

### Backend

- Updated `server/services/studentAuthService.js`.

## Testing

### Manual Testing

- [x] Verified valid HS256 JWTs authenticate successfully.
- [x] Verified JWT verification uses only the HS256 algorithm.
- [x] Verified authentication flow continues to work as expected.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review