### PR TITLE
fix: handle Supabase error object formats in capacity locking

### DIFF
--- a/server/services/capacityLockingService.js
+++ b/server/services/capacityLockingService.js
@@ -40,20 +40,33 @@ export const capacityLockingService = {
 
       return result;
     } catch (e) {
-      if (e.message?.includes('Event capacity has been reached')) {
+      const errMessage = String(e.message || '').toLowerCase();
+      const errDetails = String(e.details || '').toLowerCase();
+      const errDescription = String(e.error_description || '').toLowerCase();
+      const errCode = String(e.code || '').toLowerCase();
+
+      const contains = (str) =>
+        errMessage.includes(str) ||
+        errDetails.includes(str) ||
+        errDescription.includes(str) ||
+        errCode.includes(str);
+
+      if (contains('capacity has been reached') || contains('capacity')) {
         const err = new Error('Event capacity has been reached.');
         err.status = 409;
         throw err;
       }
       if (
-        e.message?.includes('duplicate key value violates unique constraint') ||
-        e.message?.includes('event_registrations_event_id_email_key')
+        contains('duplicate key') ||
+        contains('unique constraint') ||
+        contains('event_registrations_event_id_email_key') ||
+        errCode === '23505'
       ) {
         const err = new Error('You have already registered for this event.');
         err.status = 400;
         throw err;
       }
-      if (e.message?.includes('Event not found')) {
+      if (contains('not found')) {
         const err = new Error('Event not found.');
         err.status = 404;
         throw err;


### PR DESCRIPTION
# Summary

Improved error handling in the capacity locking service by supporting multiple Supabase error object formats, ensuring duplicate registration and capacity-related errors are mapped to the appropriate HTTP responses.

## Related Issue

Fixes #4169

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added support for matching errors from `message`, `details`, `error_description`, and `code`.
- Introduced a shared helper for consistent error matching.
- Improved duplicate registration detection using PostgreSQL error code `23505` and related constraint identifiers.
- Updated capacity and "not found" error handling to support multiple Supabase error formats.

## Technical Details

### Backend

- Updated `server/services/capacityLockingService.js`.

## Testing

### Manual Testing

- [x] Verified duplicate registration errors are correctly mapped when returned through different Supabase error fields.
- [x] Verified capacity-related errors return the expected HTTP response.
- [x] Verified "not found" errors continue to be handled correctly.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review