### PR TITLE
fix: validate campaign schedule and prevent ID collisions

### DIFF
--- a/server/services/notificationCampaignService.js
+++ b/server/services/notificationCampaignService.js
@@ -47,8 +47,9 @@ const getCampaignById = async (id) =>
 
 // Create campaign
 const createCampaign = async (data) => {
+  const nextId = campaigns.length > 0 ? Math.max(...campaigns.map((c) => c.id)) + 1 : 1;
   const campaign = {
-    id: campaigns.length + 1,
+    id: nextId,
     status: "Draft",
     createdAt: new Date().toISOString(),
     ...data,
@@ -93,6 +94,10 @@ const scheduleCampaign = async (id, scheduleData) => {
   );
 
   if (!campaign) return null;
+
+  if (scheduleData.scheduleTime && new Date(scheduleData.scheduleTime).getTime() <= Date.now()) {
+    throw new Error("Cannot schedule a campaign in the past");
+  }
 
   campaign.scheduleTime = scheduleData.scheduleTime;
   campaign.timezone = scheduleData.timezone || "UTC";
@@ -154,8 +159,9 @@ const getCampaignHistory = async () => history;
 const getTemplates = async () => templates;
 
 const createTemplate = async (data) => {
+  const nextId = templates.length > 0 ? Math.max(...templates.map((t) => t.id)) + 1 : 1;
   const template = {
-    id: templates.length + 1,
+    id: nextId,
     ...data,
   };
 


### PR DESCRIPTION
# Summary

Fixed notification campaign scheduling by rejecting past schedule times and replacing non-monotonic ID generation with monotonic IDs to prevent collisions after deletions.

## Related Issue

Fixes #4164

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added validation to reject campaign schedule times that are in the past.
- Replaced `length + 1` campaign ID generation with monotonic `Math.max(...)+1` ID generation.
- Updated notification template ID generation to use the same monotonic strategy.

## Technical Details

### Backend

- Updated `server/services/notificationCampaignService.js`.

## Testing

### Manual Testing

- [x] Verified scheduling a campaign with a past date is rejected.
- [x] Verified campaigns receive unique IDs after deletions.
- [x] Verified notification templates also receive unique monotonic IDs.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review