### PR TITLE
fix: normalize feature flag user and role comparisons

### DIFF
--- a/server/services/featureFlagsService.js
+++ b/server/services/featureFlagsService.js
@@ -148,14 +148,18 @@ class FeatureFlagsService {
 
     // 4. User ID direct target whitelist
     if (context.userId && flag.target_users && flag.target_users.length > 0) {
-      if (flag.target_users.includes(context.userId)) {
+      const normalizedUserId = String(context.userId).trim();
+      const userWhitelist = flag.target_users.map((u) => String(u).trim());
+      if (userWhitelist.includes(normalizedUserId)) {
         return true;
       }
     }
 
     // 5. User Role direct target whitelist
     if (context.role && flag.target_roles && flag.target_roles.length > 0) {
-      if (flag.target_roles.includes(context.role)) {
+      const normalizedRole = String(context.role).trim().toLowerCase();
+      const roleWhitelist = flag.target_roles.map((r) => String(r).trim().toLowerCase());
+      if (roleWhitelist.includes(normalizedRole)) {
         return true;
       }
     }


### PR DESCRIPTION
# Summary

Improved feature flag targeting by normalizing user IDs and roles before comparison, preventing false negatives caused by type and formatting differences.

## Related Issue

Fixes #4170

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Normalized `context.userId` and `target_users` to strings before comparison.
- Trimmed whitespace from user ID values to avoid formatting mismatches.
- Normalized role comparisons by trimming whitespace and converting values to lowercase.
- Ensured feature flag targeting works consistently across numeric and string identifiers.

## Technical Details

### Backend

- Updated `server/services/featureFlagsService.js`.

## Testing

### Manual Testing

- [x] Verified numeric user IDs match string entries in `target_users`.
- [x] Verified user ID comparisons ignore leading and trailing whitespace.
- [x] Verified role comparisons are case-insensitive and whitespace-tolerant.
- [x] Verified existing feature flag evaluation behavior remains unchanged for valid inputs.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review
```