### PR TITLE
ci: add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom-generation.yml
+++ b/.github/workflows/sbom-generation.yml
@@ -1,0 +1,40 @@
+name: SBOM Generation
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types:
+      - published
+
+jobs:
+  generate-sbom:
+    name: Generate Software Bill of Materials
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to upload to GitHub Releases
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@v0
+        with:
+          path: ./
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Upload SBOM as Workflow Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom
+          path: sbom.spdx.json
+          retention-days: 30
+
+      - name: Attach SBOM to Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: sbom.spdx.json


### PR DESCRIPTION
## What does this PR do?
This pull request introduces a GitHub Actions workflow that automatically generates a Software Bill of Materials (SBOM) during the CI process.

The workflow leverages the well-supported `anchore/sbom-action` (powered by Syft) to generate an SBOM in the standard SPDX JSON format (`sbom.spdx.json`). The generated SBOM is automatically uploaded as a workflow artifact on every push to the `main` branch. Additionally, when a new release is published, the workflow attaches the SBOM directly to the GitHub Release assets.

Automating SBOM generation improves software supply chain transparency, simplifies dependency auditing, and helps maintainers quickly identify if the project is affected by newly disclosed vulnerabilities.

Fixes #4205 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [ ] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

