### PR TITLE
[Bug] Undefined CONSTANT_AUTH_LENGTH makes safeEqual throw, breaking admin login and every authenticated admin request

### DIFF
--- a/server/middleware/adminAuthMiddleware.js
+++ b/server/middleware/adminAuthMiddleware.js
@@ -37,15 +37,6 @@ function safeEqual(a, b) {
   if (a === undefined || a === null || b === undefined || b === null) return false;
   const hashA = crypto.createHash('sha256').update(String(a)).digest();
   const hashB = crypto.createHash('sha256').update(String(b)).digest();
-  const bufA = Buffer.from(String(a));
-  const bufB = Buffer.from(String(b));
-
-  // Pad both buffers to constant length to prevent timing attacks based on input length
-  const paddedA = Buffer.alloc(CONSTANT_AUTH_LENGTH);
-  const paddedB = Buffer.alloc(CONSTANT_AUTH_LENGTH);
-  bufA.copy(paddedA);
-  bufB.copy(paddedB);
-
   return crypto.timingSafeEqual(hashA, hashB);
 }
 


### PR DESCRIPTION
## Problem

safeEqual in server/middleware/adminAuthMiddleware.js allocated buffers with the undefined identifier CONSTANT_AUTH_LENGTH, so Buffer.alloc(undefined) threw TypeError: The size argument must be of type number. Because safeEqual is invoked on every admin auth path, admin login always returned 500 (Unable to create admin session) and every authenticated admin API request returned 500 (Unable to validate admin session).

## Fix

Removed the dead length-padding block that referenced the never-defined CONSTANT_AUTH_LENGTH. safeEqual now hashes both values with SHA-256 and performs the constant-time comparison directly, returning 	rue/alse as intended. The padding buffers were unused by the return statement anyway.

## Files changed

- server/middleware/adminAuthMiddleware.js

## Testing

- Verified the module parses cleanly with 
ode --check.
- safeEqual compares equal values as 	rue, mismatches as alse, and returns alse immediately for 
ull/undefined operands.

Closes #4627