### PR TITLE
feat(website): add useCopyToClipboard hook with tests

### DIFF
--- a/website/src/__tests__/useCopyToClipboard.test.js
+++ b/website/src/__tests__/useCopyToClipboard.test.js
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act, cleanup } from '@testing-library/react';
+import useCopyToClipboard from '../hooks/useCopyToClipboard';
+
+describe('useCopyToClipboard', () => {
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    navigator.clipboard = originalClipboard;
+    vi.useRealTimers();
+  });
+
+  it('copies text via the async Clipboard API', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    navigator.clipboard = { writeText };
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy('hello world');
+    });
+
+    expect(writeText).toHaveBeenCalledWith('hello world');
+    expect(result.current.copied).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets copied back to false after the timeout', async () => {
+    navigator.clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    const { result } = renderHook(() => useCopyToClipboard({ timeout: 1500 }));
+
+    await act(async () => {
+      await result.current.copy('x');
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('keeps copied true indefinitely when timeout is 0', async () => {
+    navigator.clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    const { result } = renderHook(() => useCopyToClipboard({ timeout: 0 }));
+
+    await act(async () => {
+      await result.current.copy('x');
+    });
+    expect(result.current.copied).toBe(true);
+
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(result.current.copied).toBe(true);
+  });
+
+  it('coerces non-string values before copying', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    navigator.clipboard = { writeText };
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy(42);
+    });
+    expect(writeText).toHaveBeenCalledWith('42');
+  });
+
+  it('reports the error when the Clipboard API rejects', async () => {
+    navigator.clipboard = {
+      writeText: vi.fn().mockRejectedValue(new Error('Permission denied')),
+    };
+    const onError = vi.fn();
+    const { result } = renderHook(() => useCopyToClipboard({ onError }));
+
+    await act(async () => {
+      await result.current.copy('secret');
+    });
+
+    expect(result.current.copied).toBe(false);
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error.message).toBe('Permission denied');
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it('invokes onSuccess with the copied value', async () => {
+    navigator.clipboard = { writeText: vi.fn().mockResolvedValue(undefined) };
+    const onSuccess = vi.fn();
+    const { result } = renderHook(() => useCopyToClipboard({ onSuccess }));
+
+    await act(async () => {
+      await result.current.copy('payload');
+    });
+    expect(onSuccess).toHaveBeenCalledWith('payload');
+  });
+
+  it('falls back to execCommand when the Clipboard API is missing', async () => {
+    navigator.clipboard = undefined;
+    const execSpy = vi
+      .spyOn(document, 'execCommand')
+      .mockImplementation(() => true);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy('legacy text');
+    });
+
+    expect(execSpy).toHaveBeenCalledWith('copy');
+    expect(result.current.copied).toBe(true);
+
+    execSpy.mockRestore();
+  });
+
+  it('surfaces an error when execCommand fails', async () => {
+    navigator.clipboard = undefined;
+    vi.spyOn(document, 'execCommand').mockImplementation(() => false);
+
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy('legacy text');
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.copied).toBe(false);
+  });
+
+  it('resets copied and error state', async () => {
+    navigator.clipboard = { writeText: vi.fn().mockRejectedValue(new Error('nope')) };
+    const { result } = renderHook(() => useCopyToClipboard());
+
+    await act(async () => {
+      await result.current.copy('x');
+    });
+    expect(result.current.error).toBeInstanceOf(Error);
+
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.error).toBeNull();
+    expect(result.current.copied).toBe(false);
+  });
+});

--- a/website/src/hooks/useCopyToClipboard.js
+++ b/website/src/hooks/useCopyToClipboard.js
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Copies text to the clipboard and tracks the transient "copied" state.
+ *
+ * Prefers the async `navigator.clipboard` API and falls back to a hidden
+ * textarea + `document.execCommand('copy')` for browsers/contexts (or older
+ * WebViews) where the Clipboard API is not exposed. `copied` resets
+ * automatically after `timeout` ms so components can drive a checkmark or
+ * toast without extra bookkeeping.
+ *
+ * @param {object} [options] - Behaviour options.
+ * @param {number} [options.timeout=2000] - How long `copied` stays `true`
+ *   after a successful copy. Pass `0` to keep it set until `reset()`.
+ * @param {Function} [options.onSuccess] - Called with the copied string.
+ * @param {Function} [options.onError] - Called with the thrown error.
+ * @returns {object} `{ copy, copied, error, reset }`.
+ *
+ * @example
+ * const { copy, copied } = useCopyToClipboard();
+ * <button onClick={() => copy('npm i react')}>{copied ? 'Copied!' : 'Copy'}</button>
+ */
+export function useCopyToClipboard({ timeout = 2000, onSuccess, onError } = {}) {
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState(null);
+  const timerRef = useRef(null);
+  const callbacksRef = useRef({ onSuccess, onError });
+  callbacksRef.current = { onSuccess, onError };
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  const copy = useCallback(
+    async (text) => {
+      const value = String(text ?? '');
+      try {
+        if (navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
+          await navigator.clipboard.writeText(value);
+        } else {
+          legacyCopy(value);
+        }
+
+        setCopied(true);
+        setError(null);
+        clearTimeout(timerRef.current);
+        if (timeout > 0) {
+          timerRef.current = setTimeout(() => setCopied(false), timeout);
+        }
+        callbacksRef.current.onSuccess?.(value);
+      } catch (err) {
+        setCopied(false);
+        setError(err);
+        callbacksRef.current.onError?.(err);
+      }
+    },
+    [timeout]
+  );
+
+  const reset = useCallback(() => {
+    setCopied(false);
+    setError(null);
+  }, []);
+
+  return { copy, copied, error, reset };
+}
+
+/**
+ * Synchronous fallback using a temporary textarea and execCommand.
+ * Only reached when `navigator.clipboard` is unavailable.
+ *
+ * @param {string} text - Text to place on the clipboard.
+ */
+function legacyCopy(text) {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'fixed';
+  textarea.style.top = '-9999px';
+  textarea.style.opacity = '0';
+  document.body.appendChild(textarea);
+  textarea.select();
+  try {
+    const ok = document.execCommand('copy');
+    if (!ok) {
+      throw new Error('execCommand("copy") returned false');
+    }
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export default useCopyToClipboard;


### PR DESCRIPTION
## Summary

Adds `website/src/hooks/useCopyToClipboard.js`, a shared hook for copy interactions across the site.

Implementation details:
- Prefers `navigator.clipboard.writeText` and degrades to a temporary textarea + `document.execCommand('copy')`, covering desktop Safari and embedded WebViews.
- `copied` is time-based state driven by a ref-held timer; the timer is cleared on unmount, and a new copy restarts the window rather than stacking timers.
- `onSuccess`/`onError` are kept in a ref so callers never need to memoise them to avoid stale closures.
- Failures are captured in `error` (never swallowed silently) while still leaving `copied` false.

## Test Plan

`website/src/__tests__/useCopyToClipboard.test.js` (9 cases):
- modern API copy + `copied` lifecycle with fake timers
- legacy `execCommand` success and failure paths
- timeout `0` persistence, `reset()`, and error reporting

Run with: `cd website && npm run test -- useCopyToClipboard`

## Files Changed

- `website/src/hooks/useCopyToClipboard.js` (new)
- `website/src/__tests__/useCopyToClipboard.test.js` (new)

Fixes #4270

## GSSoC'26

Contribution for GSSoC'26.
