### PR TITLE
fix: replace empty catch blocks with dev-guarded error logs in SkillExchangePage

### DIFF
--- a/website/src/pages/skills/SkillExchangePage.jsx
+++ b/website/src/pages/skills/SkillExchangePage.jsx
@@ -121,7 +121,11 @@ export default function SkillExchangePage({ onBack }) {
           user: USER_ID,
         });
         fetchListings();
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to create listing:', err.message);
+        }
+      }
     }
   };
 
@@ -131,7 +135,11 @@ export default function SkillExchangePage({ onBack }) {
       try {
         const d = await apiClient(url);
         setMatches(d.matches || []);
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to find matches:', err.message);
+        }
+      }
   };
 
   const bookSession = async (match) => {
@@ -150,7 +158,11 @@ export default function SkillExchangePage({ onBack }) {
           headers: { 'Content-Type': 'application/json' },
         });
         fetchUserStats();
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to book session:', err.message);
+        }
+      }
     }
   };
 
@@ -165,7 +177,11 @@ export default function SkillExchangePage({ onBack }) {
         });
         fetchUserStats();
         fetchLeaderboard();
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to complete session:', err.message);
+        }
+      }
     }
   };
 
@@ -186,7 +202,11 @@ export default function SkillExchangePage({ onBack }) {
           headers: { 'Content-Type': 'application/json' },
         });
         setRating({ sessionId: null, score: 5, comment: '' });
-      } catch {}
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.error('[SkillExchangePage] Failed to submit feedback:', err.message);
+        }
+      }
     }
   };
 


### PR DESCRIPTION
## Description
`website/src/pages/skills/SkillExchangePage.jsx` contained five empty `catch {}` statements across skill exchange action handlers (`createListing`, `findMatches`, `bookSession`, `completeSession`, and `submitFeedback`). Runtime errors occurring during these API calls were silently swallowed.

Changes made:
- Added `console.error` logs inside all five `catch` blocks in `SkillExchangePage.jsx`.
- Guarded error logging with `import.meta.env.DEV` to match existing handlers in the component and ensure clean production execution.

Fixes #4406

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings