### PR TITLE
fix: use valid auth middleware in template routes

### DIFF
--- a/server/routes/templateRoutes.js
+++ b/server/routes/templateRoutes.js
@@ -1,11 +1,11 @@
 import express from 'express';
 import { getTemplates, createTemplate, cloneTemplate } from '../controllers/templateController.js';
-import { adminAuth } from '../middleware/auth.js'; // Adjust based on your auth setup
+import { requireAdmin } from '../middleware/adminAuthMiddleware.js';
 
 const router = express.Router();
 
 router.get('/', getTemplates);
-router.post('/', adminAuth, createTemplate);
-router.post('/:id/clone', adminAuth, cloneTemplate);
+router.post('/', requireAdmin, createTemplate);
+router.post('/:id/clone', requireAdmin, cloneTemplate);
 
 export default router;


### PR DESCRIPTION
## What does this PR do?

Fixes #4557

Replaces the invalid `adminAuth` middleware import from `../middleware/auth.js` with the existing `requireAdmin` middleware from `../middleware/adminAuthMiddleware.js`.

Also applies `requireAdmin` to the template clone endpoint.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Tested locally
- [x] Checked for console warnings and errors

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings