### PR TITLE
fix: replace native alert with notification banner in ModerationDashboard

### DIFF
--- a/website/src/components/moderation/ModerationDashboard.jsx
+++ b/website/src/components/moderation/ModerationDashboard.jsx
@@ -107,6 +107,12 @@ export default function ModerationDashboard() {
   const [selectedTab, setSelectedTab] = useState('pending');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [notification, setNotification] = useState(null);
+
+  const showNotification = (msg) => {
+    setNotification(msg);
+    setTimeout(() => setNotification(null), 5000);
+  };
 
   const [showReportModal, setShowReportModal] = useState(false);
   const [showResolveModal, setShowResolveModal] = useState(false);
@@ -234,7 +240,7 @@ export default function ModerationDashboard() {
       });
       if (!res.ok) throw new Error('Failed to approve all');
       const data = await res.json();
-      alert(`Approved ${data.approvedCount} items`);
+      showNotification(`Approved ${data.approvedCount} items`);
       fetchFlags();
       fetchStats();
     } catch (err) {
@@ -313,6 +319,25 @@ export default function ModerationDashboard() {
           >
             <span style={{ color: '#EF4444' }}>{error}</span>
             <button style={buttonStyle('danger')} onClick={() => setError(null)}>
+              Dismiss
+            </button>
+          </div>
+        )}
+
+        {notification && (
+          <div
+            role="status"
+            style={{
+              ...cardStyle,
+              border: '1px solid #10B981',
+              marginBottom: '16px',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+            }}
+          >
+            <span style={{ color: '#10B981' }}>{notification}</span>
+            <button style={buttonStyle('success')} onClick={() => setNotification(null)}>
               Dismiss
             </button>
           </div>


### PR DESCRIPTION
## Description
In `website/src/components/moderation/ModerationDashboard.jsx`, line 237 used a browser-native `alert()` dialog when batch approving all pending content for a user. The blocking browser popup halted admin workflow navigation until dismissed.

Changes made:
- Introduced a `notification` state and auto-dismissing helper in `ModerationDashboard.jsx`.
- Replaced the blocking `alert()` with a non-modal, dismissible success notification banner with proper accessibility tags (`role="status"`).

Fixes #4434

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings