### PR TITLE
fix: remove extra argument from localStorage.getItem call in InstallPrompt.jsx

### DIFF
--- a/website/src/components/pwa/InstallPrompt.jsx
+++ b/website/src/components/pwa/InstallPrompt.jsx
@@ -30,7 +30,7 @@ export default function InstallPrompt() {
     let openCount = 1;
     try {
       if (localStorage.getItem(DISMISSED_KEY) === 'true') return;
-      openCount = parseInt(localStorage.getItem(OPEN_COUNT_KEY, 10) || '0', 10) + 1;
+      openCount = parseInt(localStorage.getItem(OPEN_COUNT_KEY) || '0', 10) + 1;
       localStorage.setItem(OPEN_COUNT_KEY, String(openCount));
     } catch {
       // Storage unavailable — proceed without persisting state.


### PR DESCRIPTION
## Description
`website/src/components/pwa/InstallPrompt.jsx` contained an invalid argument in `localStorage.getItem(OPEN_COUNT_KEY, 10)` where `10` was passed as a second parameter to `localStorage.getItem`.

Changes made:
- Removed the redundant `10` argument inside `localStorage.getItem(OPEN_COUNT_KEY)`.
- Kept the proper radix `10` argument for the outer `parseInt(..., 10)`.
- Zero new TypeScript or build errors introduced.

Fixes #4336

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings