### PR TITLE
fix(eventsRepository): restore filters and restricted-group access control in list()

### DIFF
--- a/server/repositories/eventsRepository.js
+++ b/server/repositories/eventsRepository.js
@@ -45,111 +45,89 @@ export const eventsRepository = {
   } = {}) {
   // Returns { rows, total } — rows are the current page, total is the full
   // count without LIMIT so callers can build pagination metadata.
-    const cacheKey = `events:list:${page}:${limit}`;
+    const groupsKey = studentGroups === undefined ? 'public' : [...studentGroups].sort().join(',');
+    const cacheKey = `events:list:${page}:${limit}:${status ?? ''}:${startDate ?? ''}:${endDate ?? ''}:${category ?? ''}:${location ?? ''}:${search ?? ''}:${groupsKey}`;
     const cached = await getCache(cacheKey);
     if (cached) return cached;
 
     return withDb(async (client) => {
       const offset = (page - 1) * limit;
 
-      // Fix: If an empty page is returned (e.g. page out of bounds), fall back to a quick count
-      const { rows } = await client.query(
-        `select *, count(*) over()::int as total 
-         from events 
-         order by created_at desc 
-         limit $1 offset $2`,
-        [limit, offset],
-        'select * from events order by created_at desc limit $1 offset $2',
-        [limit, offset]
-      );
+      let selectClause = 'select *, count(*) over()::int as total from events';
+      const params = [];
+      const conditions = [];
 
-      const total = rows.length > 0 ? rows[0].total : 0;
-      return { rows: rows.map(mapRow), total };
-      const countResult = await client.query('select count(*)::int as total from events');
+      if (status) {
+        conditions.push(`status = $${params.length + 1}`);
+        params.push(status);
+      }
+
+      if (category) {
+        conditions.push(`LOWER(array_to_string(tags, ',')) LIKE LOWER($${params.length + 1})`);
+        params.push(`%${category}%`);
+      }
+
+      if (location) {
+        conditions.push(`LOWER(description) LIKE LOWER($${params.length + 1})`);
+        params.push(`%${location}%`);
+      }
+
+      if (search) {
+        conditions.push(
+          `(LOWER(name) LIKE LOWER($${params.length + 1})
+      OR LOWER(description) LIKE LOWER($${params.length + 2}))`
+        );
+        params.push(`%${search}%`);
+        params.push(`%${search}%`);
+      }
+
+      if (startDate) {
+        conditions.push(`date_text >= $${params.length + 1}`);
+        params.push(startDate);
+      }
+
+      if (endDate) {
+        conditions.push(`date_text <= $${params.length + 1}`);
+        params.push(endDate);
+      }
+
+      if (studentGroups === undefined) {
+        // No groups provided — only show public events
+        conditions.push(`(restricted_groups IS NULL OR jsonb_array_length(restricted_groups) = 0 OR restricted_groups = '[]'::jsonb)`);
+      } else {
+        // Show public events OR events where restricted_groups overlaps with studentGroups
+        conditions.push(
+          `(restricted_groups IS NULL OR jsonb_array_length(restricted_groups) = 0 OR restricted_groups = '[]'::jsonb OR EXISTS (SELECT 1 FROM jsonb_array_elements_text(restricted_groups) AS g WHERE g = ANY($${params.length + 1})))`
+        );
+        params.push(studentGroups.length > 0 ? studentGroups : ['-1']);
+      }
+
+      if (conditions.length > 0) {
+        selectClause += ' where ' + conditions.join(' and ');
+      }
+
+      selectClause += ` order by created_at desc limit $${params.length + 1} offset $${params.length + 2}`;
+      params.push(limit, offset);
+
+      const { rows } = await client.query(selectClause, params);
+
+      let total;
+      if (rows.length > 0) {
+        total = rows[0].total;
+      } else {
+        // Fallback count query only if offset was beyond actual table bounds
+        let countQuery = 'select count(*)::int as total from events';
+        const countParams = params.slice(0, params.length - 2);
+        if (conditions.length > 0) {
+          countQuery += ' where ' + conditions.join(' and ');
+        }
+        const countResult = await client.query(countQuery, countParams);
+        total = countResult.rows[0]?.total ?? 0;
+      }
+
       const result = { rows: rows.map(mapRow), total };
       await setCache(cacheKey, result);
       return result;
-
-      try {
-        const offset = (page - 1) * limit;
-
-        let query = 'select * from events ';
-        const params = [];
-        let conditions = [];
-
-        if (status) {
-          conditions.push(`status = $${params.length + 1}`);
-          params.push(status);
-        }
-
-        if (category) {
-          conditions.push(`LOWER(array_to_string(tags, ',')) LIKE LOWER($${params.length + 1})`);
-          params.push(`%${category}%`);
-        }
-
-        if (location) {
-          conditions.push(`LOWER(description) LIKE LOWER($${params.length + 1})`);
-          params.push(`%${location}%`);
-        }
-
-        if (search) {
-          conditions.push(
-            `(LOWER(name) LIKE LOWER($${params.length + 1})
-      OR LOWER(description) LIKE LOWER($${params.length + 2}))`
-          );
-
-          params.push(`%${search}%`);
-          params.push(`%${search}%`);
-        }
-
-        if (startDate) {
-          conditions.push(`date_text >= $${params.length + 1}`);
-          params.push(startDate);
-        }
-
-        if (endDate) {
-          conditions.push(`date_text <= $${params.length + 1}`);
-          params.push(endDate);
-        }
-
-        if (studentGroups === undefined) {
-          // If no groups provided, only show public events
-          conditions.push(`(restricted_groups IS NULL OR jsonb_array_length(restricted_groups) = 0 OR restricted_groups = '[]'::jsonb)`);
-        } else {
-          // Show public events OR events where restricted_groups overlaps with studentGroups
-          const groupArray = studentGroups.length ? studentGroups.map(id => `'${id}'`).join(',') : "'-1'"; // -1 to match nothing
-          conditions.push(`(restricted_groups IS NULL OR jsonb_array_length(restricted_groups) = 0 OR restricted_groups = '[]'::jsonb OR EXISTS (SELECT 1 FROM jsonb_array_elements_text(restricted_groups) AS g WHERE g IN (${groupArray})))`);
-          conditions.push(
-            `(restricted_groups IS NULL OR jsonb_array_length(restricted_groups) = 0 OR restricted_groups = '[]'::jsonb OR EXISTS (SELECT 1 FROM jsonb_array_elements_text(restricted_groups) AS g WHERE g = ANY($${params.length + 1})))`
-          );
-          params.push(studentGroups.length > 0 ? studentGroups : ['-1']);
-        }
-
-        if (conditions.length > 0) {
-          query += ' where ' + conditions.join(' and ');
-        }
-
-        query += ` order by created_at desc limit $${params.length + 1} offset $${params.length + 2}`;
-        params.push(limit, offset);
-
-        const { rows } = await client.query(query, params);
-
-        const countQuery = 'select count(*)::int as total from events ' + (conditions.length > 0 ? ' where ' + conditions.join(' and ') : '');
-        const countResult = await client.query(countQuery);
-        const countParams = params.slice(0, params.length - 2);
-
-        const total = countResult.rows[0]?.total ?? 0;
-
-        await client.query('COMMIT');
-
-        return {
-          rows: rows.map(mapRow),
-          total,
-        };
-      } catch (e) {
-        await client.query('ROLLBACK');
-        throw e;
-      }
     });
   },
 

--- a/server/test/eventsRepositoryList.test.js
+++ b/server/test/eventsRepositoryList.test.js
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import test, { after } from 'node:test';
+
+import { eventsRepository } from '../repositories/eventsRepository.js';
+import { setWithDbOverride } from '../repositories/db.js';
+
+after(() => {
+  setWithDbOverride(null);
+});
+
+function makeRow(overrides = {}) {
+  return {
+    id: 'evt-1',
+    name: 'Test Event',
+    short_name: 'TE',
+    date_text: '2026-09-01',
+    description: 'A test event',
+    status: 'upcoming',
+    icon: null,
+    tags: [],
+    restricted_groups: [],
+    created_at: new Date(),
+    updated_at: new Date(),
+    total: 1,
+    ...overrides,
+  };
+}
+
+test('list() applies a WHERE clause built from the filters (no unfiltered query)', async () => {
+  let capturedSql = null;
+  let capturedParams = null;
+
+  setWithDbOverride(async (fn) => {
+    const client = {
+      query: async (sql, params) => {
+        capturedSql = sql.replace(/\s+/g, ' ').trim();
+        capturedParams = params;
+        return { rows: [] };
+      },
+    };
+    return fn(client);
+  });
+
+  await eventsRepository.list({ status: 'upcoming', category: 'tech', search: 'hack' });
+
+  assert.ok(capturedSql.includes('where'), 'query must include a WHERE clause');
+  assert.ok(capturedSql.includes('status = $'), 'status filter must be applied');
+  assert.ok(capturedSql.includes('array_to_string(tags'), 'category filter must be applied');
+  assert.ok(capturedSql.includes('LIKE LOWER'), 'search filter must be applied');
+  assert.ok(capturedParams.includes('upcoming'), 'status param must be bound');
+});
+
+test('list() hides restricted events from callers with no studentGroups (public-only)', async () => {
+  const restrictedRow = makeRow({
+    id: 'evt-restricted',
+    restricted_groups: ['group-a'],
+  });
+  const publicRow = makeRow({ id: 'evt-public', restricted_groups: [] });
+
+  setWithDbOverride(async (fn) => {
+    const client = {
+      query: async (sql) => {
+        // Simulate the DB honoring the WHERE clause: only return rows whose
+        // restricted_groups is empty when no studentGroups were supplied.
+        if (sql.includes('restricted_groups')) {
+          return { rows: [publicRow] };
+        }
+        return { rows: [] };
+      },
+    };
+    return fn(client);
+  });
+
+  const { rows } = await eventsRepository.list({}); // no studentGroups -> public only
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].id, 'evt-public');
+  assert.ok(
+    !rows.some((r) => r.id === 'evt-restricted'),
+    'restricted event must not be visible to an unauthenticated/public caller'
+  );
+});
+
+test('list() includes restricted events only for callers whose studentGroups overlap', async () => {
+  let capturedSql = null;
+  let capturedParams = null;
+
+  setWithDbOverride(async (fn) => {
+    const client = {
+      query: async (sql, params) => {
+        capturedSql = sql.replace(/\s+/g, ' ').trim();
+        capturedParams = params;
+        return { rows: [] };
+      },
+    };
+    return fn(client);
+  });
+
+  await eventsRepository.list({ studentGroups: ['group-a', 'group-b'] });
+
+  assert.ok(
+    capturedSql.includes('jsonb_array_elements_text(restricted_groups)'),
+    'group-overlap condition must be present when studentGroups is provided'
+  );
+  assert.ok(
+    capturedParams.some((p) => Array.isArray(p) && p.includes('group-a')),
+    'studentGroups must be passed as a bound parameter, not interpolated into the SQL string'
+  );
+  assert.ok(
+    !capturedSql.includes(`'group-a'`),
+    'studentGroups must never be string-interpolated directly into the query'
+  );
+});
+
+test('list() total reflects the filtered count, not the full table', async () => {
+  setWithDbOverride(async (fn) => {
+    const client = {
+      query: async (sql) => {
+        // Only one row matches the filter; count(*) over() reflects that.
+        return { rows: [makeRow({ total: 1 })] };
+      },
+    };
+    return fn(client);
+  });
+
+  const { total, rows } = await eventsRepository.list({ status: 'upcoming' });
+
+  assert.equal(total, 1);
+  assert.equal(rows.length, 1);
+});
+
+test('list() does not issue a 4-argument client.query call (no stray SQL/params)', async () => {
+  let callArgCount = null;
+
+  setWithDbOverride(async (fn) => {
+    const client = {
+      query: async (...args) => {
+        callArgCount = args.length;
+        return { rows: [] };
+      },
+    };
+    return fn(client);
+  });
+
+  await eventsRepository.list({});
+
+  assert.ok(callArgCount <= 2, 'client.query should be called with (sql, params) only');
+});


### PR DESCRIPTION
## Description

Fixed a bug in `server/repositories/eventsRepository.js` where the `list()` method was serving an unfiltered query due to an early return. This made the actual filtered implementation completely unreachable.

As a result:
- All events were returned without a `WHERE` clause.
- Restricted/private events were exposed to unauthenticated and non-member users.
- Filter parameters (`status`, `category`, `location`, `search`, and date range) were silently ignored.

## Related Issue

Closes #4630

## Type of Change

- [x] Bug Fix
- [ ] Feature
- [ ] UI/UX Improvement
- [ ] Performance Optimization
- [x] Security Enhancement
- [ ] Refactoring
- [ ] Documentation
- [x] Testing
- [ ] Infrastructure
- [ ] Integration

## Changes Implemented

- Removed the dead code after the early return and made the filtered implementation the live query path.
- Restored the `studentGroups` access-control condition:
  - Public-only events when no groups are supplied.
  - Public events **OR** restricted events whose `restricted_groups` overlap with the caller's groups.
- Removed an unsafe duplicate version of the access-control condition that interpolated group IDs directly into SQL.
- Kept the parameterized `= ANY($n)` implementation to prevent SQL injection.
- Fixed the malformed 4-argument `client.query(...)` call by ensuring it uses only `(sql, params)`.
- Removed leftover `COMMIT`/`ROLLBACK` calls from the repository function since `withDb` already manages transactions.
- Updated the cache key to include all filter parameters, preventing cache poisoning across different filter combinations.
- Added `server/test/eventsRepositoryList.test.js`.

## Technical Details

### Backend

Changes are isolated to:

`server/repositories/eventsRepository.js` - `list()` method only.

No API contract, route, or schema changes were made.

## Testing

### Unit Tests

Added `server/test/eventsRepositoryList.test.js`, covering:

- [x] Query includes a real `WHERE` clause built from supplied filters.
- [x] Restricted events are hidden from callers without `studentGroups`.
- [x] Restricted events are visible only when `studentGroups` overlap, using a parameterized query rather than string interpolation.
- [x] Pagination total reflects the filtered count rather than the full table.
- [x] `client.query` is called with `(sql, params)` only, with no stray fourth argument.

**Verification:** 4 of these 5 assertions fail against the original code, and all 5 pass after the fix.

### Manual Testing

- `node --check repositories/eventsRepository.js` - passed; no syntax errors.
- `node --test test/eventsRepositoryList.test.js` - passed; all 5 tests pass.

## Breaking Changes

- [x] No Breaking Changes

## Checklist

- [x] Code follows project standards
- [x] Tests added or updated
- [ ] Documentation updated
- [x] Security reviewed
- [ ] Accessibility reviewed
- [ ] Performance validated
- [x] CI/CD passing
- [x] Ready for review