### PR TITLE
fix: restore draft content and support version restoration

### DIFF
--- a/server/services/draftRecoveryService.js
+++ b/server/services/draftRecoveryService.js
@@ -43,8 +43,9 @@ class DraftRecoveryService {
     draft.content = content;
     draft.updatedAt = new Date();
 
+    const nextVersion = draft.versions.length > 0 ? Math.max(...draft.versions.map((v) => v.version)) + 1 : 1;
     draft.versions.push({
-      version: draft.versions.length + 1,
+      version: nextVersion,
       content,
       savedAt: new Date(),
     });
@@ -62,12 +63,24 @@ class DraftRecoveryService {
     return true;
   }
 
-  restoreDraft(id) {
+  restoreDraft(id, versionNumber) {
     const draft = this.getDraft(id);
 
-    if (!draft) return null;
+    if (!draft || !draft.versions.length) return null;
 
-    return draft.versions[draft.versions.length - 1];
+    let targetVersion;
+    if (versionNumber !== undefined && versionNumber !== null) {
+      targetVersion = draft.versions.find((v) => v.version === Number(versionNumber));
+    } else {
+      targetVersion = draft.versions[draft.versions.length - 1];
+    }
+
+    if (!targetVersion) return null;
+
+    draft.content = targetVersion.content;
+    draft.updatedAt = new Date();
+
+    return draft;
   }
 
   versionHistory(id) {


### PR DESCRIPTION
# Summary

Fixed draft restoration by updating the draft content and timestamp during restore, while adding support for restoring a specific saved version.

## Related Issue

Fixes #4024

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Updated `restoreDraft` to restore the selected version's content instead of only returning the version object.
- Updated the draft's `updatedAt` timestamp after restoration.
- Added optional `versionNumber` support to restore a specific historical version.
- Replaced `length + 1` version numbering with monotonic version generation to prevent duplicate version numbers.

## Technical Details

### Backend

- Updated `server/services/draftRecoveryService.js`.

## Testing

### Manual Testing

- [x] Verified restoring the latest draft updates the draft content.
- [x] Verified restoring a specific version works correctly.
- [x] Verified invalid version numbers are handled safely.
- [x] Verified version numbers remain unique after multiple saves.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review