### PR TITLE
feat(website): add useKeyPress hook with tests

### DIFF
--- a/website/src/__tests__/useKeyPress.test.js
+++ b/website/src/__tests__/useKeyPress.test.js
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { renderHook, cleanup, fireEvent } from '@testing-library/react';
+import useKeyPress from '../hooks/useKeyPress';
+
+function press(key, options = {}) {
+  fireEvent.keyDown(window, { key, ...options });
+}
+
+describe('useKeyPress', () => {
+  afterEach(cleanup);
+
+  it('calls the handler when the key is pressed', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress('Escape', handler));
+
+    press('Escape');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the handler for other keys', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress('Escape', handler));
+
+    press('Enter');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('matches single letters case-insensitively', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress('a', handler));
+
+    press('a');
+    press('A');
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('matches any key in an array', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress(['Escape', 'Enter'], handler));
+
+    press('Enter');
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    press('Escape');
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('matches modifier combinations exactly', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress({ key: 'k', ctrlKey: true }, handler));
+
+    press('k', { ctrlKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    press('k', { ctrlKey: false });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches meta-key shortcuts (Cmd+K)', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress({ key: 'k', metaKey: true }, handler));
+
+    press('k', { metaKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    press('k', { metaKey: false });
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports multiple descriptor objects', () => {
+    const handler = vi.fn();
+    renderHook(() =>
+      useKeyPress([{ key: 'k', ctrlKey: true }, { key: 'k', metaKey: true }], handler)
+    );
+
+    press('k', { metaKey: true });
+    expect(handler).toHaveBeenCalledTimes(1);
+
+    press('k', { ctrlKey: true });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing while disabled', () => {
+    const handler = vi.fn();
+    renderHook(() => useKeyPress('Escape', handler, { enabled: false }));
+
+    press('Escape');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('re-binds when the key set changes', () => {
+    const handler = vi.fn();
+    const { rerender } = renderHook(({ key }) => useKeyPress(key, handler), {
+      initialProps: { key: 'Escape' },
+    });
+
+    rerender({ key: 'Enter' });
+    press('Escape');
+    expect(handler).not.toHaveBeenCalled();
+
+    press('Enter');
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const handler = vi.fn();
+    const { unmount } = renderHook(() => useKeyPress('Escape', handler));
+
+    unmount();
+    press('Escape');
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('uses the latest handler without re-binding', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ handler }) => useKeyPress('Escape', handler), {
+      initialProps: { handler: first },
+    });
+
+    rerender({ handler: second });
+    press('Escape');
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/website/src/hooks/useKeyPress.js
+++ b/website/src/hooks/useKeyPress.js
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Invokes a handler when one of a set of keyboard keys is pressed.
+ *
+ * Supports plain key names (`'Escape'`, `'Enter'`, `'a'`) as well as modifier
+ * combos expressed as objects, e.g. `{ key: 'k', metaKey: true, ctrlKey: true }`
+ * for a Cmd/Ctrl+K shortcut. Matching is normalised to `event.key` and is
+ * case-insensitive for single letters, so `'a'` matches both `A` and `a`.
+ *
+ * @param {string|string[]|object|object[]} keys - Key name(s) or key combo
+ *   descriptor(s). A descriptor may include `key` plus any of `ctrlKey`,
+ *   `shiftKey`, `altKey`, `metaKey`.
+ * @param {Function} handler - Callback invoked with the keydown event.
+ * @param {object} [options] - Behaviour options.
+ * @param {boolean} [options.enabled=true] - When `false`, the listener is not
+ *   attached.
+ * @param {string} [options.eventType='keydown'] - DOM event type to listen for.
+ * @returns {void}
+ *
+ * @example
+ * useKeyPress('Escape', () => setOpen(false));
+ * useKeyPress([{ key: 'k', ctrlKey: true }, { key: 'k', metaKey: true }], openPalette);
+ */
+export function useKeyPress(keys, handler, { enabled = true, eventType = 'keydown' } = {}) {
+  const handlerRef = useRef(handler);
+  handlerRef.current = handler;
+
+  useEffect(() => {
+    if (!enabled || typeof window === 'undefined') return undefined;
+
+    const keySet = Array.isArray(keys) ? keys : [keys];
+
+    const handleKey = (event) => {
+      if (keySet.some((descriptor) => matchesKey(event, descriptor))) {
+        handlerRef.current?.(event);
+      }
+    };
+
+    window.addEventListener(eventType, handleKey);
+    return () => window.removeEventListener(eventType, handleKey);
+  }, [enabled, eventType, keys]);
+
+  return undefined;
+}
+
+/**
+ * Tests a keyboard event against a single key descriptor.
+ *
+ * @param {KeyboardEvent} event - The native keyboard event.
+ * @param {string|object} descriptor - Key name or descriptor object.
+ * @returns {boolean} Whether the event satisfies the descriptor.
+ */
+function matchesKey(event, descriptor) {
+  if (descriptor && typeof descriptor === 'object') {
+    const { key, ctrlKey = false, shiftKey = false, altKey = false, metaKey = false } = descriptor;
+    return (
+      normalizeKey(event.key) === normalizeKey(key) &&
+      Boolean(event.ctrlKey) === ctrlKey &&
+      Boolean(event.shiftKey) === shiftKey &&
+      Boolean(event.altKey) === altKey &&
+      Boolean(event.metaKey) === metaKey
+    );
+  }
+  return normalizeKey(event.key) === normalizeKey(String(descriptor));
+}
+
+/**
+ * Normalises a key value so letter comparisons are case-insensitive while
+ * named keys like `'Escape'` stay exact.
+ *
+ * @param {string} key - Raw key value.
+ * @returns {string} Normalised key value.
+ */
+function normalizeKey(key) {
+  if (!key) return '';
+  return key.length === 1 ? key.toLowerCase() : key;
+}
+
+export default useKeyPress;


### PR DESCRIPTION
## Summary

Adds `website/src/hooks/useKeyPress.js`, a declarative keyboard-shortcut hook.

Implementation details:
- Key matching supports both plain names and modifier descriptors; a descriptor requires every listed modifier to be in the exact expected state, preventing sloppy shortcuts like "Ctrl+K" firing when Shift is also held.
- `normalizeKey` lowercases single characters so `'a'` matches both cases, while named keys remain exact.
- The handler lives in a ref, so callers can pass an inline closure every render without the effect re-subscribing (the listener only rebinds when the key set, event type, or `enabled` change).
- Listener attaches to `window` and is fully removed on unmount.

## Test Plan

`website/src/__tests__/useKeyPress.test.js` (11 cases):
- single key, arrays, case-insensitive letters
- modifier and meta combos, disabled mode
- re-bind on key change, unmount cleanup, latest-handler semantics

Run with: `cd website && npm run test -- useKeyPress`

## Files Changed

- `website/src/hooks/useKeyPress.js` (new)
- `website/src/__tests__/useKeyPress.test.js` (new)

Fixes #4272

## GSSoC'26

Contribution for GSSoC'26.
