### PR TITLE
fix: replace blocking demo mode alert with inline feedback banner in CollabPage

### DIFF
--- a/website/src/pages/collab/CollabPage.jsx
+++ b/website/src/pages/collab/CollabPage.jsx
@@ -10,6 +10,12 @@ export default function CollabPage({ onBack }) {
   const [selectedTeam, setSelectedTeam] = useState(null);
   const [isDemo, setIsDemo] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [feedback, setFeedback] = useState(null);
+
+  const showFeedback = (message, type = "error") => {
+    setFeedback({ message, type });
+    setTimeout(() => setFeedback(null), 4000);
+  };
 
   useEffect(() => {
     const base = getApiBase();
@@ -44,7 +50,7 @@ export default function CollabPage({ onBack }) {
 
   const handleJoinSubmit = async (requestData) => {
     if (isDemo) {
-      alert('Demo mode: Join requests are disabled.');
+      showFeedback('Demo mode: Join requests are disabled.', 'error');
       return;
     }
 
@@ -95,6 +101,30 @@ export default function CollabPage({ onBack }) {
       </div>
 
       <header style={{ marginBottom: '3rem', textAlign: 'center' }}>
+      {feedback && (
+        <div
+          role="status"
+          style={{
+            maxWidth: '600px',
+            margin: '0 auto 1.5rem auto',
+            padding: '10px 16px',
+            borderRadius: '8px',
+            backgroundColor:
+              feedback.type === 'error'
+                ? 'rgba(239, 68, 68, 0.15)'
+                : 'rgba(16, 185, 129, 0.15)',
+            color: feedback.type === 'error' ? '#f87171' : '#34d399',
+            border: `1px solid ${
+              feedback.type === 'error' ? '#ef4444' : '#10b981'
+            }`,
+            fontSize: '0.9rem',
+            fontWeight: 500,
+            textAlign: 'center',
+          }}
+        >
+          {feedback.message}
+        </div>
+      )}
         <h1
           style={{
             fontSize: '2.5rem',


### PR DESCRIPTION
## Description
In `website/src/pages/collab/CollabPage.jsx`, line 47 fired a native browser `alert('Demo mode: Join requests are disabled.')` when users attempted to submit join requests while in demo mode. This modal popup interrupted user flow.

Changes made:
- Added managed `feedback` state with auto-dismissing timeout functionality.
- Replaced the synchronous `alert()` call with non-blocking inline feedback.
- Added a styled, accessible `role="status"` banner directly above the collaboration header to notify users of demo mode restrictions.

Fixes #4424

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings