### PR TITLE
fix : removed duplicate test block in sqlInjectionGuard.test.js

### DIFF
--- a/server/test/sqlInjectionGuard.test.js
+++ b/server/test/sqlInjectionGuard.test.js
@@ -67,10 +67,6 @@ test('sqlInjectionGuard still blocks real injection payloads', async (t) => {
   const maliciousInputs = [
     '1 OR 1=1',
     "status = 'draft' OR 1=1",
-test('sqlInjectionGuard still blocks real injection payloads', async (t) => {
-  const maliciousInputs = [
-    '1 OR 1=1',
-    "status = 'draft' OR 1=1",
     "'; DROP TABLE users; --",
     "SELECT * FROM users WHERE 1=1; WAITFOR DELAY '0:0:5'",
     'UNION SELECT * FROM INFORMATION_SCHEMA.TABLES',


### PR DESCRIPTION
Closes #4474

## Summary of What Has Been Done
In `server/test/sqlInjectionGuard.test.js`, the `sqlInjectionGuard still blocks real injection payloads` test block was duplicated. Lines 66-69 started the test with a partial `maliciousInputs` array (2 items), and lines 70-77 immediately repeated the same test declaration with a complete `maliciousInputs` array (5 items). This caused `SyntaxError: Identifier 'maliciousInputs' has already been declared`.

## Changes Made
- Removed the duplicate test declaration and partial `maliciousInputs` array (former lines 70-77)
- Kept the first test declaration line but replaced the partial `maliciousInputs` array with the complete 5-item array
- The file now has one test block with the full malicious payload list

## Impact it Made
- Removes `SyntaxError: Identifier 'maliciousInputs' has already been declared'` when the file is parsed by Node.js
- Enables the Node.js test runner to load and execute the file correctly
- The SQL injection guard tests now run with all 5 malicious payloads: `1 OR 1=1`, `status = 'draft' OR 1=1`, `'; DROP TABLE users; --`, `SELECT * FROM users WHERE 1=1; WAITFOR DELAY '0:0:5'`, and `UNION SELECT * FROM INFORMATION_SCHEMA.TABLES`

Note: Please assign this PR to the `tmdeveloper007` account.