### PR TITLE
fix : auto-dismiss SessionExpiredBanner when user re-authenticates

### DIFF
--- a/admin-dashboard/src/components/SessionExpiredBanner.jsx
+++ b/admin-dashboard/src/components/SessionExpiredBanner.jsx
@@ -4,6 +4,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
+import { eventEmitter, EVENTS } from '../services/eventEmitter';
 
 // Fix #862: Auto-dismiss banner when user re-authenticates
 // Add this useEffect inside the component:
@@ -25,6 +26,13 @@ export default function SessionExpiredBanner() {
       return () => clearTimeout(timer);
     }
   }, [state]);
+
+  // Fix #862: Auto-dismiss banner when user re-authenticates
+  useEffect(() => {
+    const handleLogin = () => setVisible(false);
+    eventEmitter.on(EVENTS.AUTH_LOGIN, handleLogin);
+    return () => eventEmitter.off(EVENTS.AUTH_LOGIN, handleLogin);
+  }, []);
 
   if (!visible) return null;
 

--- a/admin-dashboard/src/services/auth.js
+++ b/admin-dashboard/src/services/auth.js
@@ -8,6 +8,8 @@
 
 import { eventEmitter, EVENTS } from "./eventEmitter";
 
+const _loginEmitter = () => eventEmitter.emit(EVENTS.AUTH_LOGIN);
+
 const API_BASE = import.meta.env.VITE_API_BASE || "http://localhost:8080";
 const TOKEN_KEY = "ns_admin_token";
 const EMAIL_KEY = "ns_admin_email";
@@ -93,6 +95,7 @@ export const auth = {
       }
       localStorage.setItem(EMAIL_KEY, cleanEmail);
       localStorage.removeItem(OFFLINE_FLAG_KEY);
+      _loginEmitter();
 
       if (data.expiresAt) {
         localStorage.setItem(EXPIRY_KEY, data.expiresAt);
@@ -132,6 +135,7 @@ export const auth = {
         localStorage.setItem(TOKEN_KEY, mockToken);
         localStorage.setItem(EMAIL_KEY, cleanEmail);
         localStorage.setItem(OFFLINE_FLAG_KEY, "true");
+        _loginEmitter();
         return { token: mockToken, email: cleanEmail, offline: true };
       }
 

--- a/admin-dashboard/src/services/eventEmitter.js
+++ b/admin-dashboard/src/services/eventEmitter.js
@@ -79,6 +79,7 @@ export const EVENTS = {
   CORE_TEAM_MEMBER_REMOVED: 'core-team:removed',
 
   AUTH_TOKEN_EXPIRED: 'auth:token-expired',
+  AUTH_LOGIN: 'auth:login',
   AUTH_LOGOUT: 'auth:logout',
 
   NOTIFY: 'notify',


### PR DESCRIPTION
## Summary of What Has Been Done
The `SessionExpiredBanner` in the admin dashboard was shown when a session expired but was never automatically dismissed when the user logged back in. Added event-driven communication between the auth service and the banner component.

## Changes Made
- Added `AUTH_LOGIN: 'auth:login'` event to `admin-dashboard/src/services/eventEmitter.js`.
- Added `_loginEmitter()` helper in `admin-dashboard/src/services/auth.js` and called it after successful login (both online and offline modes).
- In `SessionExpiredBanner.jsx`: imported `eventEmitter` and `EVENTS`, added a `useEffect` that listens for the `AUTH_LOGIN` event and calls `setVisible(false)` to auto-dismiss the banner.

## Impact it Made
- SessionExpiredBanner disappears immediately after the user successfully logs in.
- Improves UX by removing stale error messages after authentication.
- Demonstrates proper event-driven communication between auth service and UI components.

Closes #4459.
Note: Please assign this PR to the `tmdeveloper007` account.