### PR TITLE
[Bug] Duplicate rows binding in contentStore.js raises SyntaxError and prevents the entire Express server from booting

### DIFF
--- a/server/repositories/contentStore.js
+++ b/server/repositories/contentStore.js
@@ -51,7 +51,6 @@ export async function supabasePaginatedRequest(pathname, page, limit) {
       rows = [];
     }
   }
-  const rows = text ? JSON.parse(text) : [];
   // Content-Range format from PostgREST: "0-19/150" or "*/0" when empty
   const contentRange = res.headers.get("content-range") || "";
   const totalMatch = contentRange.match(/\/(\d+)$/);


### PR DESCRIPTION
## Problem

server/repositories/contentStore.js declares the same binding ows twice inside supabasePaginatedRequest. This redeclaration makes Node reject the file at parse time (SyntaxError: Identifier 'rows' has already been declared), so every module that imports contentStore.js fails to load and the whole backend (Express, Socket.IO, workers, scheduled jobs) can never boot.

## Fix

Removed the duplicated (dead) const rows = text ? JSON.parse(text) : []; declaration and kept the guarded parse that safely handles empty or malformed Supabase response bodies, returning { rows, total } as intended.

## Files changed

- server/repositories/contentStore.js

## Testing

- Verified the module parses cleanly with 
ode --check.
- The guarded parse path handles empty bodies, valid JSON, and invalid JSON (JSON.parse failures fall back to []).

Closes #4626