### PR TITLE
fix: return empty result for segments with empty criteria

### DIFF
--- a/server/services/segmentationService.js
+++ b/server/services/segmentationService.js
@@ -26,8 +26,13 @@ export const segmentationService = {
     const segment = await userSegmentsRepository.getSegmentById(segmentId);
     if (!segment) throw new Error('Segment not found');
 
+    const criteria = segment.criteria;
+    if (!criteria || typeof criteria !== 'object' || Object.keys(criteria).length === 0) {
+      return [];
+    }
+
     // We reuse the email campaign repo's user fetching logic for segments
-    return emailCampaignRepository.getSegmentUsers(segment.criteria);
+    return emailCampaignRepository.getSegmentUsers(criteria);
   },
 
   async runAutoSegmentation() {


### PR DESCRIPTION
# Summary

Fixed segment user retrieval by validating segment criteria before querying the repository, preventing empty or invalid criteria from returning all database users.

## Related Issue

Fixes #4026

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation for segment criteria before querying users.
- Returned an empty array when criteria is `null`, invalid, or empty.
- Used the validated criteria object when fetching segment users.

## Technical Details

### Backend

- Updated `server/services/segmentationService.js`.

## Testing

### Manual Testing

- [x] Verified empty criteria returns an empty array.
- [x] Verified `null` criteria returns an empty array.
- [x] Verified valid criteria continue to return the correct users.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review