### PR TITLE
feat: Implement streaming from S3 for Certificate downloads (#3772)

### DIFF
--- a/server/controllers/certificatesController.js
+++ b/server/controllers/certificatesController.js
@@ -8,6 +8,7 @@ import {
   uploadCertificatePdfToS3,
   uploadQrCodeToS3,
   downloadCertificatePdfFromS3,
+  getCertificateStreamFromS3,
 } from "../services/certificates/s3Storage.js";
 import { PrismaClient } from "@prisma/client";
 import {
@@ -108,14 +109,46 @@ export async function getMyCertificates(req, res) {
 }
 
 export async function downloadCertificatePdf(req, res) {
-  // TODO: stream from S3
-  return sendError(
-    req,
-    res,
-    'PDF download not implemented yet (S3 + storage layer TODO).',
-    501,
-    'NOT_IMPLEMENTED'
-  );
+  try {
+    const { id } = req.params;
+
+    // We fetch the certificate to get the correct eventId and code for the S3 key
+    const certificate = await prisma.certificate.findUnique({
+      where: { id },
+    });
+
+    if (!certificate) {
+      return sendError(req, res, "Certificate not found", 404, "NOT_FOUND");
+    }
+
+    const key = `certificates/${certificate.eventId}/${certificate.code}.pdf`;
+
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="certificate-${certificate.code}.pdf"`
+    );
+    res.setHeader("Content-Type", "application/pdf");
+
+    const fileStream = getCertificateStreamFromS3({ key });
+
+    fileStream.on("error", (err) => {
+      console.error("[CertificateDownload] S3 stream error:", err);
+      if (!res.headersSent) {
+        return sendError(
+          req,
+          res,
+          "Failed to download certificate from S3.",
+          500
+        );
+      }
+      res.end();
+    });
+
+    fileStream.pipe(res);
+  } catch (err) {
+    console.error("[CertificateDownload] Error initiating stream:", err);
+    return sendError(req, res, "Internal Server Error", 500);
+  }
 }
 
 export async function getOpenBadge(req, res) {

--- a/server/services/certificates/s3Storage.js
+++ b/server/services/certificates/s3Storage.js
@@ -1,12 +1,12 @@
-import AWS from 'aws-sdk';
+import AWS from "aws-sdk";
 
 // Uses existing repo conventions similar to other S3 code.
-const s3 = new AWS.S3({ region: process.env.AWS_REGION || 'us-east-1' });
+const s3 = new AWS.S3({ region: process.env.AWS_REGION || "us-east-1" });
 const BUCKET = process.env.S3_BUCKET;
 const CDN_BASE = process.env.CDN_BASE_URL;
 
 function requireBucket() {
-  if (!BUCKET) throw new Error('Missing S3_BUCKET env var');
+  if (!BUCKET) throw new Error("Missing S3_BUCKET env var");
   return BUCKET;
 }
 
@@ -17,12 +17,12 @@ export async function uploadCertificatePdfToS3({ buffer, key }) {
       Bucket: bucket,
       Key: key,
       Body: buffer,
-      ContentType: 'application/pdf',
-      CacheControl: 'public, max-age=31536000, immutable',
+      ContentType: "application/pdf",
+      CacheControl: "public, max-age=31536000, immutable",
     })
     .promise();
 
-  const url = CDN_BASE ? `${CDN_BASE}/${key}` : '';
+  const url = CDN_BASE ? `${CDN_BASE}/${key}` : "";
   return { key, url };
 }
 
@@ -33,12 +33,12 @@ export async function uploadQrCodeToS3({ buffer, key }) {
       Bucket: bucket,
       Key: key,
       Body: buffer,
-      ContentType: 'image/png',
-      CacheControl: 'public, max-age=31536000, immutable',
+      ContentType: "image/png",
+      CacheControl: "public, max-age=31536000, immutable",
     })
     .promise();
 
-  const url = CDN_BASE ? `${CDN_BASE}/${key}` : '';
+  const url = CDN_BASE ? `${CDN_BASE}/${key}` : "";
   return { key, url };
 }
 
@@ -46,4 +46,9 @@ export async function downloadCertificatePdfFromS3({ key }) {
   const bucket = requireBucket();
   const obj = await s3.getObject({ Bucket: bucket, Key: key }).promise();
   return obj.Body;
+}
+
+export function getCertificateStreamFromS3({ key }) {
+  const bucket = requireBucket();
+  return s3.getObject({ Bucket: bucket, Key: key }).createReadStream();
 }


### PR DESCRIPTION
Resolves #3772. Replaces placeholder PDF download response in \certificatesController.js\ with a memory-efficient \s3.getObject(...).createReadStream()\ piped directly to the express response. Updates \s3Storage.js\ to expose the stream getter.