### PR TITLE
fix: remove default JWT secret and stop leaking token in SSO invite response

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -80,8 +80,9 @@ GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 # Domain restriction for OAuth (e.g., "glbajajgroup.org" — leave empty for no restriction)
 OAUTH_DOMAIN_RESTRICTION=
-# JWT secret for student tokens (use a long random string in production)
-JWT_SECRET=nexasphere-jwt-dev-secret-change-in-production
+# JWT secret for student tokens — REQUIRED, no default.
+# Generate one with: openssl rand -hex 32
+JWT_SECRET=
 # JWT token expiry (default 7d)
 JWT_EXPIRY=7d
 # Base URL for OAuth callbacks (defaults to http://localhost:8080)

--- a/server/routes/admin.js
+++ b/server/routes/admin.js
@@ -407,7 +407,7 @@ router.post(
     const baseUrl = process.env.BASE_URL || 'http://localhost:8080';
     const inviteUrl = `${baseUrl}/api/auth/google?token=${token}`;
 
-    return sendSuccess(res, { token, inviteUrl });
+    return sendSuccess(res, { inviteUrl });
   }
 );
 router.get('/sessions', adminAuth, adminAuthMiddleware.getSecurityOverview);


### PR DESCRIPTION
## What does this PR do?
Fixes #3839 — a default JWT signing secret in `server/.env.example` that could enable token forgery and SSO bypass if a deployment failed to override it.

Two isolated fixes:
1. **Removed the hardcoded default JWT secret** from `server/.env.example`. `JWT_SECRET` is now blank with a comment instructing operators to generate a real one (`openssl rand -hex 32`). This closes the gap where a forgettable default let an attacker sign valid `bypassSso: true` tokens using a publicly-known secret straight from the repo.
2. **Stopped returning the raw JWT in the `/api/admin/sso-invite` response body.** The token is already delivered via `inviteUrl`; returning it a second time in the JSON body was unnecessary exposure.

**Scope note:** The issue also suggested reconsidering the `bypassSso` mechanism entirely. I looked into this, but `server/routes/admin.js`, `server/config/studentOAuth.js`, and `server/index.js` are currently **failing to parse** on `main` (confirmed via `node --check`) due to unrelated pre-existing merge corruption — duplicate imports, duplicate route/strategy blocks, orphaned import fragments left over from an unresolved merge. This is a separate, urgent problem outside this PR's scope, and I'll be filing a follow-up issue for it. Reworking `bypassSso` safely requires those files to be untangled first, so I've kept this PR to the two safe, verified-isolated fixes above.

Fixes #3839

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness (N/A — backend-only change)
- [x] Checked for console warnings and errors

Verified via `git diff main` that both file changes are isolated to the intended lines (no accidental edits to the surrounding corrupted code). Confirmed with `node --check` that neither file's pre-existing parse errors were introduced or worsened by this PR — they exist identically on `main` before this change.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings