### PR TITLE
fix: remove blocking alerts on invalid canvas graph connections

### DIFF
--- a/website/src/components/roadmaps/NodeCanvas.tsx
+++ b/website/src/components/roadmaps/NodeCanvas.tsx
@@ -124,7 +124,6 @@ export const NodeCanvas: React.FC<NodeCanvasProps> = ({ theme }) => {
 
       // Avoid self-references or circular connections
       if (node.prerequisites.includes(connectSourceId)) {
-        alert('Prerequisite connection already exists.');
         setMessage('Prerequisite connection already exists.');
         setConnectSourceId(null);
         return;
@@ -142,9 +141,6 @@ export const NodeCanvas: React.FC<NodeCanvasProps> = ({ theme }) => {
       };
 
       if (hasCycle(node.id, connectSourceId)) {
-        alert(
-          'Invalid Connection: Adding this prerequisite will create a circular dependency loop!'
-        );
         setMessage(
           'Invalid connection: adding this prerequisite will create a circular dependency loop.'
         );


### PR DESCRIPTION
## Description
In `website/src/components/roadmaps/NodeCanvas.tsx`, native browser `alert()` popups were called when users attempted to create duplicate connections or circular dependency loops while drawing graph edges. These synchronous dialogs froze the main thread and interrupted the drag-and-connect visual workflow.

Changes made:
- Removed blocking native `alert()` calls on duplicate connection checks and circular dependency validation in `NodeCanvas.tsx`.
- Retained internal non-blocking `setMessage(...)` canvas notification state to inform users of invalid connections seamlessly.

Fixes #4429

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings