### PR TITLE
fix: replace bare index keys with unique keys in ProfilePage

### DIFF
--- a/website/src/pages/profile/ProfilePage.jsx
+++ b/website/src/pages/profile/ProfilePage.jsx
@@ -471,7 +471,7 @@ export default function ProfilePage() {
                 </thead>
                 <tbody>
                   {profile.registrations.map((r, i) => (
-                    <tr key={i}>
+                    <tr key={r.id || r._id || `reg-${i}`}>
                       <td style={styles.td}>
                         {r.eventId?.title || r.eventId?.name || 'Unknown Event'}
                       </td>
@@ -499,7 +499,7 @@ export default function ProfilePage() {
           {activeTab === 'forum' &&
             (profile.forumActivity?.length ? (
               profile.forumActivity.map((post, i) => (
-                <div key={i} style={styles.forumItem}>
+                <div key={post.id || post._id || `forum-${i}`} style={styles.forumItem}>
                   <div style={styles.forumTitle}>
                     {post.title || post.content?.slice(0, 80) + '...'}
                   </div>
@@ -531,7 +531,7 @@ export default function ProfilePage() {
                 </thead>
                 <tbody>
                   {profile.mentorSessions.map((s, i) => (
-                    <tr key={i}>
+                    <tr key={s.id || s._id || `session-${i}`}>
                       <td style={styles.td}>{s.mentorId?.name || s.mentorId?.email || 'Mentor'}</td>
                       <td style={styles.td}>
                         {new Date(s.date || s.createdAt).toLocaleDateString()}
@@ -562,7 +562,7 @@ export default function ProfilePage() {
             (profile.achievements?.length ? (
               <div style={{ padding: '0.5rem 0' }}>
                 {profile.achievements.map((a, i) => (
-                  <span key={i} style={styles.achieveBadge}>
+                  <span key={a.id || a._id || a.title || `achieve-${i}`} style={styles.achieveBadge}>
                     {a.icon || '★'} {a.title || a.name || a}
                   </span>
                 ))}


### PR DESCRIPTION
## Description
`website/src/pages/profile/ProfilePage.jsx` used bare array index keys (`key={i}`) across multiple dynamic renders including event registrations, forum activity posts, mentor sessions, and achievements. Using array index keys can lead to DOM reconciliation bugs and unnecessary re-renders when data lists update.

Changes made:
- Updated `registrations` table rows to use `key={r.id || r._id || `reg-${i}`}`.
- Updated `forumActivity` list items to use `key={post.id || post._id || `forum-${i}`}`.
- Updated `mentorSessions` table rows to use `key={s.id || s._id || `session-${i}`}`.
- Updated `achievements` badge elements to use `key={a.id || a._id || a.title || `achieve-${i}`}`.

Fixes #4408

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings