### PR TITLE
fix: periodically clean up expired impersonation sessions

### DIFF
--- a/server/services/impersonationService.js
+++ b/server/services/impersonationService.js
@@ -2,8 +2,26 @@ const sessions = new Map();
 
 const IMPERSONATION_TTL_MS = 30 * 60 * 1000;
 
+function cleanupExpired() {
+  const now = Date.now();
+  for (const [token, session] of sessions.entries()) {
+    if (now - new Date(session.startedAt).getTime() > IMPERSONATION_TTL_MS) {
+      sessions.delete(token);
+    }
+  }
+}
+
+// Run cleanup periodically every 10 minutes (unreferenced to allow clean Node process exit)
+if (typeof setInterval === 'function') {
+  const interval = setInterval(cleanupExpired, 10 * 60 * 1000);
+  if (interval && typeof interval.unref === 'function') {
+    interval.unref();
+  }
+}
+
 export const impersonationService = {
   start(token, targetUser) {
+    cleanupExpired();
     sessions.set(token, {
       targetUser,
       startedAt: new Date().toISOString(),


### PR DESCRIPTION
# Summary

Added periodic cleanup for expired impersonation sessions to prevent stale session entries from accumulating in memory over time.

## Related Issue

Fixes #4162

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added a helper to remove expired impersonation sessions.
- Scheduled automatic cleanup using a periodic timer.
- Used `unref()` on the cleanup timer so it does not keep the Node.js process alive.
- Triggered cleanup before creating new impersonation sessions to remove stale entries promptly.

## Technical Details

### Backend

- Updated `server/services/impersonationService.js`.

## Testing

### Manual Testing

- [x] Verified expired sessions are removed during scheduled cleanup.
- [x] Verified expired sessions are cleaned before creating new impersonation sessions.
- [x] Verified the cleanup timer does not prevent the Node.js process from exiting.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review