### PR TITLE
fix(observability): repair invalid Grafana dashboard JSON (#4263)

### DIFF
--- a/observability/grafana/dashboards/application.json
+++ b/observability/grafana/dashboards/application.json
@@ -1,7 +1,10 @@
 {
   "uid": "nexa-application",
   "title": "Application",
-  "tags": ["nexasphere", "application"],
+  "tags": [
+    "nexasphere",
+    "application"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
@@ -11,7 +14,12 @@
       "id": 1,
       "title": "Requests by Status",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (status)",
@@ -19,17 +27,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (status)",
-        "legendFormat": "{{status}}",
-        "refId": "A"
-      }]
     },
     {
       "id": 2,
       "title": "Requests by Method",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (method)",
@@ -37,17 +45,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m])) by (method)",
-        "legendFormat": "{{method}}",
-        "refId": "A"
-      }]
     },
     {
       "id": 3,
       "title": "Latency by Route (p95)",
       "type": "timeseries",
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le, route))",
@@ -55,17 +63,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le, route))",
-        "legendFormat": "{{route}}",
-        "refId": "A"
-      }]
     },
     {
       "id": 4,
       "title": "5xx Errors by Route",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
       "targets": [
         {
           "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m])) by (route)",
@@ -73,11 +81,6 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m])) by (route)",
-        "legendFormat": "{{route}}",
-        "refId": "A"
-      }]
     }
   ]
 }

--- a/observability/grafana/dashboards/business-metrics.json
+++ b/observability/grafana/dashboards/business-metrics.json
@@ -1,7 +1,10 @@
 {
   "uid": "nexa-business",
   "title": "Business Metrics",
-  "tags": ["nexasphere", "business"],
+  "tags": [
+    "nexasphere",
+    "business"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
@@ -11,14 +14,29 @@
       "id": 1,
       "title": "Active Users Online",
       "type": "stat",
-      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
-      "targets": [{ "expr": "nexasphere_active_users_online", "refId": "A" }]
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "nexasphere_active_users_online",
+          "refId": "A"
+        }
+      ]
     },
     {
       "id": 2,
       "title": "Events Registered (rate/min)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 16, "x": 8, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 8,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "rate(nexasphere_events_registered_total[5m]) * 60",
@@ -26,17 +44,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "rate(nexasphere_events_registered_total[5m]) * 60",
-        "legendFormat": "registrations/min",
-        "refId": "A"
-      }]
     },
     {
       "id": 3,
       "title": "Events Created (rate/min)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "rate(nexasphere_events_created_total[5m]) * 60",
@@ -44,17 +62,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "rate(nexasphere_events_created_total[5m]) * 60",
-        "legendFormat": "created/min",
-        "refId": "A"
-      }]
     },
     {
       "id": 4,
       "title": "Page Load p95",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(nexasphere_page_load_seconds_bucket[5m])) by (le))",
@@ -62,11 +80,6 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "histogram_quantile(0.95, sum(rate(nexasphere_page_load_seconds_bucket[5m])) by (le))",
-        "legendFormat": "p95",
-        "refId": "A"
-      }]
     }
   ]
 }

--- a/observability/grafana/dashboards/database.json
+++ b/observability/grafana/dashboards/database.json
@@ -1,7 +1,10 @@
 {
   "uid": "nexa-database",
   "title": "Database",
-  "tags": ["nexasphere", "database"],
+  "tags": [
+    "nexasphere",
+    "database"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
@@ -11,22 +14,46 @@
       "id": 1,
       "title": "Database Up",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "targets": [{ "expr": "nexasphere_database_up", "refId": "A" }],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "nexasphere_database_up",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            { "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              }
+            }
           ]
         }
       }
-      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }] } }
     },
     {
       "id": 2,
       "title": "Pool Connections",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "targets": [
         {
           "expr": "pg_pool_connections",
@@ -34,17 +61,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "pg_pool_connections",
-        "legendFormat": "{{state}}",
-        "refId": "A"
-      }]
     },
     {
       "id": 3,
       "title": "Waiting Connections",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "targets": [
         {
           "expr": "pg_pool_connections{state=\"waiting\"}",
@@ -52,20 +79,28 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "pg_pool_connections{state=\"waiting\"}",
-        "legendFormat": "waiting",
-        "refId": "A"
-      }]
     },
     {
       "id": 4,
       "title": "Cache Hit/Miss Rate",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
       "targets": [
-        { "expr": "rate(redis_cache_hits_total[5m])", "legendFormat": "hits/s", "refId": "A" },
-        { "expr": "rate(redis_cache_misses_total[5m])", "legendFormat": "misses/s", "refId": "B" }
+        {
+          "expr": "rate(redis_cache_hits_total[5m])",
+          "legendFormat": "hits/s",
+          "refId": "A"
+        },
+        {
+          "expr": "rate(redis_cache_misses_total[5m])",
+          "legendFormat": "misses/s",
+          "refId": "B"
+        }
       ]
     }
   ]

--- a/observability/grafana/dashboards/infrastructure.json
+++ b/observability/grafana/dashboards/infrastructure.json
@@ -1,7 +1,10 @@
 {
   "uid": "nexa-infrastructure",
   "title": "Infrastructure",
-  "tags": ["nexasphere", "infrastructure"],
+  "tags": [
+    "nexasphere",
+    "infrastructure"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
@@ -11,7 +14,12 @@
       "id": 1,
       "title": "CPU Usage %",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
@@ -19,17 +27,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)",
-        "legendFormat": "CPU",
-        "refId": "A"
-      }]
     },
     {
       "id": 2,
       "title": "Memory Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
       "targets": [
         {
           "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
@@ -37,17 +45,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)",
-        "legendFormat": "memory used ratio",
-        "refId": "A"
-      }]
     },
     {
       "id": 3,
       "title": "Disk Usage",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})",
@@ -55,17 +63,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "1 - (node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay\"})",
-        "legendFormat": "{{mountpoint}}",
-        "refId": "A"
-      }]
     },
     {
       "id": 4,
       "title": "Network I/O",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
       "targets": [
         {
           "expr": "rate(node_network_receive_bytes_total[5m])",
@@ -77,15 +85,18 @@
           "legendFormat": "tx {{device}}",
           "refId": "B"
         }
-        { "expr": "rate(node_network_receive_bytes_total[5m])", "legendFormat": "rx {{device}}", "refId": "A" },
-        { "expr": "rate(node_network_transmit_bytes_total[5m])", "legendFormat": "tx {{device}}", "refId": "B" }
       ]
     },
     {
       "id": 5,
       "title": "Redis Memory",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 16 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
       "targets": [
         {
           "expr": "redis_memory_used_bytes",
@@ -93,11 +104,6 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "redis_memory_used_bytes",
-        "legendFormat": "used",
-        "refId": "A"
-      }]
     }
   ]
 }

--- a/observability/grafana/dashboards/system-overview.json
+++ b/observability/grafana/dashboards/system-overview.json
@@ -1,7 +1,10 @@
 {
   "uid": "nexa-system-overview",
   "title": "System Overview",
-  "tags": ["nexasphere", "overview"],
+  "tags": [
+    "nexasphere",
+    "overview"
+  ],
   "timezone": "browser",
   "schemaVersion": 39,
   "version": 1,
@@ -11,29 +14,63 @@
       "id": 1,
       "title": "Service Up",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
-      "targets": [{ "expr": "up{job=\"nexasphere-api\"}", "refId": "A" }],
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "up{job=\"nexasphere-api\"}",
+          "refId": "A"
+        }
+      ],
       "fieldConfig": {
         "defaults": {
           "mappings": [
-            { "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }
+            {
+              "type": "value",
+              "options": {
+                "0": {
+                  "text": "DOWN"
+                },
+                "1": {
+                  "text": "UP"
+                }
+              }
+            }
           ]
         }
       }
-      "fieldConfig": { "defaults": { "mappings": [{ "type": "value", "options": { "0": { "text": "DOWN" }, "1": { "text": "UP" } } }] } }
     },
     {
       "id": 2,
       "title": "Firing Alerts",
       "type": "stat",
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
-      "targets": [{ "expr": "count(ALERTS{alertstate=\"firing\"})", "refId": "A" }]
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "targets": [
+        {
+          "expr": "count(ALERTS{alertstate=\"firing\"})",
+          "refId": "A"
+        }
+      ]
     },
     {
       "id": 3,
       "title": "Request Rate (req/s)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
       "targets": [
         {
           "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m]))",
@@ -41,13 +78,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{ "expr": "sum(rate(http_requests_total{job=\"nexasphere-api\"}[5m]))", "legendFormat": "RPS", "refId": "A" }]
     },
     {
       "id": 4,
       "title": "Error Rate (5xx)",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
       "targets": [
         {
           "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m]))",
@@ -55,13 +96,17 @@
           "refId": "A"
         }
       ]
-      "targets": [{ "expr": "sum(rate(http_errors_total{job=\"nexasphere-api\"}[5m]))", "legendFormat": "5xx/s", "refId": "A" }]
     },
     {
       "id": 5,
       "title": "p95 Latency",
       "type": "timeseries",
-      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 12
+      },
       "targets": [
         {
           "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le))",
@@ -69,11 +114,6 @@
           "refId": "A"
         }
       ]
-      "targets": [{
-        "expr": "histogram_quantile(0.95, sum(rate(http_request_duration_seconds_bucket{job=\"nexasphere-api\"}[5m])) by (le))",
-        "legendFormat": "p95",
-        "refId": "A"
-      }]
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?
All five provisioned Grafana dashboards had duplicate `targets` / `fieldConfig` properties with no separators, so `jq` and Grafana provisioning failed to parse them. Removed the duplicate keys and verified each file with `jq empty`.

Fixes #4263

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [x] Checked for console warnings and errors

`jq empty observability/grafana/dashboards/*.json` — all OK

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
