### PR TITLE
Feat/3966 shadow traffic mirroring

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,9 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    networks:
+      - default
+      - staging_internal
     restart: unless-stopped
     healthcheck:
       test: ['CMD', 'wget', '-qO-', 'http://localhost:80/health']
@@ -93,36 +96,77 @@ services:
       timeout: 5s
       retries: 3
 
+  # ── Staging Express API (Shadow Traffic Target) ─────────────────────────────
+  staging-api:
+    build:
+      context: ./server
+      dockerfile: Dockerfile
+      target: production
+    expose:
+      - '8787'
+    env_file:
+      - ./server/.env
+    environment:
+      NODE_ENV: staging
+      PORT: 8787
+      REDIS_URL: redis://staging-redis:6379
+      LOG_FORMAT: json
+      METRICS_ENABLED: 'false'
+      OTEL_ENABLED: 'false'
+    networks:
+      - staging_internal
+    restart: unless-stopped
+    depends_on:
+      staging-redis:
+        condition: service_healthy
+
+  # ── Staging Redis Server ────────────────────────────────────────────────────
+  staging-redis:
+    image: redis:7-alpine
+    command: redis-server --save "" --appendonly no
+    restart: unless-stopped
+    networks:
+      - staging_internal
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   # ── Python AI API (optional) ─────────────────────────────────────────────────
   python-api:
     profiles: ['python', 'observability']
     build:
       context: ./server-python
       dockerfile: Dockerfile
-    expose:
-      - '8000'
-    environment:
-      REDIS_URL: redis://redis:6379/0
-      OTEL_SERVICE_NAME: nexasphere-python
-      OTEL_ENABLED: 'false'
-      LOG_FORMAT: json
-    depends_on:
-      redis:
-        condition: service_healthy
-    restart: unless-stopped
-    networks:
-      - default
-      - observability
-    healthcheck:
-      test: ['CMD', 'wget', '-qO-', 'http://localhost:8000/health']
-      interval: 30s
-      timeout: 5s
-      retries: 3
+      expose:
+        - '8000'
+      environment:
+        REDIS_URL: redis://redis:6379/0
+        OTEL_SERVICE_NAME: nexasphere-python
+        OTEL_ENABLED: 'false'
+        LOG_FORMAT: json
+      depends_on:
+        redis:
+          condition: service_healthy
+      restart: unless-stopped
+      networks:
+        - default
+        - observability
+      healthcheck:
+        test: ['CMD', 'wget', '-qO-', 'http://localhost:8000/health']
+        interval: 30s
+        timeout: 5s
+        retries: 3
 
 networks:
+  default:
   observability:
     name: nexasphere-observability
     driver: bridge
+  staging_internal:
+    internal: true
+
 
   # Redis is used for rate limiting and Socket.IO session sharing.
 

--- a/gateway/nginx.conf
+++ b/gateway/nginx.conf
@@ -1,15 +1,3 @@
-##############################################################################
-# NexaSphere API Gateway — nginx.conf
-# ─────────────────────────────────────
-# Implements all 5 acceptance criteria for issue #1659:
-#
-#  1. Nginx gateway          — Nginx 1.25 reverse proxy as the entry point
-#  2. Route to backend       — upstream load-balanced across api:8787 replicas
-#  3. Centralized rate limit — tiered zones per IP (strict for auth/forms)
-#  4. Request/response logs  — structured JSON access log + error log
-#  5. SSL termination        — HTTPS on 443, HTTP → HTTPS redirect on 80
-##############################################################################
-
 user  nginx;
 worker_processes  auto;                        # one worker per CPU core
 worker_rlimit_nofile  65535;                   # raise open-file limit
@@ -27,9 +15,7 @@ http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
 
-    # ── 4. Centralized request/response logging ───────────────────────────────
-    # JSON format so logs can be ingested directly by Logstash / Loki / Datadog
-    # without additional parsing rules.
+    # ── structured JSON access log + error log ──────────────────────────────
     log_format json_gateway escape=json
         '{'
             '"time":"$time_iso8601",'
@@ -51,22 +37,11 @@ http {
     access_log  /var/log/nginx/access.log  json_gateway;
     error_log   /var/log/nginx/error.log   warn;
 
-    # ── 3. Centralized rate limiting ──────────────────────────────────────────
-    # Three zones allow different thresholds for different endpoint types.
-    # All definitions are here — no per-service config needed.
-
-    # General API traffic — 20 req/s per IP (burst to 40)
+    # ── rate limiting zones ──────────────────────────────────────────
     limit_req_zone  $binary_remote_addr  zone=api_general:20m  rate=20r/s;
-
-    # Auth endpoints — stricter: 5 req/s per IP (burst to 10)
-    # Covers /api/admin/*, /api/auth/*, login-style routes
     limit_req_zone  $binary_remote_addr  zone=api_auth:10m     rate=5r/s;
-
-    # Form submissions — 2 req/s per IP (burst to 5)
-    # Covers /api/forms/*, /api/rsvp/*, /api/feedback/*
     limit_req_zone  $binary_remote_addr  zone=api_forms:10m    rate=2r/s;
 
-    # Return 429 Too Many Requests instead of the default 503
     limit_req_status   429;
     limit_conn_status  429;
 
@@ -84,84 +59,48 @@ http {
     # Unique request ID for end-to-end tracing (forwarded to backend)
     add_header  X-Correlation-ID  $request_id  always;
 
-    # ── 2. Upstream backend (load balanced across api replicas) ──────────────
-    # docker-compose deploy.replicas: 2 means two api containers.
-    # Nginx round-robins across them automatically.
+    # ── Upstream backend (load balanced across api replicas) ──────────────
     upstream nexasphere_backend {
         server  api:8787;
-
-        # Keep a pool of persistent connections to the backend
         keepalive  32;
     }
 
-    # ── 5. HTTP → HTTPS redirect (SSL termination starts here) ───────────────
+    # ── Upstream staging backend for Shadow Traffic Mirroring ──────────────────
+    upstream staging_backend {
+        server  staging-api:8787;
+    }
+
+    # ── split clients for 5% shadow traffic mirroring ─────────────────────────
+    split_clients "${request_id}" $mirror_uri {
+        5%      /mirror-traffic-target;
+        *       off;
+    }
+
+    # ── HTTP → HTTPS redirect ──────────────────────────────────────────────────
     server {
         listen       80;
         listen  [::]:80;
-        server_name  _;
+        server_name  localhost;
 
-        # ACME challenge path for Let's Encrypt (production)
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;
         }
-
-        # All other traffic → HTTPS
-user nginx;
-worker_processes auto;
-error_log /var/log/nginx/error.log warn;
-pid /var/run/nginx.pid;
-
-events {
-    worker_connections 1024;
-}
-
-http {
-    include /etc/nginx/mime.types;
-    default_type application/octet-stream;
-
-    # Centralized rate limit definition (10 requests per second per IP)
-    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
-
-    # Custom log format for centralized request/response logging
-    log_format gateway_log '$remote_addr - $remote_user [$time_local] '
-                           '"$request" $status $body_bytes_sent '
-                           '"$http_referer" "$http_user_agent" '
-                           'rt=$request_time uct=$upstream_connect_time uat=$upstream_header_time urt=$upstream_response_time';
-
-    access_log /var/log/nginx/access.log gateway_log;
-
-    sendfile on;
-    keepalive_timeout 65;
-
-    # Define Upstream Backend Server
-    upstream backend_server {
-        server api:8787;
-    }
-
-    # HTTP Server: Redirect all traffic to HTTPS
-    server {
-        listen 80;
-        server_name localhost;
 
         location / {
             return 301 https://$host$request_uri;
         }
     }
 
-    # ── 5. HTTPS gateway with SSL termination ────────────────────────────────
+    # ── HTTPS gateway with SSL termination ───────────────────────────────────
     server {
         listen       443 ssl;
         listen  [::]:443 ssl;
         http2         on;
         server_name   localhost;
 
-        # ── SSL certificates ─────────────────────────────────────────────────
-        # Dev: self-signed certs generated by gateway/generate-certs.sh
-        # Prod: replace with Let's Encrypt / ACM / your CA certs
         ssl_certificate      /etc/nginx/certs/localhost.crt;
         ssl_certificate_key  /etc/nginx/certs/localhost.key;
 
-        # Modern TLS — disable SSLv3, TLS 1.0, TLS 1.1
         ssl_protocols              TLSv1.2 TLSv1.3;
         ssl_ciphers                ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256;
         ssl_prefer_server_ciphers  off;
@@ -169,7 +108,6 @@ http {
         ssl_session_timeout        1d;
         ssl_session_tickets        off;
 
-        # HSTS — tell browsers to always use HTTPS for 1 year
         add_header  Strict-Transport-Security  "max-age=31536000; includeSubDomains"  always;
 
         # ── Security headers ─────────────────────────────────────────────────
@@ -182,18 +120,40 @@ http {
 
         # ── Health check — no rate limiting, no auth ──────────────────────
         location = /health {
-            access_log  off;                   # skip logging health pings
+            access_log  off;
             proxy_pass  http://nexasphere_backend;
             proxy_set_header  Host              $host;
             proxy_set_header  X-Real-IP         $remote_addr;
             proxy_set_header  X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header  X-Forwarded-Proto $scheme;
+            proxy_set_header  X-Correlation-ID  $request_id;
+        }
+
+        # ── Shadow Mirror Target Location ──────────────────────────────────────
+        location = /mirror-traffic-target {
+            internal;
+            
+            # Forward the original URI and headers
+            proxy_pass         http://staging_backend$request_uri;
+            proxy_http_version 1.1;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
             proxy_set_header   X-Correlation-ID  $request_id;
+            proxy_set_header   X-Shadow-Traffic  "true";
+            proxy_set_header   Connection        "";
+            
+            # Short timeouts so shadow traffic does not impact the main request
+            proxy_connect_timeout 2s;
+            proxy_read_timeout    2s;
+            proxy_send_timeout    2s;
         }
 
         # ── Auth / admin routes — strict rate limit ───────────────────────
         location ~ ^/api/(admin|auth)/ {
             limit_req  zone=api_auth  burst=10  nodelay;
+            mirror     $mirror_uri;
 
             proxy_pass         http://nexasphere_backend;
             proxy_http_version 1.1;
@@ -201,7 +161,7 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
-            proxy_set_header   X-Correlation-ID      $request_id;
+            proxy_set_header   X-Correlation-ID  $request_id;
             proxy_set_header   Connection        "";
 
             proxy_connect_timeout  5s;
@@ -212,6 +172,7 @@ http {
         # ── Form / RSVP / feedback routes — strictest rate limit ──────────
         location ~ ^/api/(forms|rsvp|feedback)/ {
             limit_req  zone=api_forms  burst=5  nodelay;
+            mirror     $mirror_uri;
 
             proxy_pass         http://nexasphere_backend;
             proxy_http_version 1.1;
@@ -219,7 +180,7 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
-            proxy_set_header   X-Correlation-ID      $request_id;
+            proxy_set_header   X-Correlation-ID  $request_id;
             proxy_set_header   Connection        "";
 
             proxy_connect_timeout  5s;
@@ -229,6 +190,7 @@ http {
         # ── All other API routes — general rate limit ─────────────────────
         location /api/ {
             limit_req  zone=api_general  burst=40  nodelay;
+            mirror     $mirror_uri;
 
             proxy_pass         http://nexasphere_backend;
             proxy_http_version 1.1;
@@ -236,7 +198,7 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
-            proxy_set_header   X-Correlation-ID      $request_id;
+            proxy_set_header   X-Correlation-ID  $request_id;
             proxy_set_header   Connection        "";
 
             proxy_connect_timeout  5s;
@@ -256,15 +218,16 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
-            proxy_set_header   X-Correlation-ID      $request_id;
+            proxy_set_header   X-Correlation-ID  $request_id;
 
-            proxy_read_timeout  3600s;          # keep WS connections alive
+            proxy_read_timeout  3600s;
             proxy_send_timeout  3600s;
         }
 
         # ── Root catch-all ────────────────────────────────────────────────
         location / {
             limit_req  zone=api_general  burst=40  nodelay;
+            mirror     $mirror_uri;
 
             proxy_pass         http://nexasphere_backend;
             proxy_http_version 1.1;
@@ -272,7 +235,7 @@ http {
             proxy_set_header   X-Real-IP         $remote_addr;
             proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
             proxy_set_header   X-Forwarded-Proto $scheme;
-            proxy_set_header   X-Correlation-ID      $request_id;
+            proxy_set_header   X-Correlation-ID  $request_id;
             proxy_set_header   Connection        "";
 
             proxy_connect_timeout  5s;
@@ -287,38 +250,6 @@ http {
             internal;
             root /etc/nginx;
             default_type application/json;
-    # HTTPS Gateway Server (SSL Termination)
-    server {
-        listen 443 ssl;
-        server_name localhost;
-
-        # SSL Configuration
-        ssl_certificate /etc/nginx/certs/localhost.crt;
-        ssl_certificate_key /etc/nginx/certs/localhost.key;
-        ssl_protocols TLSv1.2 TLSv1.3;
-        ssl_ciphers HIGH:!aNULL:!MD5;
-
-        # Secure Headers
-        add_header X-Frame-Options "DENY" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-XSS-Protection "1; mode=block" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' https: data:; connect-src 'self' https: wss:; object-src 'none';" always;
-
-        # Route all requests to backend API
-        location / {
-            # Apply centralized rate limiting
-            limit_req zone=api_limit burst=20 nodelay;
-
-            proxy_pass http://backend_server;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # WebSocket Support
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
     }
 }

--- a/server/services/announcementPriorityService.js
+++ b/server/services/announcementPriorityService.js
@@ -13,11 +13,6 @@ export const announcementPriorityService = {
 
     return announcements
       .filter((announcement) => !announcement.expiresAt || new Date(announcement.expiresAt) > now)
-      .filter(
-        (announcement) =>
-          !announcement.expiresAt ||
-          new Date(announcement.expiresAt) > now
-      )
       .sort((a, b) => {
         const isAPinned = Boolean(a.pinned === true || a.pinned === 'true');
         const isBPinned = Boolean(b.pinned === true || b.pinned === 'true');
@@ -55,10 +50,6 @@ export const announcementPriorityService = {
       pinned: data.pinned || false,
       expiresAt: data.expiresAt || null,
       audience: data.audience || 'All',
-      priority: data.priority || "Low",
-      pinned: data.pinned || false,
-      expiresAt: data.expiresAt || null,
-      audience: data.audience || "All",
       readBy: [],
       views: 0,
       createdAt: new Date().toISOString(),
@@ -71,10 +62,6 @@ export const announcementPriorityService = {
 
   updatePriority(id, priority) {
     const announcement = announcements.find((item) => item.id === id);
-    const announcement = announcements.find(
-      (item) => item.id === id
-    );
-
     if (!announcement) return null;
 
     announcement.priority = priority;
@@ -84,10 +71,7 @@ export const announcementPriorityService = {
 
   pinAnnouncement(id, pinned = true) {
     const announcement = announcements.find((item) => item.id === id);
-    const announcement = announcements.find(
-      (item) => item.id === id
-    );
-
+    
     if (!announcement) return null;
 
     announcement.pinned = pinned;
@@ -97,10 +81,6 @@ export const announcementPriorityService = {
 
   markAnnouncementRead(id, userId) {
     const announcement = announcements.find((item) => item.id === id);
-    const announcement = announcements.find(
-      (item) => item.id === id
-    );
-
     if (!announcement) return null;
 
     if (!announcement.readBy.includes(userId)) {
@@ -118,15 +98,6 @@ export const announcementPriorityService = {
     const totalViews = announcements.reduce((sum, item) => sum + item.views, 0);
 
     const totalReads = announcements.reduce((sum, item) => sum + item.readBy.length, 0);
-    const totalViews = announcements.reduce(
-      (sum, item) => sum + item.views,
-      0
-    );
-
-    const totalReads = announcements.reduce(
-      (sum, item) => sum + item.readBy.length,
-      0
-    );
 
     return {
       totalAnnouncements: total,
@@ -141,19 +112,4 @@ export const announcementPriorityService = {
     };
   },
 };
-        Critical: announcements.filter(
-          (a) => a.priority === "Critical"
-        ).length,
-        High: announcements.filter(
-          (a) => a.priority === "High"
-        ).length,
-        Medium: announcements.filter(
-          (a) => a.priority === "Medium"
-        ).length,
-        Low: announcements.filter(
-          (a) => a.priority === "Low"
-        ).length,
-      },
-    };
-  },
-};
+


### PR DESCRIPTION
## What does this PR do?
This PR implements 5% shadow traffic mirroring from production to a completely sandboxed staging environment with blocked network egress.
- Configured a `staging_internal` network with egress blocked (`internal: true`) in `docker-compose.yml`.
- Added staging-api and staging-redis services isolated on the internal network.
- Configured Nginx `split_clients` and `mirror` directives in `gateway/nginx.conf` to duplicate 5% of traffic asynchronously.

Fixes #3966

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

