### PR TITLE
fix: prevent duplicate agreement creation for accepted proposals

### DIFF
--- a/server/services/sponsorshipMarketplaceService.js
+++ b/server/services/sponsorshipMarketplaceService.js
@@ -93,17 +93,20 @@ export const sponsorshipMarketplaceService = {
     if (!p) return null;
     p.status = status;
     if (status === 'Accepted') {
-      const agreement = {
-        id: 'agr-' + Date.now(),
-        proposalId,
-        companyId: p.companyId,
-        tier: p.tier,
-        benefits: p.benefits,
-        status: 'Active',
-        deliverables: p.benefits.map((b) => ({ item: b, done: false })),
-        createdAt: new Date().toISOString(),
-      };
-      agreements.push(agreement);
+      let agreement = agreements.find((a) => a.proposalId === proposalId);
+      if (!agreement) {
+        agreement = {
+          id: 'agr-' + Date.now(),
+          proposalId,
+          companyId: p.companyId,
+          tier: p.tier,
+          benefits: p.benefits || [],
+          status: 'Active',
+          deliverables: (p.benefits || []).map((b) => ({ item: b, done: false })),
+          createdAt: new Date().toISOString(),
+        };
+        agreements.push(agreement);
+      }
       p.agreementId = agreement.id;
       return { proposal: p, agreement };
     }


### PR DESCRIPTION
# Summary

Prevented duplicate agreement creation when a sponsorship proposal is accepted multiple times by reusing an existing agreement associated with the proposal.

## Related Issue

Fixes #4163

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Checked for an existing agreement before creating a new one.
- Reused the existing agreement when the proposal had already been accepted.
- Added safe defaults for proposal benefits to avoid runtime errors when generating deliverables.
- Continued linking the proposal to the associated agreement.

## Technical Details

### Backend

- Updated `server/services/sponsorshipMarketplaceService.js`.

## Testing

### Manual Testing

- [x] Verified only one agreement is created for repeated `Accepted` updates.
- [x] Verified proposals continue to reference the existing agreement.
- [x] Verified agreement creation still works correctly on the first acceptance.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review