### PR TITLE
fix: replace native alert() calls with inline notification banner in AccountSettingsPage

### DIFF
--- a/website/src/pages/settings/AccountSettingsPage.jsx
+++ b/website/src/pages/settings/AccountSettingsPage.jsx
@@ -103,7 +103,13 @@ export default function AccountSettingsPage() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteConfirmText, setDeleteConfirmText] = useState('');
   const [deleting, setDeleting] = useState(false);
+  const [notification, setNotification] = useState(null);
   const navigate = useNavigate();
+
+  const showNotification = (type, message) => {
+    setNotification({ type, message });
+    setTimeout(() => setNotification(null), 5000);
+  };
 
   const handleExport = async () => {
     try {
@@ -120,7 +126,7 @@ export default function AccountSettingsPage() {
       link.click();
       link.remove();
     } catch (err) {
-      alert(err.response?.data?.error || 'Failed to export data');
+      showNotification('error', err.response?.data?.error || 'Failed to export data');
     } finally {
       setExporting(false);
     }
@@ -131,10 +137,10 @@ export default function AccountSettingsPage() {
     try {
       setDeleting(true);
       await apiClient.delete('/api/auth/me');
-      alert('Your account has been successfully deleted.');
+      showNotification('success', 'Your account has been successfully deleted.');
       window.location.href = '/login';
     } catch (err) {
-      alert(err.response?.data?.error || 'Failed to delete account');
+      showNotification('error', err.response?.data?.error || 'Failed to delete account');
       setDeleting(false);
     }
   };
@@ -143,6 +149,42 @@ export default function AccountSettingsPage() {
     <div style={styles.page}>
       <div style={styles.container}>
         <h1 style={styles.header}>Account Settings</h1>
+
+        {notification && (
+          <div
+            role="alert"
+            style={{
+              padding: '1rem 1.25rem',
+              borderRadius: '8px',
+              marginBottom: '1.5rem',
+              display: 'flex',
+              alignItems: 'center',
+              justify: 'space-between',
+              background: notification.type === 'error' ? 'rgba(239, 68, 68, 0.15)' : 'rgba(34, 197, 94, 0.15)',
+              border: `1px solid ${notification.type === 'error' ? '#ef4444' : '#22c55e'}`,
+              color: notification.type === 'error' ? '#fca5a5' : '#86efac',
+              fontSize: '0.95rem',
+              fontWeight: '500',
+            }}
+          >
+            <span>{notification.message}</span>
+            <button
+              onClick={() => setNotification(null)}
+              style={{
+                background: 'none',
+                border: 'none',
+                color: 'inherit',
+                cursor: 'pointer',
+                marginLeft: 'auto',
+                fontSize: '1.1rem',
+                padding: '0 0.5rem',
+              }}
+              aria-label="Dismiss notification"
+            >
+              &times;
+            </button>
+          </div>
+        )}
 
         <div style={styles.section}>
           <h2 style={styles.sectionTitle}>Export My Data</h2>


### PR DESCRIPTION
## Description
In `website/src/pages/settings/AccountSettingsPage.jsx`, browser-native blocking `alert()` calls were being triggered during data export failures and account deletion flows. Native browser alerts break UI consistency, interrupt user workflows, and fail accessibility standards.

Changes made:
- Added an inline auto-dismissing `notification` state banner supporting success and error messages with clear accessibility (`role="alert"`).
- Replaced blocking `alert()` calls in `handleExport` and `handleDeleteAccount` with the non-blocking notification feedback pattern.

Fixes #4415

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings