### PR TITLE
fix: safely handle invalid timestamps in audit reports

### DIFF
--- a/server/services/auditReportGenerator.js
+++ b/server/services/auditReportGenerator.js
@@ -9,6 +9,16 @@
 
 import logger from '../utils/logger.js';
 
+function formatSafeIsoDate(val) {
+  if (!val) return null;
+  try {
+    const d = new Date(val);
+    return Number.isNaN(d.getTime()) ? null : d.toISOString();
+  } catch (err) {
+    return null;
+  }
+}
+
 export async function generateCompliancePdfReport({ run, runIssues = [], summary = {} }) {
   // Minimal, dependency-free placeholder. Replace with a real PDF renderer (pdfkit, puppeteer, etc.).
   const payload = {
@@ -16,8 +26,8 @@ export async function generateCompliancePdfReport({ run, runIssues = [], summary
       runId: run?.id,
       runType: run?.run_type,
       createdBy: run?.created_by_admin_id,
-      startedAt: run?.started_at,
-      finishedAt: run?.finished_at,
+      startedAt: formatSafeIsoDate(run?.started_at),
+      finishedAt: formatSafeIsoDate(run?.finished_at),
       status: run?.status,
     },
     summary,


### PR DESCRIPTION
# Summary

Prevents audit report generation from crashing when log timestamps are invalid or malformed by safely validating timestamps before formatting them.

## Related Issue

Fixes #4173

## Type of Change

- [x] Bug Fix

## Changes Implemented

- Added a helper to safely validate and format timestamps.
- Prevented `RangeError: Invalid time value` from being thrown.
- Returned `null` for invalid or malformed timestamps instead of formatting invalid dates.
- Updated audit report generation to use the safe timestamp formatter.

## Technical Details

### Backend

- Updated `server/services/auditReportGenerator.js`.

## Testing

### Manual Testing

- [x] Verified valid timestamps are formatted correctly.
- [x] Verified `null` timestamps no longer crash report generation.
- [x] Verified malformed timestamps are handled safely.
- [x] Verified audit reports continue generating successfully.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Ready for review
```