### PR TITLE
Fix/addnode coordinate overwrite

### DIFF
--- a/website/src/context/RoadmapBuilderContext.tsx
+++ b/website/src/context/RoadmapBuilderContext.tsx
@@ -145,8 +145,8 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
           baseX = Math.max(10, Math.min(baseX, 1800 - 220 - 10));
           baseY = Math.max(10, Math.min(baseY, 1200 - 90 - 10));
 
-          finalX = baseX;
-          finalY = baseY;
+          if (finalX === undefined) finalX = baseX;
+          if (finalY === undefined) finalY = baseY;
 
           // Collision Avoidance & Staggered Spawning
           const OFFSET = 40;

--- a/website/src/context/RoadmapBuilderContext.tsx
+++ b/website/src/context/RoadmapBuilderContext.tsx
@@ -98,7 +98,6 @@ export const RoadmapBuilderProvider: React.FC<{ children: ReactNode }> = ({ chil
       }
     } finally {
       isHydrated.current = true;
-      console.error('Failed to load roadmap from localStorage:', e);
     }
   }, []);
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes a bug in the `addNode` function of `RoadmapBuilderContext.tsx`. Previously, if `addNode` was called with only an `x` coordinate or only a `y` coordinate, both coordinates would be completely overwritten by default/canvas-aware base coordinates. The logic has been updated so it only calculates and falls back to base values for the specific coordinate that is missing, preserving any valid user-provided coordinate.

Fixes #4325 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?

- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [x] Checked for console warnings and errors

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
