### PR TITLE
fix: remove leftover console.log statement in WorkspacePage

### DIFF
--- a/website/src/pages/workspace/WorkspacePage.tsx
+++ b/website/src/pages/workspace/WorkspacePage.tsx
@@ -84,7 +84,6 @@ export default function WorkspacePage({ roomId, onBack }: WorkspacePageProps) {
     if (user.initials !== initials) {
       setUser((prev) => ({ ...prev, initials }));
     }
-    console.log(`Collaborative Workspace joined: ${roomId} as ${user.name}`);
     return () => {
       if (typingTimeoutRef.current) {
         clearTimeout(typingTimeoutRef.current);


### PR DESCRIPTION
## Description
In `website/src/pages/workspace/WorkspacePage.tsx`, a production `console.log` statement was executing inside a `useEffect` hook whenever a user joined a workspace room, outputting room ID and user profile details to standard output.

Changes made:
- Removed the leftover debug `console.log(\`Collaborative Workspace joined: ${roomId} as ${user.name}\`)` statement from `WorkspacePage.tsx`.

Fixes #4417

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings