### PR TITLE
fix: synchronize bookmark folder updates and deletions

### DIFF
--- a/server/services/bookmarkService.js
+++ b/server/services/bookmarkService.js
@@ -99,7 +99,15 @@ class BookmarkService {
         message: 'Folder not found.',
       };
 
+    const oldName = folder.name;
     folder.name = name;
+
+    // Update matching bookmarks
+    bookmarks.forEach((b) => {
+      if (b.folder === oldName) {
+        b.folder = name;
+      }
+    });
 
     return {
       success: true,
@@ -116,7 +124,15 @@ class BookmarkService {
         message: 'Folder not found.',
       };
 
+    const folderName = folders[index].name;
     folders.splice(index, 1);
+
+    // Reset matching bookmarks to General
+    bookmarks.forEach((b) => {
+      if (b.folder === folderName) {
+        b.folder = 'General';
+      }
+    });
 
     return {
       success: true,


### PR DESCRIPTION
# Summary

Updated bookmark folder management to keep bookmark folder references synchronized when folders are renamed or deleted.

## Related Issue

Fixes #4165

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Updated bookmarks referencing a folder when the folder is renamed.
- Reset bookmarks belonging to a deleted folder to the default `General` folder.
- Prevented orphaned bookmark folder references after folder updates and deletions.

## Technical Details

### Backend

- Updated `server/services/bookmarkService.js`.

## Testing

### Manual Testing

- [x] Verified bookmarks move to the renamed folder after a folder rename.
- [x] Verified bookmarks are reassigned to `General` when a folder is deleted.
- [x] Verified folder filtering continues to work correctly after rename and deletion.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review