### PR TITLE
fix: remove duplicate key={idx} props in RoadmapsPage

### DIFF
--- a/website/src/pages/roadmaps/RoadmapsPage.jsx
+++ b/website/src/pages/roadmaps/RoadmapsPage.jsx
@@ -322,9 +322,8 @@ export default function RoadmapsPage({ onBack }) {
                 <div className="resources-vertical-stack">
                   {selectedNode.tutorials.map((tutorial, idx) => (
                     <a
-                      key={`tutorial-${selectedNode.id}-${tutorial.url}`}
-                      aria-label="Interactive element"
-                      key={idx}
+                      key={tutorial.url || `tutorial-${selectedNode.id}-${idx}`}
+                      aria-label="Interactive element" 
                       href={tutorial.url}
                       target="_blank"
                       rel="noopener noreferrer"
@@ -348,9 +347,8 @@ export default function RoadmapsPage({ onBack }) {
                 <div className="resources-vertical-stack">
                   {selectedNode.practice.map((item, idx) => (
                     <a
-                      key={`practice-${selectedNode.id}-${item.url}`}
-                      aria-label="Interactive element"
-                      key={idx}
+                      key={item.url || `practice-${selectedNode.id}-${idx}`}
+                      aria-label="Interactive element" 
                       href={item.url}
                       target="_blank"
                       rel="noopener noreferrer"


### PR DESCRIPTION
## Description
In `website/src/pages/roadmaps/RoadmapsPage.jsx`, tutorial and practice resource elements contained duplicate `key` props where `key={idx}` was defined directly below unique template literal string keys (`key={`tutorial-${selectedNode.id}-${tutorial.url}`}`). Because `key={idx}` appeared last on the element, React used the array index key instead of the unique resource key, causing inefficient DOM reconciliation during re-renders.

Changes made:
- Removed duplicate `key={idx}` props on tutorial and practice resource map items.
- Preserved unique resource URL keys with index fallbacks.

Fixes #4409

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings