### PR TITLE
fix: add window check around stream_chat_name localStorage access in LiveStreamPage.jsx

### DIFF
--- a/website/src/pages/streaming/LiveStreamPage.jsx
+++ b/website/src/pages/streaming/LiveStreamPage.jsx
@@ -106,6 +106,7 @@ function HlsPlayer({ streamUrl, hlsUrl, status }) {
 function ChatPanel({ messages, onSendMessage }) {
   const [input, setInput] = useState('');
   const [userName, setUserName] = useState(() => {
+    if (typeof window === 'undefined') return '';
     try {
       return (localStorage.getItem('stream_chat_name') || '').slice(0, 50);
     } catch {
@@ -139,10 +140,12 @@ function ChatPanel({ messages, onSendMessage }) {
           onChange={(e) => {
             const trimmed = e.target.value.slice(0, 50);
             setUserName(trimmed);
-            try {
-              localStorage.setItem('stream_chat_name', trimmed);
-            } catch {
-              // Ignore QuotaExceededError — name is still stored in state
+            if (typeof window !== 'undefined') {
+              try {
+                localStorage.setItem('stream_chat_name', trimmed);
+              } catch {
+                // Ignore QuotaExceededError — name is still stored in state
+              }
             }
           }}
           className="w-full px-2 py-1.5 bg-gray-700 border border-gray-600 rounded text-xs focus:outline-none focus:ring-2 focus:ring-purple-500"


### PR DESCRIPTION
## Description
`LiveStreamPage.jsx` accessed `localStorage` directly during `userName` state initialization and input changes, risking server-side rendering (SSR) execution errors when `window` is undefined.

Changes made:
- Added `typeof window === 'undefined'` guard to `userName` state initializer for `stream_chat_name`
- Added `typeof window !== 'undefined'` check around `localStorage.setItem('stream_chat_name', trimmed)` in input `onChange`
- Verified clean build with zero TypeScript errors

Fixes #4366

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings