### PR TITLE
fix : removed duplicate imports in metrics.test.js

### DIFF
--- a/server/test/metrics.test.js
+++ b/server/test/metrics.test.js
@@ -2,7 +2,6 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import express from 'express';
 import { initObservability } from '../observability/index.js';
-import { httpRequestsTotal, recordEventRegistration, register } from '../observability/metrics.js';
 import {
   httpRequestsTotal,
   recordEventRegistration,


### PR DESCRIPTION
Closes #4472

## Summary of What Has Been Done
In `server/test/metrics.test.js`, removed the duplicate single-line import of `httpRequestsTotal`, `recordEventRegistration`, and `register` from `../observability/metrics.js` on line 5. The same symbols were already being imported in multi-line format on lines 6-10.

## Changes Made
- Deleted line 5: `import { httpRequestsTotal, recordEventRegistration, register } from '../observability/metrics.js';`
- Kept only the multi-line import block on lines 5-9 (previously lines 6-10)

## Impact it Made
- Removes `SyntaxError: Identifier 'httpRequestsTotal' has already been declared'` when the file is loaded by Node.js
- Enables the Node.js test runner to parse and execute the file successfully
- The `GET /metrics returns Prometheus text format` test can now run normally

Note: Please assign this PR to the `tmdeveloper007` account.