### PR TITLE
fix: replace plain index keys with unique prefixed keys in PortfolioSkeleton.jsx

### DIFF
--- a/website/src/components/ui/skeleton/PortfolioSkeleton.jsx
+++ b/website/src/components/ui/skeleton/PortfolioSkeleton.jsx
@@ -53,7 +53,7 @@ export const PortfolioSkeleton = () => {
               {/* Stable widths — avoid Math.random() in render which causes
                   layout instability and breaks React hydration */}
               {[96, 120, 88, 112, 100, 136].map((w, i) => (
-                <Skeleton key={i} width={`${w}px`} height="32px" style={{ borderRadius: '16px' }} />
+                <Skeleton key={`portfolio-skill-${i}`} width={`${w}px`} height="32px" style={{ borderRadius: '16px' }} />
               ))}
             </div>
           </section>
@@ -71,7 +71,7 @@ export const PortfolioSkeleton = () => {
             >
               {Array.from({ length: 4 }).map((_, i) => (
                 <article
-                  key={i}
+                  key={`portfolio-project-${i}`}
                   className="portfolio-project-card"
                   style={{
                     display: 'flex',


### PR DESCRIPTION
## Description
`website/src/components/ui/skeleton/PortfolioSkeleton.jsx` used raw array indices (`key={i}`) across multiple mapped skeleton sections (skills and project cards). Using non-prefixed index keys across separate loops can lead to key collision warnings in React and reconciliation glitches during layout shifts.

Changes made:
- Updated skill tag skeleton keys to `key={`portfolio-skill-${i}`}`.
- Updated project card skeleton keys to `key={`portfolio-project-${i}`}`.
- Zero new TypeScript or build errors introduced.

Fixes #4361

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings