### PR TITLE
fix: automatically cleanup expired impersonation sessions

### DIFF
--- a/server/services/impersonationService.js
+++ b/server/services/impersonationService.js
@@ -2,8 +2,26 @@ const sessions = new Map();
 
 const IMPERSONATION_TTL_MS = 30 * 60 * 1000;
 
+function cleanupExpired() {
+  const now = Date.now();
+  for (const [token, session] of sessions.entries()) {
+    if (now - new Date(session.startedAt).getTime() > IMPERSONATION_TTL_MS) {
+      sessions.delete(token);
+    }
+  }
+}
+
+// Periodically purge expired impersonation sessions every 10 minutes
+if (typeof setInterval === 'function') {
+  const interval = setInterval(cleanupExpired, 10 * 60 * 1000);
+  if (interval && typeof interval.unref === 'function') {
+    interval.unref();
+  }
+}
+
 export const impersonationService = {
   start(token, targetUser) {
+    cleanupExpired();
     sessions.set(token, {
       targetUser,
       startedAt: new Date().toISOString(),
@@ -15,12 +33,9 @@ export const impersonationService = {
   },
 
   getActive(token) {
-    const session = sessions.get(token);
-    if (!session) return null;
-    if (Date.now() - new Date(session.startedAt).getTime() > IMPERSONATION_TTL_MS) {
-      sessions.delete(token);
-      return null;
-    }
-    return session;
+    cleanupExpired();
+    return sessions.get(token) || null;
   },
+
+  cleanupExpired,
 };


### PR DESCRIPTION
## Summary

Fixes #4236

### Changes Made
- Added a reusable `cleanupExpired()` helper to remove expired impersonation sessions.
- Scheduled periodic cleanup every 10 minutes using `setInterval`.
- Invoked cleanup before creating new impersonation sessions.
- Simplified `getActive()` by delegating expiration handling to the cleanup helper.
- Used `interval.unref()` to avoid preventing the Node.js process from exiting.

### Problem Solved
Previously, expired impersonation sessions remained in memory until `getActive()` was called for the same token, causing unnecessary memory growth over long-running server processes.

This update ensures expired sessions are removed proactively and periodically, preventing stale session accumulation.