### PR TITLE
feat(website): add promise resilience utilities with tests

### DIFF
--- a/website/src/__tests__/promise.test.js
+++ b/website/src/__tests__/promise.test.js
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { withTimeout, retry, sequential, mapLimit, delayValue } from '../utils/promise';
+
+const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('withTimeout', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resolves with the input result before the deadline', async () => {
+    const pending = withTimeout(Promise.resolve(42), 1000);
+    const result = await Promise.resolve(pending);
+    await tick();
+    expect(result).toBe(42);
+  });
+
+  it('rejects with the timeout message after the deadline', async () => {
+    const pending = withTimeout(new Promise(() => {}), 500);
+    let rejected = null;
+    pending.catch((e) => {
+      rejected = e;
+    });
+
+    vi.advanceTimersByTime(501);
+    await tick();
+    expect(rejected).toBeInstanceOf(Error);
+    expect(rejected.message).toBe('Operation timed out');
+  });
+
+  it('rejects a non-thenable immediately', async () => {
+    await expect(withTimeout(null, 100)).rejects.toThrow(TypeError);
+  });
+});
+
+describe('retry', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('resolves on the first successful attempt', async () => {
+    const fn = vi.fn().mockResolvedValue('ok');
+    const result = await retry(fn, { retries: 3 });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries and eventually succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValue('recovered');
+
+    const resultPromise = retry(fn, { retries: 3, baseDelay: 100 });
+    const assertion = resultPromise.then((value) => {
+      expect(value).toBe('recovered');
+      expect(fn).toHaveBeenCalledTimes(3);
+    });
+
+    await vi.advanceTimersByTimeAsync(2000);
+    await assertion;
+  });
+
+  it('rejects with the last error after exhausting attempts', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('stubborn'));
+    const promise = retry(fn, { retries: 2, baseDelay: 10 });
+    const assertion = expect(promise).rejects.toThrow('stubborn');
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops early when shouldRetry returns false', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fatal'))
+      .mockResolvedValue('ignored');
+    const promise = retry(fn, {
+      retries: 5,
+      shouldRetry: (e) => e.message !== 'fatal',
+    });
+    const assertion = expect(promise).rejects.toThrow('fatal');
+    await vi.advanceTimersByTimeAsync(1000);
+    await assertion;
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('notifies via onRetry with the attempt number', async () => {
+    const onRetry = vi.fn();
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('x'))
+      .mockResolvedValue('ok');
+
+    const promise = retry(fn, { retries: 2, baseDelay: 50, onRetry });
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    expect(onRetry.mock.calls[0][1]).toBe(1);
+  });
+});
+
+describe('sequential', () => {
+  it('runs tasks in order and preserves order', async () => {
+    const order = [];
+    const results = await sequential([1, 2, 3], async (n) => {
+      order.push(n);
+      return n * 2;
+    });
+    expect(order).toEqual([1, 2, 3]);
+    expect(results).toEqual([2, 4, 6]);
+  });
+});
+
+describe('mapLimit', () => {
+  it('respects the concurrency limit', async () => {
+    let active = 0;
+    let peak = 0;
+    await mapLimit([1, 2, 3, 4, 5, 6], 2, async (n) => {
+      active += 1;
+      peak = Math.max(peak, active);
+      await tick();
+      active -= 1;
+      return n;
+    });
+    expect(peak).toBe(2);
+  });
+
+  it('preserves input order', async () => {
+    const results = await mapLimit([1, 2, 3, 4], 1, async (n) => n * 3);
+    expect(results).toEqual([3, 6, 9, 12]);
+  });
+
+  it('rejects invalid limits', async () => {
+    await expect(mapLimit([1], 0, async () => {})).rejects.toThrow(RangeError);
+  });
+});
+
+describe('delayValue', () => {
+  it('resolves with the value after the delay', async () => {
+    vi.useFakeTimers();
+    const pending = delayValue('done', 300);
+    const assertion = pending.then((value) => expect(value).toBe('done'));
+    await vi.advanceTimersByTimeAsync(300);
+    await assertion;
+    vi.useRealTimers();
+  });
+});

--- a/website/src/utils/promise.js
+++ b/website/src/utils/promise.js
@@ -1,0 +1,129 @@
+/**
+ * Promise helpers for resilient async flows.
+ *
+ * The site's data layer already layers retries and caching (`syncManager.js`,
+ * `offlineQueue.js`, `indexedDB.js`), but each does its own retry/timeout
+ * bookkeeping. These small, dependency-free helpers standardise the common
+ * patterns so callers get bounded latency and backoff without reimplementing
+ * setTimeout plumbing.
+ */
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Rejects a promise chain after `ms` milliseconds.
+ *
+ * @param {Promise} promise - The promise to race against.
+ * @param {number} ms - Timeout in milliseconds.
+ * @param {string} [message='Operation timed out'] - Rejection reason.
+ * @returns {Promise} Settles with the input's result or rejects on timeout.
+ *
+ * @example
+ * const data = await withTimeout(api.get('/events'), 5000);
+ */
+export function withTimeout(promise, ms, message = 'Operation timed out') {
+  if (!promise || typeof promise.then !== 'function') {
+    return Promise.reject(new TypeError('withTimeout expects a thenable'));
+  }
+  let timerId;
+  const timeout = new Promise((_, reject) => {
+    timerId = setTimeout(() => reject(new Error(message)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timerId));
+}
+
+/**
+ * Re-runs an async function on failure using exponential backoff.
+ *
+ * @param {Function} fn - Async function to retry. Called with the attempt
+ *   number (1-based) as its first argument.
+ * @param {object} [options] - Retry options.
+ * @param {number} [options.retries=3] - Max additional attempts after the
+ *   first failure.
+ * @param {number} [options.baseDelay=250] - Initial delay in ms.
+ * @param {number} [options.maxDelay=5000] - Cap on the backoff delay.
+ * @param {Function} [options.onRetry] - Called with the error and attempt.
+ * @param {Function} [options.shouldRetry] - Predicate deciding whether to
+ *   retry for a given error. Defaults to retrying everything.
+ * @returns {Promise} Resolves with `fn`'s result or rejects with the last
+ *   error after exhausting attempts.
+ *
+ * @example
+ * const events = await retry(() => api.list('/events'), { retries: 2 });
+ */
+export async function retry(
+  fn,
+  { retries = 3, baseDelay = 250, maxDelay = 5000, onRetry, shouldRetry } = {}
+) {
+  let attempt = 0;
+  let lastError;
+  while (attempt <= retries) {
+    attempt += 1;
+    try {
+      return await fn(attempt);
+    } catch (error) {
+      lastError = error;
+      if (attempt > retries) break;
+      if (shouldRetry && !shouldRetry(error)) break;
+      const delay = Math.min(baseDelay * 2 ** (attempt - 1), maxDelay);
+      onRetry?.(error, attempt, delay);
+      await sleep(delay);
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Runs async tasks one at a time, awaiting each before starting the next.
+ *
+ * @param {Array} items - Input values for each task.
+ * @param {Function} task - Async function receiving `(item, index)`.
+ * @returns {Promise<Array>} Results in input order.
+ */
+export async function sequential(items, task) {
+  const results = [];
+  for (let i = 0; i < items.length; i += 1) {
+    results.push(await task(items[i], i));
+  }
+  return results;
+}
+
+/**
+ * Runs async tasks with a concurrency limit, preserving input order.
+ *
+ * @param {Array} items - Input values for each task.
+ * @param {number} limit - Maximum concurrent tasks.
+ * @param {Function} task - Async function receiving `(item, index)`.
+ * @returns {Promise<Array>} Results in input order.
+ */
+export async function mapLimit(items, limit, task) {
+  if (!(limit >= 1)) throw new RangeError('mapLimit requires limit >= 1');
+  const results = new Array(items.length);
+  let cursor = 0;
+
+  const worker = async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await task(items[index], index);
+    }
+  };
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () => worker());
+  await Promise.all(workers);
+  return results;
+}
+
+/**
+ * Resolves with a value only after `ms` milliseconds (e.g. enforced minimum
+ * loading time).
+ *
+ * @param {*} value - Value to resolve with.
+ * @param {number} ms - Minimum delay.
+ * @returns {Promise} Promise resolving with `value`.
+ */
+export function delayValue(value, ms) {
+  return sleep(ms).then(() => value);
+}
+
+export default retry;


### PR DESCRIPTION
## Summary

Adds `website/src/utils/promise.js`.

Implementation details:
- `retry` uses `baseDelay * 2 ** (attempt - 1)` capped at `maxDelay`, passing the 1-based attempt into `fn` so callers can distinguish calls. `shouldRetry` lets transient errors (5xx) be retried while fatal errors (4xx) abort immediately.
- `withTimeout` races against a reject-on-timer promise and always clears the timer via `finally`, so no stale timers leak from timeouts that resolve first.
- `mapLimit` implements a fixed worker-pool over a shared cursor, guaranteeing output order matches input order regardless of which worker finishes first.
- `delayValue` gives callers a deterministic "minimum loading time" without bespoke `setTimeout` chains.

## Test Plan

`website/src/__tests__/promise.test.js` (12 cases, vitest fake timers):
- timeout resolve/reject, retry recovery/exhaustion/abort/backoff
- sequential ordering, concurrency peak, mapLimit order + invalid limit

Run with: `cd website && npm run test -- promise`

## Files Changed

- `website/src/utils/promise.js` (new)
- `website/src/__tests__/promise.test.js` (new)

Fixes #4288

## GSSoC'26

Contribution for GSSoC'26.
