### PR TITLE
fix : wrapped document.activeElement in typeof check in JoinRequestModal

### DIFF
--- a/website/src/components/collab/JoinRequestModal.jsx
+++ b/website/src/components/collab/JoinRequestModal.jsx
@@ -22,7 +22,7 @@ export default function JoinRequestModal({ team, onClose, onSubmit }) {
   };
   // Store the element that triggered the modal so focus can be
   // returned to it when the modal closes.
-  const triggerRef = useRef(document.activeElement);
+  const triggerRef = useRef(typeof document !== 'undefined' ? document.activeElement : null);
 
   // Reset form state whenever the modal opens (team changes)
   // This ensures users start with a fresh form each time they open the modal


### PR DESCRIPTION
## Summary of What Has Been Done
Added typeof document !== undefined guard before document.activeElement access in JoinRequestModal.jsx. This prevents the component from crashing during server-side rendering where document is not defined.

## Changes Made
- Applied targeted fix for issue #4346

## Impact it Made
Resolves issue #4346.

## Note
Please assign this PR to the `tmdeveloper007` account.
