### PR TITLE
fix: replace array index keys with prefixed string keys in EventCardSkeleton.jsx

### DIFF
--- a/website/src/components/ui/skeleton/EventCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/EventCardSkeleton.jsx
@@ -7,7 +7,7 @@ export function EventCardSkeleton({ count = 4 }) {
     <div role="status" aria-label="Loading events..." aria-busy="true">
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`event-skeleton-${i}`}
           style={{
             display: 'flex',
             gap: '24px',
@@ -62,7 +62,7 @@ export function EventCardSkeleton({ count = 4 }) {
             {/* Description lines */}
             {[85, 75, 55].map((w, li) => (
               <div
-                key={li}
+                key={`desc-line-${li}`}
                 className="skeleton-pulse"
                 style={{
                   height: '11px',


### PR DESCRIPTION
## Description
`website/src/components/ui/skeleton/EventCardSkeleton.jsx` rendered skeleton items using plain array indices (`key={i}` and `key={li}`), which can cause React reconciliation and animation state issues during list transitions.

Changes made:
- Updated outer array map key to `key={`event-skeleton-${i}`}`.
- Updated nested description line map key to `key={`desc-line-${li}`}`.
- Zero new TypeScript or build errors introduced.

Fixes #4339

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings