### PR TITLE
fix: move top-level localStorage access inside useMemo in SkillExchangePage.jsx

### DIFF
--- a/website/src/pages/skills/SkillExchangePage.jsx
+++ b/website/src/pages/skills/SkillExchangePage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 
 // Validates a date value before formatting — avoids rendering literal
 // "Invalid Date" text when the API returns a null or malformed timestamp.
@@ -18,7 +18,20 @@ function formatSkillSessionDate(value) {
   return date.toLocaleDateString();
 }
 
-const USER_ID = localStorage.getItem('ns_user_id') || `user-${Date.now().toString(36)}`;
+function getUserId() {
+  if (typeof window === 'undefined') return 'user-ssr';
+  try {
+    let id = localStorage.getItem('ns_user_id');
+    if (!id) {
+      id = `user-${Date.now().toString(36)}`;
+      localStorage.setItem('ns_user_id', id);
+    }
+    return id;
+  } catch {
+    return `user-fallback`;
+  }
+}
+
 const PROFICIENCY = ['Beginner', 'Intermediate', 'Advanced'];
 const FORMATS = ['Video', 'Chat', 'In-person'];
 const DURATIONS = [30, 60, 90];
@@ -30,11 +43,8 @@ function formatSkillDate(value) {
   return date.toLocaleDateString();
 }
 
-if (!localStorage.getItem('ns_user_id')) {
-  localStorage.setItem('ns_user_id', USER_ID);
-}
-
 export default function SkillExchangePage({ onBack }) {
+  const USER_ID = useMemo(() => getUserId(), []);
   const [tab, setTab] = useState('listings');
   const [listings, setListings] = useState([]);
   const [matches, setMatches] = useState([]);


### PR DESCRIPTION
## Description
`website/src/pages/skills/SkillExchangePage.jsx` executed top-level `localStorage.getItem` and `localStorage.setItem` calls during module evaluation outside component hooks or lifecycle methods.

Changes made:
- Added `getUserId()` lazy helper function with safe SSR/fallback handling.
- Moved `USER_ID` creation inside `useMemo` within `SkillExchangePage` component.
- Imported `useMemo` from `react`.
- Zero new TypeScript or build errors introduced.

Fixes #4338

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings