### PR TITLE
ci: add Trivy Docker image vulnerability scanning workflow

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,36 @@
+name: Trivy Container Vulnerability Scanner
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  trivy-scan:
+    name: Build and Scan Docker Image
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Build an image from Dockerfile
+        run: docker build -t nexasphere/test-image:${{ github.sha }} .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'nexasphere/test-image:${{ github.sha }}'
+          format: 'json'
+          output: 'trivy-results.json'
+          severity: 'CRITICAL,HIGH'
+          exit-code: '1'
+
+      - name: Upload Trivy scan results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: trivy-vulnerability-report
+          path: trivy-results.json
+          retention-days: 14


### PR DESCRIPTION
## What does this PR do?
This pull request integrates Trivy into our GitHub Actions CI pipeline to automatically scan our Docker images for vulnerabilities. 

The new workflow triggers automatically on pull requests and pushes to the default `main` branch. It first builds the Docker image locally and then runs the Trivy vulnerability scanner against it. It is configured to automatically fail the workflow if any vulnerabilities with HIGH or CRITICAL severity are detected, preventing insecure images from moving further in our pipeline. Finally, the scan report is generated in JSON format and uploaded as a workflow artifact, giving maintainers an actionable security report.

This addition improves our software supply chain security and provides continuous container security validation early in the development lifecycle.

Fixes #4213 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [ ] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
