### PR TITLE
fix : remove duplicate setInterval in AnalyticsDashboard

### DIFF
--- a/admin-dashboard/src/components/AnalyticsDashboard.jsx
+++ b/admin-dashboard/src/components/AnalyticsDashboard.jsx
@@ -37,29 +37,11 @@ export default function AnalyticsDashboard({ eventId }) {
       console.error('Failed to fetch check-in stats:', err);
     }
   }, [eventId]);
-  // Fetch check-in stats
+  // Fetch immediately on mount / eventId change
   useEffect(() => {
-    if (!eventId || !isAuthenticated) return;
-
-    const fetchCheckInStats = async () => {
-      try {
-        const stats = await analyticsAPI.getCheckInStats(eventId);
-        setCheckInStats(stats);
-      } catch (err) {
-        console.error('Failed to fetch check-in stats:', err);
-      }
-    };
-
+    if (!eventId) return;
     fetchCheckInStats();
-    const interval = setInterval(fetchCheckInStats, 10000); // Refresh every 10 seconds
-
-    return () => clearInterval(interval);
-  }, [eventId, isAuthenticated]);
-
-  // Fetch check-in stats
-  useEffect(() => {
-    fetchCheckInStats();
-  }, [fetchCheckInStats]);
+  }, [eventId, fetchCheckInStats]);
 
   useLogoutAwareInterval(fetchCheckInStats, 10000, Boolean(eventId));
 


### PR DESCRIPTION
## Summary of What Has Been Done

Removed a duplicate `useEffect` block in `admin-dashboard/src/components/AnalyticsDashboard.jsx` that set up a raw `setInterval` alongside the existing `useLogoutAwareInterval` call. Both were polling `fetchCheckInStats` every 10 seconds, doubling API load. The raw interval also had no logout awareness, meaning it continued firing after user logout.

## Changes Made

- Removed the first `useEffect` (lines 40-57) with raw `setInterval(fetchCheckInStats, 10000)`.
- Removed the second redundant `useEffect` that re-declared `fetchCheckInStats` and called it.
- Added a minimal `useEffect` for immediate fetch on mount/eventId change.
- Kept `useLogoutAwareInterval(fetchCheckInStats, 10000, Boolean(eventId))` as the single logout-aware polling mechanism.

## Impact it Made

- Eliminated duplicate API polling calls (2x reduction in check-in stats requests).
- Polling now stops immediately on logout via `useLogoutAwareInterval`.

Closes #1132

Note: Please assign this PR to the `tmdeveloper007` account.