### PR TITLE
fix: emit waiting room events to the correct socket room

### DIFF
--- a/server/services/waitingRoomService.js
+++ b/server/services/waitingRoomService.js
@@ -66,8 +66,8 @@ export const waitingRoomService = {
       total: queue.length,
     });
     const io = getIO();
-    if (entry.userId) {
-      io.to(entry.userId).emit('waiting:admitted', { eventId, fullName: entry.fullName });
+    if (io && entry.userId) {
+      io.to(`user-${entry.userId}`).emit('waiting:admitted', { eventId, fullName: entry.fullName });
     }
     logger.info('Attendee admitted from waiting room', { eventId, email: entry.email });
     return entry;


### PR DESCRIPTION
# Summary

Fixed waiting room admission notifications by emitting events to the correct user socket room and preventing runtime errors when the socket server is not initialized.

## Related Issue

Fixes #4161

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Updated socket event emission to use the correct `user-${userId}` room naming convention.
- Added a null check before emitting events to prevent crashes when the socket server is unavailable.
- Preserved the existing admission workflow while improving reliability.

## Technical Details

### Backend

- Updated `server/services/waitingRoomService.js`.

## Testing

### Manual Testing

- [x] Verified admitted users receive the `waiting:admitted` event.
- [x] Verified no runtime error occurs when the socket server is uninitialized.
- [x] Verified waiting room admission continues to function correctly.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review