### PR TITLE
fix: use unique descriptive keys in EventCardSkeleton and RepoCardSkeleton

### DIFF
--- a/website/src/components/ui/skeleton/EventCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/EventCardSkeleton.jsx
@@ -7,7 +7,7 @@ export function EventCardSkeleton({ count = 4 }) {
     <div role="status" aria-label="Loading events..." aria-busy="true">
       {Array.from({ length: count }, (_, i) => (
         <div
-          key={i}
+          key={`event-card-skeleton-${i}`}
           style={{
             display: 'flex',
             gap: '24px',

--- a/website/src/components/ui/skeleton/RepoCardSkeleton.jsx
+++ b/website/src/components/ui/skeleton/RepoCardSkeleton.jsx
@@ -6,7 +6,7 @@ export const RepoCardSkeleton = ({ count = 1 }) => {
     <>
       {Array.from({ length: count }).map((_, i) => (
         <div
-          key={i}
+          key={`repo-card-skeleton-${i}`}
           className="checklist-item"
           style={{
             display: 'flex',


### PR DESCRIPTION
## Description
`EventCardSkeleton.jsx` and `RepoCardSkeleton.jsx` used bare array indices (`key={i}`) when rendering skeleton card list items. This can lead to key collision issues or inefficient DOM reconciliation when skeleton counts change dynamically.

Changes made:
- Updated key prop in `EventCardSkeleton.jsx` to `key={`event-card-skeleton-${i}`}`.
- Updated key prop in `RepoCardSkeleton.jsx` to `key={`repo-card-skeleton-${i}`}`.

Fixes #4407

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings