### PR TITLE
fix: initialize company interests array to prevent filtering errors

### DIFF
--- a/server/services/sponsorshipMarketplaceService.js
+++ b/server/services/sponsorshipMarketplaceService.js
@@ -54,9 +54,13 @@ export const sponsorshipMarketplaceService = {
       logo: null,
       testimonials: [],
       pastSponsorships: [],
+      interests: [],
       createdAt: new Date().toISOString(),
       ...data,
     };
+    if (!Array.isArray(company.interests)) {
+      company.interests = [];
+    }
     companies.push(company);
     return company;
   },


### PR DESCRIPTION
# Summary

Fixed company creation to ensure the `interests` field is always initialized as an array, preventing runtime errors during interest-based filtering.

## Related Issue

Fixes #4160

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Initialized the `interests` field during company creation.
- Added validation to ensure `company.interests` is always an array before storing the company.
- Prevented `TypeError` caused by calling array methods on undefined values.

## Technical Details

### Backend

- Updated `server/services/sponsorshipMarketplaceService.js`.

## Testing

### Manual Testing

- [x] Verified companies created without an `interests` field no longer crash filtering.
- [x] Verified interest-based filtering continues to work correctly.
- [x] Verified `company.interests` is always stored as an array.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review