### PR TITLE
fix : useLogoutAwareInterval in useAdminStats to stop polling on logout

### DIFF
--- a/admin-dashboard/src/hooks/useAdminStats.js
+++ b/admin-dashboard/src/hooks/useAdminStats.js
@@ -1,7 +1,8 @@
 // admin-dashboard/src/hooks/useAdminStats.js
 // Custom hook that fetches platform stats from GET /api/admin/stats
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useLogoutAwareInterval } from './useLogoutAwareInterval';
 
 const API_BASE = import.meta.env.VITE_API_BASE || 'http://localhost:8787';
 
@@ -10,47 +11,35 @@ export function useAdminStats() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  useEffect(() => {
-    let cancelled = false;
+  const fetchStats = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
 
-    async function fetchStats() {
-      try {
-        setLoading(true);
-        setError(null);
+      const response = await fetch(`${API_BASE}/api/admin/stats`, {
+        credentials: 'include', // send session cookie for auth
+      });
 
-        const response = await fetch(`${API_BASE}/api/admin/stats`, {
-          credentials: 'include', // send session cookie for auth
-        });
-
-        if (!response.ok) {
-          throw new Error(`Failed to fetch stats: ${response.status}`);
-        }
-
-        const data = await response.json();
-        if (!cancelled) {
-          setStats(data);
-        }
-      } catch (err) {
-        if (!cancelled) {
-          setError(err.message);
-        }
-      } finally {
-        if (!cancelled) {
-          setLoading(false);
-        }
+      if (!response.ok) {
+        throw new Error(`Failed to fetch stats: ${response.status}`);
       }
+
+      const data = await response.json();
+      setStats(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
     }
-
-    fetchStats();
-
-    // Refresh stats every 60 seconds while the dashboard is open
-    const interval = setInterval(fetchStats, 60_000);
-
-    return () => {
-      cancelled = true;
-      clearInterval(interval);
-    };
   }, []);
+
+  // Initial fetch on mount
+  useEffect(() => {
+    fetchStats();
+  }, [fetchStats]);
+
+  // Poll every 60 seconds; stops automatically on logout
+  useLogoutAwareInterval(fetchStats, 60_000);
 
   return { stats, loading, error };
 }


### PR DESCRIPTION
## Summary of What Has Been Done

Replaced the raw `setInterval` in `admin-dashboard/src/hooks/useAdminStats.js` with `useLogoutAwareInterval` from the same directory. The raw interval continued firing indefinitely after user logout, generating unnecessary failed authentication requests against protected endpoints.

## Changes Made

- Added import for `useLogoutAwareInterval`.
- Extracted `fetchStats` as a `useCallback` to serve both the initial `useEffect` and the polling hook.
- Replaced `setInterval(fetchStats, 60_000)` + manual cleanup with `useLogoutAwareInterval(fetchStats, 60_000)` at the top level.
- `useLogoutAwareInterval` registers `AUTH_LOGOUT` and `AUTH_TOKEN_EXPIRED` event listeners to stop polling immediately when the user logs out.

## Impact it Made

- Background stats polling stops automatically on logout.
- No more orphaned auth requests after session termination.
- Cleaner separation between initial fetch (useEffect) and ongoing polling (logout-aware hook).

Closes #1132

Note: Please assign this PR to the `tmdeveloper007` account.