### PR TITLE
fix(emailService): define attachments param and fix sendEmailOverride scope

### DIFF
--- a/server/services/emailService.js
+++ b/server/services/emailService.js
@@ -32,6 +32,7 @@ const transporter = nodemailer.createTransport({
 });
 
 const defaultFrom = process.env.EMAIL_FROM || '"NexaSphere Team" <noreply@nexasphere.com>';
+export let sendEmailOverride = null;
 
 async function _sendMail(mailOptions) {
   return transporter.sendMail(mailOptions);
@@ -82,6 +83,7 @@ export async function sendEmail({
   data,
   from = defaultFrom,
   customTemplateContent = null,
+  attachments = [],
 }) {
   try {
     const html = await renderTemplate(templateName, data, customTemplateContent);
@@ -93,6 +95,12 @@ export async function sendEmail({
       html,
       attachments,
     };
+
+    if (sendEmailOverride) {
+      const info = await sendEmailOverride(mailOptions);
+      logger.info(`[Email Service] Message sent successfully via override: ${info?.messageId || 'n/a'}`);
+      return { success: true, messageId: info?.messageId };
+    }
 
     if (!isProduction && (!process.env.SMTP_USER || !process.env.SMTP_PASS)) {
       logger.info(`[Email Service - DEV] Would send email to: ${to}`);

--- a/server/test/emailService.test.js
+++ b/server/test/emailService.test.js
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import test, { mock } from 'node:test';
+
+// Exercise the real SMTP path (not the dev-mode simulation branch) via a
+// mocked nodemailer transporter instead of a live SMTP connection.
+process.env.SMTP_HOST = 'smtp.test.local';
+process.env.SMTP_PORT = '587';
+process.env.SMTP_USER = 'test-user';
+process.env.SMTP_PASS = 'test-pass';
+
+const sendMailCalls = [];
+
+mock.module('nodemailer', {
+  defaultExport: {
+    createTransport: () => ({
+      sendMail: async (mailOptions) => {
+        sendMailCalls.push(mailOptions);
+        return { messageId: 'mock-message-id' };
+      },
+    }),
+  },
+});
+
+const { sendEmail } = await import('../services/emailService.js');
+
+test('sendEmail resolves { success: true } and forwards attachments to the transporter', async () => {
+  sendMailCalls.length = 0;
+
+  const attachments = [{ filename: 'invoice.pdf', content: 'dummy-content' }];
+
+  const result = await sendEmail({
+    to: 'user@example.com',
+    subject: 'Welcome to NexaSphere',
+    templateName: 'welcome',
+    data: { name: 'Test User', verifyUrl: 'https://example.com/verify' },
+    attachments,
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(sendMailCalls.length, 1);
+  assert.deepEqual(sendMailCalls[0].attachments, attachments);
+});
+
+test('sendEmail defaults attachments to an empty array and does not throw when omitted', async () => {
+  sendMailCalls.length = 0;
+
+  const result = await sendEmail({
+    to: 'user@example.com',
+    subject: 'Welcome to NexaSphere',
+    templateName: 'welcome',
+    data: { name: 'Test User', verifyUrl: 'https://example.com/verify' },
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(sendMailCalls.length, 1);
+  assert.deepEqual(sendMailCalls[0].attachments, []);
+});


### PR DESCRIPTION
## Description

Fixes a bug where `sendEmail()` in `server/services/emailService.js` referenced an undeclared `attachments` variable, throwing a `ReferenceError` on every call. Because the error was thrown inside the function's `try` block, it was silently caught and converted to `{ success: false }`, causing every transactional email on the platform (welcome/verification, password reset, RSVP/waitlist, event reminders, and security alerts) to fail silently.

Also fixes `setSendEmailOverride`, which was assigning to an undeclared module variable and was never actually consulted by `sendEmail`, breaking the SMTP-mocking hook used by `test/realtimeFaultIsolation.test.js`.

## Related Issue

Closes #4629

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [ ] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Added `attachments = []` to `sendEmail`'s destructured parameters so it is properly defined and passed through to `mailOptions`.
- Declared `export let sendEmailOverride = null;` at module scope instead of relying on an implicit/undeclared global.
- Wired `sendEmail` to call `sendEmailOverride` when set, before hitting the real SMTP transporter, matching the existing pattern in `pushNotificationService.js`.
- Added `server/test/emailService.test.js` covering:
  - Attachments are correctly forwarded to the transporter.
  - Attachments default to `[]` without throwing.
  - `sendEmail` resolves `{ success: true }` on a mocked successful send.

## Technical Details

### Backend

Changes are isolated to `server/services/emailService.js`:

- Updated the `sendEmail` function.
- Added the `sendEmailOverride` module variable.
- No API contract, route, or schema changes.

## Testing

### Unit Tests

Added `server/test/emailService.test.js`.

- Verified the test fails with `ReferenceError: attachments is not defined` against the pre-fix code.
- Verified all tests pass after the fix.

### Manual Testing

Manually confirmed that `sendEmailOverride`, when set, is invoked and its thrown errors are caught and converted to `{ success: false }` as expected by `test/realtimeFaultIsolation.test.js`.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [ ] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [x] CI/CD passing
- [x] Ready for review