### PR TITLE
fix: replace array index key with composite key in HashtagText.jsx

### DIFF
--- a/website/src/components/common/HashtagText.jsx
+++ b/website/src/components/common/HashtagText.jsx
@@ -14,7 +14,7 @@ const HashtagText = ({ text, className = '' }) => {
           const tag = part.substring(1); // remove '#'
           return (
             <Link
-              key={index}
+              key={`hashtag-part-${index}-${part}`}
               to={`/search?q=%23${tag}&type=all`}
               className="text-blue-500 hover:text-blue-700 hover:underline"
               onClick={(e) => e.stopPropagation()}
@@ -23,7 +23,7 @@ const HashtagText = ({ text, className = '' }) => {
             </Link>
           );
         }
-        return <React.Fragment key={index}>{part}</React.Fragment>;
+        return <React.Fragment key={`hashtag-part-${index}-${part}`}>{part}</React.Fragment>;
       })}
     </span>
   );


### PR DESCRIPTION
## Description
`website/src/components/common/HashtagText.jsx` used array indices (`key={index}`) when mapping split text fragments into `Link` components and `React.Fragment` elements. Using array indices on dynamic text splits causes React reconciliation issues and inefficient DOM re-renders when text content updates dynamically.

Changes made:
- Replaced `key={index}` with a composite key: `key={`hashtag-part-${index}-${part}`}`.
- Zero new TypeScript or build errors introduced.

Fixes #4362

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings