### PR TITLE
fix: join socket to email room on user identify

### DIFF
--- a/server/config/socket.js
+++ b/server/config/socket.js
@@ -163,6 +163,8 @@ export function _onConnection(socket) {
       connectedAt: new Date(),
     });
 
+    socket.join(`user-${String(email).toLowerCase()}`);
+
     logger.info('User identified successfully', { userId: String(userId), socketId: socket.id });
   });
 


### PR DESCRIPTION
## What does this PR do?
This PR addresses a silent failure in real-time Socket.IO communications where events targeted by email were being broadcast into non-existent rooms. Previously, the `user:identify` socket handler updated internal user tracking but forgot to actually subscribe the socket to its dedicated `user-${email}` room. 

This change adds `socket.join(\`user-${String(email).toLowerCase()}\`)` during the identification phase, ensuring that utilities like `emitToUserByEmail` now successfully route payloads to the intended clients.

Fixes #4153

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [x] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
