### PR TITLE
fix: prevent waiting room admission crash when Socket.IO is unavailable

### DIFF
--- a/server/services/waitingRoomService.js
+++ b/server/services/waitingRoomService.js
@@ -66,8 +66,8 @@ export const waitingRoomService = {
       total: queue.length,
     });
     const io = getIO();
-    if (entry.userId) {
-      io.to(entry.userId).emit('waiting:admitted', { eventId, fullName: entry.fullName });
+    if (io && entry.userId) {
+      io.to(`user-${entry.userId}`).emit('waiting:admitted', { eventId, fullName: entry.fullName });
     }
     logger.info('Attendee admitted from waiting room', { eventId, email: entry.email });
     return entry;


### PR DESCRIPTION
Fixes #4233

## Summary

This PR fixes Issue #4233 by preventing waiting room admissions from crashing when the Socket.IO instance is unavailable and ensuring notifications are emitted to the correct user room.

### Changes Made

- Added a null check before using the Socket.IO instance returned by `getIO()`.
- Updated the notification target to use the standard `user-${userId}` room naming convention.
- Prevented `TypeError` crashes when Socket.IO has not been initialized.

### Issue Fixed

- Prevents crashes caused by calling `.to()` on a null Socket.IO instance.
- Ensures waiting room admission notifications are delivered to the correct user-specific room.
