### PR TITLE
fix : initialize errorsByEndpoint in errorTrackingService.js

### DIFF
--- a/server/services/errorTrackingService.js
+++ b/server/services/errorTrackingService.js
@@ -1,17 +1,18 @@
-import 'dotenv/config';
+import "dotenv/config";
 /**
  * Error Tracking Service
  * Manages error logging, tracking, and analysis
  */
 
-import crypto from 'crypto';
-import logger from '../utils/logger.js';
-import { captureMessage, addBreadcrumb } from '../utils/sentry.js';
-import securityPatchManager from '../utils/securityPatchManager.js';
-import encryptionManager from '../utils/encryptionManager.js';
+import crypto from "crypto";
+import logger from "../utils/logger.js";
+import { captureMessage, addBreadcrumb } from "../utils/sentry.js";
+import securityPatchManager from "../utils/securityPatchManager.js";
+import encryptionManager from "../utils/encryptionManager.js";
 
 // In-memory error store (consider using database in production)
 const errorStore = {
+  errorsByEndpoint: {},
   errors: [],
 };
 
@@ -20,16 +21,19 @@ function getEnvironmentMetadata() {
     nodeVersion: process.version,
     platform: process.platform,
     arch: process.arch,
-    nodeEnv: process.env.NODE_ENV || 'unknown',
+    nodeEnv: process.env.NODE_ENV || "unknown",
   };
 }
 
 function generateErrorFingerprint(error, context = {}) {
-  const name = error?.name || 'Error';
-  const message = error?.message || 'Unknown error';
-  const endpoint = `${context.method || 'UNKNOWN'} ${context.url || 'unknown'}`;
+  const name = error?.name || "Error";
+  const message = error?.message || "Unknown error";
+  const endpoint = `${context.method || "UNKNOWN"} ${context.url || "unknown"}`;
 
-  return crypto.createHash('sha1').update(`${name}:${message}:${endpoint}`).digest('hex');
+  return crypto
+    .createHash("sha1")
+    .update(`${name}:${message}:${endpoint}`)
+    .digest("hex");
 }
 
 /**
@@ -98,20 +102,9 @@ async function logError(error, context = {}) {
   errorStore.errorsByEndpoint[endpoint]++;
 
   // Log to Winston (which now forwards to Sentry automatically)
-  logger.error(error.message || 'Error logged', {
+  logger.error(error.message || "Error logged", {
     error,
     ...errorData,
-    userId: context.userId,
-    requestPath: context.url,
-    tags: { status: errorData.status, endpoint },
-  logger.error(error.message || 'Error logged', { 
-    error, 
-    ...errorData, 
-    userId: context.userId,
-    requestPath: context.url,
-  logger.error(error.message || 'Error logged', { 
-    error, 
-    ...errorData, 
     userId: context.userId,
     requestPath: context.url,
     tags: { status: errorData.status, endpoint },
@@ -119,9 +112,9 @@ async function logError(error, context = {}) {
 
   // Add breadcrumb
   addBreadcrumb({
-    category: 'error',
+    category: "error",
     message: error.message,
-    level: 'error',
+    level: "error",
     data: { status: errorData.status, url: errorData.url },
   });
 
@@ -151,12 +144,13 @@ function getErrorStats() {
     errorsByEndpointMap[endpoint] = (errorsByEndpointMap[endpoint] || 0) + 1;
   }
 
-  const errorsByStatus = Object.entries(errorsByStatusMap).map(([status, count]) => ({
-    status: parseInt(status),
-    count,
-    percentage: total > 0 ? ((count / total) * 100).toFixed(2) : '0.00',
-    percentage: total > 0 ? ((count / total) * 100).toFixed(2) : "0.00",
-  }));
+  const errorsByStatus = Object.entries(errorsByStatusMap).map(
+    ([status, count]) => ({
+      status: parseInt(status),
+      count,
+      percentage: total > 0 ? ((count / total) * 100).toFixed(2) : "0.00",
+    })
+  );
 
   const topEndpoints = Object.entries(errorsByEndpointMap)
     .sort((a, b) => b[1] - a[1])
@@ -177,7 +171,9 @@ function getErrorStats() {
       lastSeen: err.timestamp,
     };
     errorsByFingerprintMap[key].count += 1;
-    if (new Date(err.timestamp) > new Date(errorsByFingerprintMap[key].lastSeen)) {
+    if (
+      new Date(err.timestamp) > new Date(errorsByFingerprintMap[key].lastSeen)
+    ) {
       errorsByFingerprintMap[key].lastSeen = err.timestamp;
     }
   }
@@ -244,9 +240,10 @@ function truncateData(data, maxBytes) {
   const str = JSON.stringify(data);
   if (str.length <= maxBytes) return data;
   function truncateStrings(obj, budget) {
-    if (typeof obj === 'string') return obj.slice(0, Math.floor(budget));
-    if (Array.isArray(obj)) return obj.map((item) => truncateStrings(item, budget / obj.length));
-    if (obj && typeof obj === 'object') {
+    if (typeof obj === "string") return obj.slice(0, Math.floor(budget));
+    if (Array.isArray(obj))
+      return obj.map((item) => truncateStrings(item, budget / obj.length));
+    if (obj && typeof obj === "object") {
       const keys = Object.keys(obj);
       const out = {};
       for (const key of keys) {
@@ -257,11 +254,6 @@ function truncateData(data, maxBytes) {
     return obj;
   }
   return truncateStrings(data, maxBytes);
-  try {
-    return JSON.parse(str.slice(0, maxBytes));
-  } catch {
-    return null;
-  }
 }
 
 /**
@@ -293,7 +285,7 @@ function sanitizeData(data) {
   for (const key of Object.keys(sanitized)) {
     for (const pattern of sensitivePatterns) {
       if (pattern.test(key)) {
-        sanitized[key] = '***REDACTED***';
+        sanitized[key] = "***REDACTED***";
         break;
       }
     }
@@ -311,7 +303,7 @@ function sanitizeHeaders(headers) {
 
   const sanitized = {};
   for (const [key, value] of Object.entries(headers)) {
-    if (typeof value === 'string' && value.length > 500) {
+    if (typeof value === "string" && value.length > 500) {
       sanitized[key] = value.slice(0, 500);
     } else {
       sanitized[key] = value;
@@ -319,20 +311,20 @@ function sanitizeHeaders(headers) {
   }
 
   const sensitiveHeaders = [
-    'authorization',
-    'cookie',
-    'x-api-key',
-    'x-csrf-token',
-    'x-session-id',
-    'x-auth-token',
-    'x-access-token',
-    'x-refresh-token',
-    'set-cookie',
+    "authorization",
+    "cookie",
+    "x-api-key",
+    "x-csrf-token",
+    "x-session-id",
+    "x-auth-token",
+    "x-access-token",
+    "x-refresh-token",
+    "set-cookie",
   ];
 
   sensitiveHeaders.forEach((header) => {
     if (sanitized[header.toLowerCase()]) {
-      sanitized[header.toLowerCase()] = '***REDACTED***';
+      sanitized[header.toLowerCase()] = "***REDACTED***";
     }
   });
 
@@ -364,7 +356,9 @@ export const checkCriticalSecurityAlerts = () => {
   const criticalIssues = securityPatchManager.getCriticalVulnerabilities();
 
   if (criticalIssues.length > 0) {
-    logger.error(`[SECURITY ALERT] ${criticalIssues.length} critical patches required`);
+    logger.error(
+      `[SECURITY ALERT] ${criticalIssues.length} critical patches required`
+    );
   }
 
   return criticalIssues;
@@ -374,16 +368,13 @@ export const checkCriticalSecurityAlerts = () => {
 export const checkEncryptionCompliance = () => {
   const status = encryptionManager.getEncryptionStatus();
 
-  if (status.status !== 'SECURE') {
-    logger.error('[SECURITY ALERT] Encryption compliance issue detected');
+  if (status.status !== "SECURE") {
+    logger.error("[SECURITY ALERT] Encryption compliance issue detected");
   }
 
   return status;
 };
 
-export { logError, getErrorStats, getRecentErrors, getEndpointErrors, getUserErrors, clearErrors };
-export const predictServiceFailure = (history) => {
-  // simple prediction logic
 export {
   logError,
   getErrorStats,


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed multiple issues in `server/services/errorTrackingService.js`:

1. **Added `errorsByEndpoint` initialization** to the `errorStore` object. The `logError` function accessed `errorStore.errorsByEndpoint[endpoint]` at runtime without it being initialized, causing a TypeError when the first error was logged.

2. **Removed three duplicate `logger.error` calls** - partial code fragments that would have caused syntax errors.

3. **Removed duplicate `percentage` key** in the `errorsByStatus` mapping.

4. **Removed unreachable code** in `truncateData` function (duplicate return statements).

5. **Removed duplicate export block** and incomplete `predictServiceFailure` stub.

## Changes Made

- `server/services/errorTrackingService.js`: Added `errorsByEndpoint: {}` to `errorStore`; removed duplicate code fragments

## Impact it Made

- Error tracking service no longer crashes on first error log
- Cleaner, syntactically correct code with no duplicate declarations

Closes #4315.

Note: Please assign this PR to the `tmdeveloper007` account.