### PR TITLE
fix: guard direct localStorage access in inline API headers against SSR failures in WaitlistManager.jsx

### DIFF
--- a/website/src/pages/admin/WaitlistManager.jsx
+++ b/website/src/pages/admin/WaitlistManager.jsx
@@ -1,5 +1,10 @@
 import React, { useState, useEffect } from 'react';
 
+const getToken = () => {
+  if (typeof window === 'undefined') return '';
+  return localStorage.getItem('token') || '';
+};
+
 export default function WaitlistManager() {
   const [eventId, setEventId] = useState('');
   const [waitlist, setWaitlist] = useState([]);
@@ -16,7 +21,7 @@ export default function WaitlistManager() {
     try {
       const res = await fetch(`/api/admin/waitlist/event/${eventId}`, {
         headers: {
-          'Authorization': `Bearer ${localStorage.getItem('token')}`
+          'Authorization': `Bearer ${getToken()}`
         }
       });
       const data = await res.json();
@@ -43,7 +48,7 @@ export default function WaitlistManager() {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${localStorage.getItem('token')}`
+          'Authorization': `Bearer ${getToken()}`
         },
         body: JSON.stringify({ email })
       });


### PR DESCRIPTION
## Description
`WaitlistManager.jsx` directly evaluated `localStorage.getItem('token')` within inline fetch header definitions, risking top-level server-side rendering (SSR) failures when `window` is undefined.

Changes made:
- Introduced a safe `getToken()` helper guarded with `typeof window === 'undefined'`
- Replaced direct `localStorage` calls in API request headers with `getToken()`
- Verified clean build and type checks

Fixes #4365

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings