### PR TITLE
fix: replace empty catch blocks with dev-guarded warning logs in useSearch hook

### DIFF
--- a/website/src/hooks/useSearch.js
+++ b/website/src/hooks/useSearch.js
@@ -73,7 +73,10 @@ export function useSearch(activities, events) {
     try {
       const saved = localStorage.getItem('ns_recent_searches');
       return saved ? JSON.parse(saved) : [];
-    } catch {
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.warn('[useSearch] Failed to read recent searches from localStorage:', err);
+      }
       return [];
     }
   });
@@ -86,7 +89,11 @@ export function useSearch(activities, events) {
       const next = [clean, ...filtered].slice(0, 10);
       try {
         localStorage.setItem('ns_recent_searches', JSON.stringify(next));
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[useSearch] Failed to save recent search to localStorage:', err);
+        }
+      }
       return next;
     });
   }, []);
@@ -96,7 +103,11 @@ export function useSearch(activities, events) {
       const next = prev.filter((s) => s !== searchTerm);
       try {
         localStorage.setItem('ns_recent_searches', JSON.stringify(next));
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn('[useSearch] Failed to save recent search to localStorage:', err);
+        }
+      }
       return next;
     });
   }, []);
@@ -212,7 +223,11 @@ export function useSearch(activities, events) {
               }));
             all = [...all, ...matched];
           }
-        } catch {}
+        } catch (err) {
+          if (import.meta.env.DEV) {
+            console.warn('[useSearch] Failed to fetch team members:', err);
+          }
+        }
       }
 
       setResults(all);


### PR DESCRIPTION
## Description
The `useSearch` hook contained several silent `catch {}` blocks around `localStorage` operations and API requests (e.g., team member search fetch). When storage is restricted or API requests fail unexpectedly, errors were swallowed quietly, making debugging difficult.

Changes made:
- Added `console.warn` logs in `catch` blocks for reading/writing recent searches to `localStorage` and fetching team members.
- Guarded error logging with `import.meta.env.DEV` to ensure clean execution in production.

Fixes #4405

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings