### PR TITLE
fix : replaced console.warn with structured logger in aiTagging.js

### DIFF
--- a/server/services/aiTagging.js
+++ b/server/services/aiTagging.js
@@ -1,3 +1,4 @@
+import logger from '../utils/logger.js';
 /**
  * server/services/aiTagging.js
  * AI-powered face detection, object recognition, auto-categorisation,
@@ -87,7 +88,7 @@ async function analyzePhoto(photoId, imageBuffer) {
       }
     } catch (err) {
       // SearchFacesByImage fails if collection is empty — not fatal
-      console.warn('Face search skipped:', err.message);
+      logger.warn('Face search skipped: {err}', { err: err.message });
     }
   }
 


### PR DESCRIPTION
## Summary of What Has Been Done
Replaced the bare `console.warn()` call in `server/services/aiTagging.js` with the project's structured logger for consistent logging.

## Changes Made
- Added `import logger from '../utils/logger.js';` at the top of the file
- Replaced `console.warn('Face search skipped:', err.message);` with `logger.warn('Face search skipped: {err}', { err: err.message });`

## Impact it Made
- Consistent structured logging format across the aiTagging service
- Improved debuggability of face search failures in production logs

## Note: please assign this PR to the `tmdeveloper007` account.

Closes #4067