### PR TITLE
fix(portfolio): return 503 instead of mock data when database is unavailable

### DIFF
--- a/server-python/routers/portfolio.py
+++ b/server-python/routers/portfolio.py
@@ -62,37 +62,6 @@ class PortfoliosListResponse(BaseModel):
     total: int
 
 
-# ──────────────────────────────────────────────
-# Mock fallback data
-# ──────────────────────────────────────────────
-
-MOCK_PORTFOLIOS = [
-    {
-        "id": "00000000-0000-0000-0000-000000000001",
-        "member_id": "00000000-0000-0000-0000-000000000001",
-        "full_name": "Rajesh Puripanda",
-        "role": "Community Member",
-        "github_username": "rajesh-puripanda",
-        "leetcode_username": "rajesh_puripanda",
-        "cached_github_stats": {
-            "public_repos": 24,
-            "followers": 89,
-            "avatar_url": "https://avatars.githubusercontent.com/u/0?v=4",
-            "bio": "Full-stack developer passionate about open source and distributed systems.",
-        },
-        "cached_leetcode_stats": {
-            "totalSolved": 187,
-            "easySolved": 98,
-            "mediumSolved": 72,
-            "hardSolved": 17,
-            "ranking": 45231,
-        },
-        "last_synced_at": datetime.now(timezone.utc).isoformat(),
-        "is_cached": True,
-    }
-]
-
-
 def _db_available() -> bool:
     """Quick connectivity check without creating a full session."""
     try:
@@ -100,7 +69,7 @@ def _db_available() -> bool:
             conn.execute(text("SELECT 1"))
         return True
     except (OperationalError, ProgrammingError) as e:
-        logger.warning("Database unavailable — falling back to mock data: %s", e)
+        logger.warning("Database unavailable: %s", e)
         return False
 
 
@@ -111,9 +80,15 @@ def _db_available() -> bool:
 
 @router.get("", response_model=PortfoliosListResponse)
 async def list_portfolios(db: Session = Depends(get_db)):
-    """Return all member portfolios. Falls back to mock data if DB is down."""
+    """Return all member portfolios. Raises 503 if the database is
+    unavailable — never returns mock/sample data disguised as real
+    portfolios, since that could mislead clients into displaying a
+    fake member profile as if it were live data."""
     if not _db_available():
-        return PortfoliosListResponse(portfolios=MOCK_PORTFOLIOS, total=len(MOCK_PORTFOLIOS))
+        raise HTTPException(
+            status_code=503,
+            detail="Portfolio database is currently unavailable. Please try again later.",
+        )
 
     records = db.query(MemberPortfolio).all()
     if not records:


### PR DESCRIPTION
## What does this PR do?
Closes #4264

When the portfolio database was unavailable, `GET /api/content/portfolios` returned a fixed sample profile ("Rajesh Puripanda") with the same response shape as live data, with no indicator that it was fallback/mock data. Clients could not distinguish this fake profile from a real member.

This PR removes the mock fallback and makes the endpoint return an explicit `503 Service Unavailable` when the database is unreachable, consistent with the existing behavior already used in `refresh_portfolio_stats()`.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?
- [x] Tested locally
- [ ] Verified UI/UX responsiveness
- [x] Checked for console warnings and errors

Verified that:
- The endpoint raises a `503` with a clear error message when `_db_available()` returns `False`
- Normal behavior (returning real portfolio records) is unaffected when the database is reachable

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

## Notes for Maintainer
This is a fresh, independent fix for this issue after the previous linked PR (#4508) went stale due to 7+ days of inactivity and was auto-unassigned.