### PR TITLE
fix: resolve ReferenceError in RoadmapBuilderContext hydration

### DIFF
--- a/website/src/context/RoadmapBuilderContext.tsx
+++ b/website/src/context/RoadmapBuilderContext.tsx
@@ -98,7 +98,6 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
       }
     } finally {
       isHydrated.current = true;
-      console.error('Failed to load roadmap from localStorage:', e);
     }
   }, []);
 


### PR DESCRIPTION
## What does this PR do?


This PR removes an erroneous `console.error` statement from the `finally` block inside the hydration `useEffect` of `RoadmapBuilderContext.tsx`. Previously, it attempted to log the error object `e`, but since `e` is block-scoped to the `catch` block, this threw a `ReferenceError` every time the component mounted, completely crashing the workspace. Error logging is now correctly localized only within the `catch` block.

Fixes #4324

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?


- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [x] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
