### PR TITLE
fix: replace native alert dialogs with inline status indicator in RoadmapBuilder

### DIFF
--- a/website/src/components/roadmaps/RoadmapBuilder.tsx
+++ b/website/src/components/roadmaps/RoadmapBuilder.tsx
@@ -52,6 +52,12 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
 
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isGenerating, setIsGenerating] = useState(false);
+  const [aiStatus, setAiStatus] = useState<{ message: string; type: 'success' | 'info' | 'error' } | null>(null);
+
+  const showAiStatus = (message: string, type: 'success' | 'info' | 'error') => {
+    setAiStatus({ message, type });
+    setTimeout(() => setAiStatus(null), 5000);
+  };
   const [activeTheme, setActiveTheme] = useState<'dark' | 'light'>(() => {
     return (document.documentElement.getAttribute('data-theme') as 'dark' | 'light') || 'dark';
   });
@@ -205,14 +211,15 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
 
       if (newNodes.length > 0) {
         setNodes([...nodes, ...newNodes]);
-        alert(
-          `AI generated ${newNodes.length} adaptive learning milestones based on your profile.`
+        showAiStatus(
+          `AI generated ${newNodes.length} adaptive learning milestones based on your profile.`,
+          'success'
         );
       } else {
-        alert('No new adaptive milestones generated at this time.');
+        showAiStatus('No new adaptive milestones generated at this time.', 'info');
       }
     } catch (err: any) {
-      alert('Failed to generate AI roadmap. ' + err.message);
+      showAiStatus('Failed to generate AI roadmap. ' + err.message, 'error');
     } finally {
       setIsGenerating(false);
     }
@@ -220,6 +227,37 @@ const RoadmapBuilderInner: React.FC<RoadmapBuilderInnerProps> = ({ onBack }) => 
 
   return (
     <div className="roadmap-builder-container">
+      {/* AI Status Banner */}
+      {aiStatus && (
+        <div
+          role="status"
+          className="mb-4 p-3 rounded-xl flex items-center justify-between text-sm border"
+          style={{
+            backgroundColor:
+              aiStatus.type === 'success'
+                ? 'rgba(16, 185, 129, 0.15)'
+                : aiStatus.type === 'info'
+                ? 'rgba(59, 130, 246, 0.15)'
+                : 'rgba(239, 68, 68, 0.15)',
+            borderColor:
+              aiStatus.type === 'success' ? '#10b981' : aiStatus.type === 'info' ? '#3b82f6' : '#ef4444',
+            color:
+              aiStatus.type === 'success' ? '#34d399' : aiStatus.type === 'info' ? '#60a5fa' : '#f87171',
+          }}
+        >
+          <span>
+            {aiStatus.type === 'success' ? '✅' : aiStatus.type === 'info' ? 'ℹ️' : '⚠️'} {aiStatus.message}
+          </span>
+          <button
+            onClick={() => setAiStatus(null)}
+            className="ml-2 text-base hover:opacity-80"
+            aria-label="Dismiss AI status"
+          >
+            &times;
+          </button>
+        </div>
+      )}
+
       {/* Top Header Layout */}
       <header className="builder-header flex flex-col md:flex-row justify-between items-start md:items-center gap-4 mb-8">
         <div className="flex items-center gap-4">


### PR DESCRIPTION
## Description
In `website/src/components/roadmaps/RoadmapBuilder.tsx`, native browser `alert()` popups were used to display AI milestone generation outcomes and error states. Synchronous native dialogs interrupt the user's flow and break interface consistency.

Changes made:
- Added an auto-dismissing inline status state (`aiStatus`) and helper (`showAiStatus`).
- Replaced all 3 native `alert()` calls in `handleGenerateAIPath` with non-blocking, accessible status banners (`role="status"`) equipped with a dismiss button.

Fixes #4431

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings