### PR TITLE
fix: safely parse ns_registrations and guard localStorage in EventDetailPage.jsx

### DIFF
--- a/website/src/pages/events/EventDetailPage.jsx
+++ b/website/src/pages/events/EventDetailPage.jsx
@@ -1014,13 +1014,17 @@ export default function EventDetailPage({ event, activityColor, activityIcon, on
           sessionStorage.setItem(registrationKey, 'confirmed');
         }
         // Store in localStorage for retrieval
-        try {
-          const stored = JSON.parse(localStorage.getItem('ns_registrations') || '[]');
-          stored.push(localTicket);
-          localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
-        } catch (error) {
-          if (import.meta.env.DEV) {
-            console.warn('[EventDetailPage] Failed to persist local registration:', error);
+        if (typeof window !== 'undefined') {
+          try {
+            const raw = localStorage.getItem('ns_registrations');
+            const parsed = raw ? JSON.parse(raw) : [];
+            const stored = Array.isArray(parsed) ? parsed : [];
+            stored.push(localTicket);
+            localStorage.setItem('ns_registrations', JSON.stringify(stored.slice(-20)));
+          } catch (error) {
+            if (import.meta.env.DEV) {
+              console.warn('[EventDetailPage] Failed to persist local registration:', error);
+            }
           }
         }
       }


### PR DESCRIPTION
## Description
`EventDetailPage.jsx` directly parsed `localStorage.getItem('ns_registrations')` without verifying whether the parsed structure was an array or checking for SSR window availability, creating a potential `TypeError` / `SyntaxError` on malformed local storage data.

Changes made:
- Added `typeof window !== 'undefined'` check around `localStorage` operations
- Added `Array.isArray()` validation on `JSON.parse` output with safe array fallback before calling `.push()` and `.slice()`
- Verified clean build with zero TypeScript errors

Fixes #4367

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings