### PR TITLE
fix : removed duplicate code block and params key in xss.test.js

### DIFF
--- a/server/test/xss.test.js
+++ b/server/test/xss.test.js
@@ -13,10 +13,6 @@ test('XSS Sanitizer Middleware', async (t) => {
         },
         tags: ['<a href="javascript:alert(1)">Link</a>', 'safe'],
       },
-          count: 42
-        },
-        tags: ['<a href="javascript:alert(1)">Link</a>', 'safe']
-      }
     };
     const res = {};
     xssSanitizer(req, res, () => {});
@@ -31,7 +27,6 @@ test('XSS Sanitizer Middleware', async (t) => {
     const req = {
       query: { search: '<img src=x onerror=alert(1)>Query' },
       params: { id: '<script></script>123' },
-      params: { id: '<script></script>123' }
     };
     const res = {};
     xssSanitizer(req, res, () => {});


### PR DESCRIPTION
## Summary of What Has Been Done
Removed a duplicate code block (lines 16-19) in `server/test/xss.test.js` that contained spurious duplicate object properties (`count: 42`, `tags: [...]`), which was causing a `SyntaxError: Missing initializer in const declaration`. Also removed a duplicate `params` key on line 34.

## Changes Made
- `server/test/xss.test.js`: Removed 5 lines of duplicate garbage code inside the test `req.body` object
- `server/test/xss.test.js`: Removed duplicate `params` key from test `req` object

## Impact it Made
Fixes the `SyntaxError` that prevents `xss.test.js` from being loaded by the Node.js test runner. The file now passes `node --check` syntax validation. This contributes to resolving the `Server - Install & Unit Tests` CI failure.

Closes #4376

Note: Please assign this PR to the `tmdeveloper007` account.