### PR TITLE
fix : align theme storage key between theme-init.js and ThemeProvider

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1747,7 +1747,7 @@ export default function App() {
   const [wipeOn,       setWipeOn]       = useState(false);
   const [wipePh,       setWipePh]       = useState('out');
   const [page,         setPage]         = useState(null);
-  const [theme,        setTheme]        = useState(() => localStorage.getItem('ns-theme') || 'dark');
+  const [theme,        setTheme]        = useState(() => localStorage.getItem('ns-theme') || localStorage.getItem('nexasphere-theme') || 'dark');
   const [eventsData,   setEventsData]   = useState(fallbackEvents);
   const [searchOpen,   setSearchOpen]   = useState(false);
   const [bookmarksOpen,setBookmarksOpen]= useState(false);
@@ -1819,7 +1819,7 @@ function MainApp() {
   const [wipeOn,        setWipeOn]        = useState(false);
   const [wipePh,        setWipePh]        = useState('out');
   const [page,          setPage]          = useState(null);
-  const [theme,         setTheme]         = useState(() => localStorage.getItem('ns-theme') || 'dark');
+  const [theme,         setTheme]         = useState(() => localStorage.getItem('ns-theme') || localStorage.getItem('nexasphere-theme') || 'dark');
   const [eventsData,    setEventsData]    = useState(fallbackEvents);
   const [searchOpen,    setSearchOpen]    = useState(false);
   const [bookmarksOpen, setBookmarksOpen] = useState(false);
@@ -1940,11 +1940,11 @@ export default function App() {
 
   /* ── Theme: persisted to localStorage ── */
   const [theme, setTheme] = useState(
-    () => localStorage.getItem('ns-theme') || 'dark'
+    () => localStorage.getItem('ns-theme') || localStorage.getItem('nexasphere-theme') || 'dark'
   );
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
-    localStorage.setItem('ns-theme', theme);
+    localStorage.setItem('nexasphere-theme', theme);
   }, [theme]);
 
   useEffect(() => {

--- a/website/public/theme-init.js
+++ b/website/public/theme-init.js
@@ -1,6 +1,6 @@
 (function () {
   try {
-    var stored = localStorage.getItem('ns-theme');
+    var stored = localStorage.getItem('nexasphere-theme');
     if (stored === 'light' || stored === 'dark') {
       document.documentElement.setAttribute('data-theme', stored);
     } else {


### PR DESCRIPTION
## Summary of What Has Been Done

Fixed a localStorage key mismatch that caused the website theme to reset on page refresh. `website/public/theme-init.js` was reading from `ns-theme` while `ThemeProvider.tsx`, `main.jsx`, and the App component all write to `nexasphere-theme`. After a refresh, `theme-init.js` could not find the saved value in `ns-theme` and fell back to system preference, silently overriding the user's explicit theme choice.

## Changes Made

- `website/public/theme-init.js`: Changed `localStorage.getItem('ns-theme')` to `localStorage.getItem('nexasphere-theme')` so the early FOUC-prevention script reads the correct key.
- `src/App.jsx`: Updated initialization to fall back from `ns-theme` to `nexasphere-theme` for backward compatibility, and changed the save from `ns-theme` to `nexasphere-theme` to align with all other theme-writing code.

## Impact it Made

- User's chosen theme now persists correctly across page refreshes and new sessions.
- No more flash of wrong theme on load.
- The FOUC-prevention script and React hydration now read from the same key.

Closes #1130

Note: Please assign this PR to the `tmdeveloper007` account.