### PR TITLE
fix: remove blocking alert on circular dependency in NodeModal

### DIFF
--- a/website/src/components/roadmaps/NodeModal.tsx
+++ b/website/src/components/roadmaps/NodeModal.tsx
@@ -134,7 +134,6 @@ export const NodeModal: React.FC<NodeModalProps> = ({ theme }) => {
       };
 
       if (hasCycle(node.id, targetId)) {
-        alert('Invalid connection: checking this node will create a circular loop!');
         setUrlError('Invalid connection: checking this node will create a circular loop.');
         return;
       }


### PR DESCRIPTION
## Description
In `website/src/components/roadmaps/NodeModal.tsx`, a native browser `alert()` popup was triggered whenever cycle detection identified a circular graph connection during prerequisite toggling.

Changes made:
- Removed the redundant, blocking native `alert()` call on cycle detection in `handlePrereqToggle`.
- Retained the existing `setUrlError` inline feedback state to display the circular loop warning directly within the modal.

Fixes #4430

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings