### PR TITLE
fix: replace blocking alert() popups with inline status feedback in CertificateTemplateEditor

### DIFF
--- a/website/src/pages/admin/CertificateTemplateEditor.jsx
+++ b/website/src/pages/admin/CertificateTemplateEditor.jsx
@@ -5,6 +5,12 @@ export default function CertificateTemplateEditor({ token }) {
   const [activeTemplate, setActiveTemplate] = useState(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [statusMessage, setStatusMessage] = useState(null);
+
+  const showStatus = (text, type = "success") => {
+    setStatusMessage({ text, type });
+    setTimeout(() => setStatusMessage(null), 4000);
+  };
   const canvasRef = useRef(null);
   const [draggingElement, setDraggingElement] = useState(null);
 
@@ -139,14 +145,15 @@ export default function CertificateTemplateEditor({ token }) {
       });
       
       if (res.ok) {
-          alert('Template saved successfully!');
+          showStatus('Template saved successfully!', 'success');
           fetchTemplates();
       } else {
-          alert('Failed to save template');
+          const errData = await res.json().catch(() => ({}));
+          showStatus(errData.message || 'Failed to save template', 'error');
       }
     } catch (err) {
       console.error(err);
-      alert('Error saving template');
+      showStatus(err.message || 'Error saving template', 'error');
     } finally {
       setSaving(false);
     }
@@ -158,6 +165,28 @@ export default function CertificateTemplateEditor({ token }) {
     <div style={{ padding: '2rem', background: '#1e293b', borderRadius: '16px', color: 'var(--t1)' }}>
       <h2>Certificate Template Editor</h2>
       <p style={{ color: 'var(--t2)', marginBottom: '1.5rem' }}>Drag and drop text fields to customize your certificate layout.</p>
+      {statusMessage && (
+        <div
+          role="status"
+          style={{
+            padding: '10px 14px',
+            borderRadius: '6px',
+            marginBottom: '1.5rem',
+            backgroundColor:
+              statusMessage.type === 'error'
+                ? 'rgba(239, 68, 68, 0.15)'
+                : 'rgba(16, 185, 129, 0.15)',
+            color: statusMessage.type === 'error' ? '#f87171' : '#34d399',
+            border: `1px solid ${
+              statusMessage.type === 'error' ? '#ef4444' : '#10b981'
+            }`,
+            fontSize: '0.9rem',
+            fontWeight: 500,
+          }}
+        >
+          {statusMessage.text}
+        </div>
+      )}
       
       {activeTemplate && (
           <div style={{ display: 'flex', gap: '2rem' }}>


### PR DESCRIPTION
## Description
In `website/src/pages/admin/CertificateTemplateEditor.jsx`, lines 142, 145, and 149 utilized native browser `alert()` popups to report success or error states during certificate template modifications. These blocking popups interrupted the admin workflow.

Changes made:
- Added managed `statusMessage` state with auto-dismissing timeout functionality.
- Replaced all synchronous `alert()` dialogs with non-blocking inline feedback messages.
- Added a styled, accessible `role="status"` banner directly beneath the editor header to display clear success and error notifications.

Fixes #4418

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings