### PR TITLE
feat(website): add useClickOutside hook with tests

### DIFF
--- a/website/src/__tests__/useClickOutside.test.jsx
+++ b/website/src/__tests__/useClickOutside.test.jsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import { useRef } from 'react';
+import useClickOutside from '../hooks/useClickOutside';
+
+function OutsideHarness({ onOutside, enabled, ignore, events }) {
+  const triggerRef = useRef(null);
+  const panelRef = useClickOutside(onOutside, { enabled, ignore: ignore ? [triggerRef] : [], events });
+
+  return (
+    <div>
+      <button ref={triggerRef}>trigger</button>
+      <div ref={panelRef} data-testid="panel">
+        panel
+      </div>
+      <button>outside</button>
+    </div>
+  );
+}
+
+describe('useClickOutside', () => {
+  afterEach(cleanup);
+
+  it('invokes the handler when clicking outside the watched element', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} />);
+
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invoke the handler when clicking inside the watched element', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} />);
+
+    fireEvent.mouseDown(screen.getByTestId('panel'));
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the handler when clicking an ignored ref node', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} ignore />);
+
+    fireEvent.mouseDown(screen.getByText('trigger'));
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it('fires for touchstart events', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} />);
+
+    fireEvent.touchStart(screen.getByText('outside'));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the native event to the handler', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} />);
+
+    const target = screen.getByText('outside');
+    fireEvent.mouseDown(target);
+    expect(onOutside).toHaveBeenCalledWith(expect.any(Event));
+  });
+
+  it('respects custom event types', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} events={['click']} />);
+
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(onOutside).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByText('outside'));
+    expect(onOutside).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when disabled', () => {
+    const onOutside = vi.fn();
+    render(<OutsideHarness onOutside={onOutside} enabled={false} />);
+
+    fireEvent.mouseDown(screen.getByText('outside'));
+    expect(onOutside).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the handler is not a function', () => {
+    render(<OutsideHarness onOutside={undefined} />);
+    expect(() => fireEvent.mouseDown(screen.getByText('outside'))).not.toThrow();
+  });
+});

--- a/website/src/hooks/useClickOutside.js
+++ b/website/src/hooks/useClickOutside.js
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Calls a handler when a pointer event lands outside the referenced element.
+ *
+ * Useful for dismissing dropdowns, menus, modals and popovers. Supports any
+ * number of extra "ignore" refs (e.g. a trigger button) so interacting with
+ * those nodes does not close the surface. Events are captured at the document
+ * level with the capture flag, which keeps the hook working even when the
+ * click target is removed from the DOM before the handler runs (a common
+ * React pitfall with onClickOutside implementations).
+ *
+ * @param {Function} onOutside - Callback invoked with the native event when a
+ *   click/tap occurs outside every watched node.
+ * @param {object} [options] - Behaviour options.
+ * @param {boolean} [options.enabled=true] - When `false`, listeners are not
+ *   attached and the hook becomes a no-op.
+ * @param {string[]} [options.events=['mousedown','touchstart']] - Event types
+ *   that count as "outside" interactions.
+ * @param {React.RefObject[]} [options.ignore=[]] - Additional refs whose nodes
+ *   are treated as inside.
+ * @returns {React.RefObject} A ref that must be attached to the element being
+ *   watched.
+ *
+ * @example
+ * function Dropdown() {
+ *   const triggerRef = useRef(null);
+ *   const panelRef = useClickOutside(() => setOpen(false), { ignore: [triggerRef] });
+ *   return (
+ *     <>
+ *       <button ref={triggerRef}>Open</button>
+ *       {open && <div ref={panelRef}>Panel</div>}
+ *     </>
+ *   );
+ * }
+ */
+export function useClickOutside(
+  onOutside,
+  { enabled = true, events = ['mousedown', 'touchstart'], ignore = [] } = {}
+) {
+  const ref = useRef(null);
+  const handlerRef = useRef(onOutside);
+  const optionsRef = useRef({ events, ignore });
+
+  handlerRef.current = onOutside;
+  optionsRef.current = { events, ignore };
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined' || typeof onOutside !== 'function') {
+      return undefined;
+    }
+
+    const handleEvent = (event) => {
+      const { target } = event;
+      if (!target || !target.isConnected) return;
+
+      const { events: eventTypes, ignore: ignoredRefs } = optionsRef.current;
+      const insideNodes = [ref.current, ...ignoredRefs.map((r) => r?.current)].filter(Boolean);
+      const hitInside = insideNodes.some((node) => {
+        if (node === target) return true;
+        if (typeof node.contains === 'function') return node.contains(target);
+        return false;
+      });
+
+      if (hitInside) return;
+      handlerRef.current?.(event);
+    };
+
+    const { events: eventTypes } = optionsRef.current;
+    eventTypes.forEach((type) => document.addEventListener(type, handleEvent, true));
+    return () => {
+      eventTypes.forEach((type) => document.removeEventListener(type, handleEvent, true));
+    };
+  }, [enabled]);
+
+  return ref;
+}
+
+export default useClickOutside;


### PR DESCRIPTION
## Summary

Adds `website/src/hooks/useClickOutside.js`, a reusable hook for dismissible surfaces.

Implementation details:
- Handlers and options are stored in refs (`handlerRef`, `optionsRef`) so the effect only re-subscribes when `enabled` flips — a rerender never churns document listeners.
- Listeners are attached in the capture phase, which keeps outside-detection correct when the click target unmounts during the same event tick (a known failure mode of bubble-phase onClickOutside patterns).
- Node membership checks use `node.contains(target)` guarded by `isConnected`, avoiding false positives for detached targets and stale refs.
- The default `['mousedown', 'touchstart']` set matches native dismiss semantics better than `click` and works on touch devices.

## Test Plan

`website/src/__tests__/useClickOutside.test.jsx` (8 cases):
- handler fires on outside click, not on inside click or ignored refs
- `touchstart` and custom event types are honoured
- disabled mode and non-function handlers are safe no-ops

Run with: `cd website && npm run test -- useClickOutside`

## Files Changed

- `website/src/hooks/useClickOutside.js` (new)
- `website/src/__tests__/useClickOutside.test.jsx` (new)

Fixes #4268

## GSSoC'26

Contribution for GSSoC'26.
