### PR TITLE
fix: cancel pending requests when deleting workflows

### DIFF
--- a/server/services/workflowAutomationService.js
+++ b/server/services/workflowAutomationService.js
@@ -97,8 +97,9 @@ module.exports = {
   },
 
   createWorkflow(data) {
+    const nextId = workflows.length > 0 ? Math.max(...workflows.map((w) => w.id)) + 1 : 1;
     const workflow = {
-      id: workflows.length + 1,
+      id: nextId,
       ...data,
       status: "Active"
     };
@@ -145,6 +146,16 @@ module.exports = {
       };
     }
 
+    const deletedWorkflow = workflows[index];
+
+    // Cancel pending requests associated with the deleted workflow
+    requests.forEach((req) => {
+      if (req.workflow === deletedWorkflow.name && req.status === "Pending") {
+        req.status = "Cancelled";
+        req.currentApprover = "-";
+      }
+    });
+
     workflows.splice(index, 1);
 
     return {
@@ -153,8 +164,9 @@ module.exports = {
     };
   },
     submitRequest(data) {
+    const nextId = requests.length > 0 ? Math.max(...requests.map((r) => r.id)) + 1 : 101;
     const request = {
-      id: requests.length + 101,
+      id: nextId,
       workflow: data.workflow,
       title: data.title,
       requester: data.requester,
@@ -166,7 +178,7 @@ module.exports = {
     requests.push(request);
 
     history.push({
-      id: history.length + 1,
+      id: history.length > 0 ? Math.max(...history.map((h) => h.id)) + 1 : 1,
       requestId: request.id,
       action: "Submitted",
       by: request.requester,


### PR DESCRIPTION
# Summary

Updated workflow deletion to cancel associated pending approval requests and replaced non-monotonic ID generation with monotonic IDs to prevent collisions.

## Related Issue

Fixes #4166

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Cancelled pending approval requests associated with a deleted workflow.
- Reset `currentApprover` to `"-"` for cancelled requests.
- Replaced `length + 1` workflow ID generation with monotonic `Math.max(...)+1` IDs.
- Replaced request and history ID generation with monotonic IDs.

## Technical Details

### Backend

- Updated `server/services/workflowAutomationService.js`.

## Testing

### Manual Testing

- [x] Verified pending requests are cancelled when their workflow is deleted.
- [x] Verified `currentApprover` is reset for cancelled requests.
- [x] Verified workflow, request, and history IDs remain unique after deletions.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review