### PR TITLE
fix: guard direct localStorage reads against SSR hydration mismatch in ResourcesPage.jsx

### DIFF
--- a/website/src/pages/resources/ResourcesPage.jsx
+++ b/website/src/pages/resources/ResourcesPage.jsx
@@ -12,6 +12,7 @@ import { getApiBase } from '../../utils/runtimeConfig';
 
 // ── localStorage helpers ──────────────────────────────────────────────────────
 function loadSet(key) {
+  if (typeof window === 'undefined') return new Set();
   try {
     const stored = localStorage.getItem(key);
     if (stored) {
@@ -25,6 +26,7 @@ function loadSet(key) {
 }
 
 function saveSet(key, set) {
+  if (typeof window === 'undefined') return;
   try {
     localStorage.setItem(key, JSON.stringify([...set]));
   } catch {


### PR DESCRIPTION
## Description
`ResourcesPage.jsx` contained direct calls to `localStorage` within `loadSet` and `saveSet` helper functions during initial state evaluation, causing potential SSR hydration mismatches and `ReferenceError: window is not defined` in server-rendered environments.

Changes made:
- Added `typeof window === 'undefined'` guards inside `loadSet` and `saveSet` helper functions prior to accessing `localStorage`
- Ensured safe fallback returning an empty `Set()` during server rendering
- Verified clean build and type checks

Fixes #4364

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings