### PR TITLE
ci: add Docker build validation workflow

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,31 @@
+name: Docker Build Validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docker-build:
+    name: Build Docker Image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          tags: nexasphere:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## What does this PR do?
This pull request introduces a dedicated GitHub Actions CI workflow to automatically validate Docker image builds on every pull request and push to the default `main` branch. 

It ensures that code changes are always compatible with the project's containerization setup by building the Docker image using Docker Buildx. The workflow uses caching to optimize build times and intentionally does not push the image to a registry, as its purpose is purely validation. A build failure will fail the workflow, preventing container-breaking changes from being merged.

Fixes #4197 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [ ] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
