### PR TITLE
feat(website): add shared date utilities with tests

### DIFF
--- a/website/src/__tests__/dateUtils.test.js
+++ b/website/src/__tests__/dateUtils.test.js
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  toDate,
+  addDays,
+  startOfDay,
+  endOfDay,
+  isToday,
+  isPast,
+  isFuture,
+  isWithinDays,
+  daysBetween,
+  formatDateRange,
+  toISODate,
+} from '../utils/dateUtils';
+
+const DAY = 24 * 60 * 60 * 1000;
+
+describe('toDate', () => {
+  it('parses Date, ISO string and timestamp', () => {
+    const d = new Date('2025-06-10T10:00:00Z');
+    expect(toDate(d).getTime()).toBe(d.getTime());
+    expect(toDate('2025-06-10T10:00:00Z').getTime()).toBe(d.getTime());
+    expect(toDate(d.getTime()).getTime()).toBe(d.getTime());
+  });
+
+  it('returns null for invalid input', () => {
+    expect(toDate(null)).toBeNull();
+    expect(toDate('not-a-date')).toBeNull();
+    expect(toDate(new Date('invalid'))).toBeNull();
+  });
+});
+
+describe('addDays', () => {
+  it('adds and subtracts days', () => {
+    const base = new Date(2025, 0, 10);
+    expect(addDays(base, 5).getDate()).toBe(15);
+    expect(addDays(base, -3).getDate()).toBe(7);
+  });
+
+  it('does not mutate the input', () => {
+    const base = new Date(2025, 0, 10);
+    addDays(base, 5);
+    expect(base.getDate()).toBe(10);
+  });
+});
+
+describe('startOfDay / endOfDay', () => {
+  it('zeroes and maxes the time components', () => {
+    const d = new Date(2025, 5, 15, 14, 30, 45, 123);
+    const start = startOfDay(d);
+    const end = endOfDay(d);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+  });
+});
+
+describe('isToday', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns true for now and false for other days', () => {
+    expect(isToday(new Date())).toBe(true);
+    expect(isToday(new Date(Date.now() - DAY))).toBe(false);
+  });
+
+  it('returns false for invalid input', () => {
+    expect(isToday(null)).toBe(false);
+  });
+});
+
+describe('isPast / isFuture', () => {
+  it('classifies relative to now', () => {
+    expect(isPast(Date.now() - DAY)).toBe(true);
+    expect(isPast(Date.now() + DAY)).toBe(false);
+    expect(isFuture(Date.now() + DAY)).toBe(true);
+    expect(isFuture(Date.now() - DAY)).toBe(false);
+  });
+
+  it('returns false for invalid input', () => {
+    expect(isPast(null)).toBe(false);
+    expect(isFuture(null)).toBe(false);
+  });
+});
+
+describe('isWithinDays', () => {
+  it('includes the inclusive window edges', () => {
+    expect(isWithinDays(Date.now(), 1)).toBe(true);
+    expect(isWithinDays(Date.now() + DAY, 1)).toBe(true);
+    expect(isWithinDays(Date.now() + 2 * DAY, 1)).toBe(false);
+  });
+});
+
+describe('daysBetween', () => {
+  it('computes whole-day differences', () => {
+    expect(daysBetween('2025-01-01', '2025-01-04')).toBe(3);
+    expect(daysBetween('2025-01-04', '2025-01-01')).toBe(-3);
+  });
+
+  it('returns null for invalid input', () => {
+    expect(daysBetween('bad', '2025-01-01')).toBeNull();
+  });
+});
+
+describe('formatDateRange', () => {
+  it('collapses same-day ranges', () => {
+    const out = formatDateRange('2025-06-10', '2025-06-10');
+    expect(out).not.toContain('–');
+  });
+
+  it('renders multi-day ranges with a separator', () => {
+    const out = formatDateRange('2025-06-10', '2025-06-14');
+    expect(out).toContain('–');
+    expect(out).toContain('Jun');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(formatDateRange(null)).toBeNull();
+  });
+});
+
+describe('toISODate', () => {
+  it('formats YYYY-MM-DD with padding', () => {
+    expect(toISODate(new Date(2025, 5, 9))).toBe('2025-06-09');
+    expect(toISODate('2025-12-31T23:59:00Z').slice(0, 10)).toBe('2025-12-31');
+  });
+
+  it('returns null for invalid input', () => {
+    expect(toISODate(null)).toBeNull();
+  });
+});

--- a/website/src/utils/dateUtils.js
+++ b/website/src/utils/dateUtils.js
@@ -1,0 +1,187 @@
+/**
+ * Date mathematics and calendar helpers.
+ *
+ * Complements `formatRelativeTime.js` (relative labels) with the day/week
+ * arithmetic the events calendar, attendance grid and analytics dashboards
+ * need. All functions accept a `Date`, timestamp or ISO string and normalise
+ * through `toDate`, returning `null` for anything unparseable instead of
+ * throwing on an invalid `Date`.
+ */
+
+/**
+ * Coerces a value into a valid Date, or `null` when it cannot be parsed.
+ *
+ * @param {Date|string|number|null|undefined} value - Value to coerce.
+ * @returns {Date|null} Valid date or `null`.
+ */
+export function toDate(value) {
+  if (value == null) return null;
+  if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+/**
+ * Returns a new Date with `days` added (negative values subtract).
+ *
+ * @param {Date|string|number} value - Base date.
+ * @param {number} days - Days to add.
+ * @returns {Date|null} Resulting date.
+ */
+export function addDays(value, days) {
+  const date = toDate(value);
+  if (!date) return null;
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+/**
+ * Returns a new Date at 00:00:00.000 for the given day.
+ *
+ * @param {Date|string|number} value - Reference date.
+ * @returns {Date|null} Start of day.
+ */
+export function startOfDay(value) {
+  const date = toDate(value);
+  if (!date) return null;
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+/**
+ * Returns a new Date at 23:59:59.999 for the given day.
+ *
+ * @param {Date|string|number} value - Reference date.
+ * @returns {Date|null} End of day.
+ */
+export function endOfDay(value) {
+  const date = toDate(value);
+  if (!date) return null;
+  const copy = new Date(date);
+  copy.setHours(23, 59, 59, 999);
+  return copy;
+}
+
+/**
+ * Whether a date falls on today's calendar day.
+ *
+ * @param {Date|string|number} value - Date to test.
+ * @returns {boolean} True when it is today.
+ */
+export function isToday(value) {
+  const date = toDate(value);
+  if (!date) return false;
+  const now = new Date();
+  return (
+    date.getFullYear() === now.getFullYear() &&
+    date.getMonth() === now.getMonth() &&
+    date.getDate() === now.getDate()
+  );
+}
+
+/**
+ * Whether a date is strictly before now.
+ *
+ * @param {Date|string|number} value - Date to test.
+ * @returns {boolean} True when the date is in the past.
+ */
+export function isPast(value) {
+  const date = toDate(value);
+  if (!date) return false;
+  return date.getTime() < Date.now();
+}
+
+/**
+ * Whether a date is strictly after now.
+ *
+ * @param {Date|string|number} value - Date to test.
+ * @returns {boolean} True when the date is in the future.
+ */
+export function isFuture(value) {
+  const date = toDate(value);
+  if (!date) return false;
+  return date.getTime() > Date.now();
+}
+
+/**
+ * Whether a date falls within `days` days of today (inclusive).
+ *
+ * @param {Date|string|number} value - Date to test.
+ * @param {number} days - Window size in days.
+ * @returns {boolean} True when within the window.
+ */
+export function isWithinDays(value, days) {
+  const date = toDate(value);
+  if (!date) return false;
+  const now = startOfDay(new Date());
+  const target = startOfDay(date);
+  if (!now || !target) return false;
+  const diff = Math.abs(target.getTime() - now.getTime());
+  return diff <= days * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * Whole days between two dates (positive when `from` precedes `to`).
+ *
+ * @param {Date|string|number} from - Earlier date.
+ * @param {Date|string|number} to - Later date.
+ * @returns {number|null} Day difference or `null` on invalid input.
+ */
+export function daysBetween(from, to) {
+  const fromDate = startOfDay(from);
+  const toDateVal = startOfDay(to);
+  if (!fromDate || !toDateVal) return null;
+  return Math.round((toDateVal.getTime() - fromDate.getTime()) / (24 * 60 * 60 * 1000));
+}
+
+/**
+ * Formats a date range as a human string, collapsing same-day ranges.
+ *
+ * @param {Date|string|number} start - Range start.
+ * @param {Date|string|number} end - Range end.
+ * @param {object} [options] - Options.
+ * @param {string} [options.locale] - Locale for the formatter.
+ * @param {object} [options.dateStyle={day:'numeric', month:'short'}] - Style.
+ * @returns {string|null} E.g. `12 Aug – 14 Aug` or `12 Aug`.
+ */
+export function formatDateRange(start, end, { locale, dateStyle = { day: 'numeric', month: 'short' } } = {}) {
+  const startDate = toDate(start);
+  const endDate = toDate(end);
+  if (!startDate) return null;
+  const fmt = (d) => d.toLocaleDateString(locale, dateStyle);
+  if (!endDate || startOfDay(startDate).getTime() === startOfDay(endDate).getTime()) {
+    return fmt(startDate);
+  }
+  return `${fmt(startDate)} – ${fmt(endDate)}`;
+}
+
+/**
+ * Formats a date for API/URL payloads as `YYYY-MM-DD`.
+ *
+ * @param {Date|string|number} value - Date to format.
+ * @returns {string|null} ISO calendar date.
+ */
+export function toISODate(value) {
+  const date = toDate(value);
+  if (!date) return null;
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+export default {
+  toDate,
+  addDays,
+  startOfDay,
+  endOfDay,
+  isToday,
+  isPast,
+  isFuture,
+  isWithinDays,
+  daysBetween,
+  formatDateRange,
+  toISODate,
+};


### PR DESCRIPTION
## Summary

Adds `website/src/utils/dateUtils.js`.

Implementation details:
- Every helper funnels through `toDate`, which normalises `Date`/timestamp/ISO-string inputs and returns `null` for anything unparseable — so `isToday(null)` returns `false` instead of throwing, matching the defensive style of `formatRelativeTime.js`.
- `addDays`/`startOfDay`/`endOfDay` always return fresh `Date` copies, never mutating caller state.
- `formatDateRange` compares calendar days (not milliseconds) so a same-day range like `10 Jun 00:00` -> `10 Jun 23:59` renders as a single day.
- `toISODate` builds `YYYY-MM-DD` manually (rather than `toISOString().slice(0,10)`) to avoid UTC/local timezone drift for local events.

## Test Plan

`website/src/__tests__/dateUtils.test.js` (17 cases):
- coercion and invalid input, day arithmetic, immutability
- today/past/future windows, day differences, ranges, ISO formatting

Run with: `cd website && npm run test -- dateUtils`

## Files Changed

- `website/src/utils/dateUtils.js` (new)
- `website/src/__tests__/dateUtils.test.js` (new)

Fixes #4290

## GSSoC'26

Contribution for GSSoC'26.
