### PR TITLE
feat(website): add reduced-motion preference hooks with tests

### DIFF
--- a/website/src/__tests__/usePrefersReducedMotion.test.js
+++ b/website/src/__tests__/usePrefersReducedMotion.test.js
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import {
+  usePrefersReducedMotion,
+  useMotionPreference,
+} from '../hooks/usePrefersReducedMotion';
+
+const originalMatchMedia = window.matchMedia;
+
+/**
+ * Builds a matchMedia mock whose matches state is derived from the query.
+ */
+function mockMatchMedia(resolution) {
+  window.matchMedia = vi.fn().mockImplementation((query) => {
+    const queries = {
+      '(prefers-reduced-motion: reduce)': resolution === 'reduce',
+      '(prefers-reduced-motion: no-preference)': resolution === 'no-preference',
+    };
+    const listeners = new Set();
+    const mql = {
+      matches: Boolean(queries[query]),
+      media: query,
+      onchange: null,
+      addEventListener: (type, listener) => {
+        if (type === 'change') listeners.add(listener);
+      },
+      removeEventListener: (type, listener) => {
+        if (type === 'change') listeners.delete(listener);
+      },
+      addListener: (listener) => listeners.add(listener),
+      removeListener: (listener) => listeners.delete(listener),
+      dispatchEvent: vi.fn(),
+    };
+    mql._set = (value) => {
+      mql.matches = value;
+      const event = { matches: value };
+      listeners.forEach((listener) => listener(event));
+    };
+    return mql;
+  });
+}
+
+describe('usePrefersReducedMotion', () => {
+  beforeEach(() => mockMatchMedia('reduce'));
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns true when reduce is preferred', () => {
+    mockMatchMedia('reduce');
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when the user has no motion preference', () => {
+    mockMatchMedia('no-preference');
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false when the media query is unsupported', () => {
+    window.matchMedia = undefined;
+    const { result } = renderHook(() => usePrefersReducedMotion());
+    expect(result.current).toBe(false);
+  });
+
+  it('flips to true when the OS preference changes at runtime', () => {
+    mockMatchMedia('no-preference');
+    const { result } = renderHook(() => usePrefersReducedMotion());
+
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    expect(result.current).toBe(false);
+
+    act(() => {
+      mql._set(true);
+    });
+    expect(result.current).toBe(true);
+  });
+});
+
+describe('useMotionPreference', () => {
+  beforeEach(() => mockMatchMedia('reduce'));
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  it('returns "reduce" when reduced motion is requested', () => {
+    mockMatchMedia('reduce');
+    const { result } = renderHook(() => useMotionPreference());
+    expect(result.current).toBe('reduce');
+  });
+
+  it('returns "no-preference" when the user opts in', () => {
+    mockMatchMedia('no-preference');
+    const { result } = renderHook(() => useMotionPreference());
+    expect(result.current).toBe('no-preference');
+  });
+
+  it('returns "unset" when neither value matches', () => {
+    mockMatchMedia('unset');
+    const { result } = renderHook(() => useMotionPreference());
+    expect(result.current).toBe('unset');
+  });
+});

--- a/website/src/hooks/usePrefersReducedMotion.js
+++ b/website/src/hooks/usePrefersReducedMotion.js
@@ -1,0 +1,48 @@
+import useMediaQuery from './useMediaQuery';
+
+/**
+ * True when the user has requested reduced motion via
+ * `prefers-reduced-motion: reduce` (OS-level accessibility setting).
+ *
+ * Components that run continuous animations or auto-scrolling can gate that
+ * behaviour with this hook instead of hard-coding it into CSS, which is
+ * particularly useful for imperative JS animations (canvas loops, carousels,
+ * marquees) that CSS media queries cannot reach.
+ *
+ * @returns {boolean} Whether the user prefers reduced motion.
+ *
+ * @example
+ * const reduceMotion = usePrefersReducedMotion();
+ * useEffect(() => {
+ *   if (reduceMotion) return;
+ *   const raf = requestAnimationFrame(animate);
+ *   return () => cancelAnimationFrame(raf);
+ * }, [reduceMotion]);
+ */
+export function usePrefersReducedMotion() {
+  return useMediaQuery('(prefers-reduced-motion: reduce)');
+}
+
+/**
+ * Resolves the full `prefers-reduced-motion` preference into a stable value.
+ *
+ * Returns `'reduce'` when the user has opted out of motion, `'no-preference'`
+ * when they explicitly opted in, and `'unset'` when the media query reports
+ * neither value (older browsers may only support `reduce`).
+ *
+ * @returns {'reduce'|'no-preference'|'unset'} The resolved preference.
+ *
+ * @example
+ * const motion = useMotionPreference();
+ * const animationDuration = motion === 'reduce' ? 0 : 300;
+ */
+export function useMotionPreference() {
+  const reduced = useMediaQuery('(prefers-reduced-motion: reduce)');
+  const noPreference = useMediaQuery('(prefers-reduced-motion: no-preference)');
+
+  if (reduced) return 'reduce';
+  if (noPreference) return 'no-preference';
+  return 'unset';
+}
+
+export default usePrefersReducedMotion;


### PR DESCRIPTION
## Summary

Adds `website/src/hooks/usePrefersReducedMotion.js`, exposing OS motion preferences to React components.

Implementation details:
- `usePrefersReducedMotion` is a thin, SSR-safe wrapper over `useMediaQuery('(prefers-reduced-motion: reduce)')`, so it inherits listener cleanup, hydration-safe initialisation, and fallback semantics instead of duplicating `matchMedia` logic.
- `useMotionPreference` resolves the preference into a single value (`reduce`/`no-preference`/`unset`), giving imperative animation code a stable branch point without three separate queries.
- Because it composes the existing hook, enabling motion gating in `ParticleBackground`/count-up components requires no new event plumbing.

## Test Plan

`website/src/__tests__/usePrefersReducedMotion.test.js` (7 cases):
- both hooks across all preference resolutions
- runtime OS-preference flip
- `matchMedia` unavailable (SSR) fallback

Run with: `cd website && npm run test -- usePrefersReducedMotion`

## Files Changed

- `website/src/hooks/usePrefersReducedMotion.js` (new)
- `website/src/__tests__/usePrefersReducedMotion.test.js` (new)

Fixes #4274

## GSSoC'26

Contribution for GSSoC'26.
