### PR TITLE
fix: resolve cache service syntax error

### DIFF
--- a/server/services/cacheService.js
+++ b/server/services/cacheService.js
@@ -86,6 +86,7 @@ export const cacheService = {
   buildKey(prefix, id) {
     return `cache:${prefix}:${id}`;
   },
+};
 
 // In-memory cache store
 // Entry shape: { value, expiresAt, version }


### PR DESCRIPTION
## What does this PR do?

Fixes a syntax error in `server/services/cacheService.js` that prevented Node.js from parsing the cache service.

The cache service object was missing its closing `};`, causing:

`SyntaxError: Unexpected identifier 'cacheStore'`

The missing closing statement has been restored.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?

- [x] Tested locally
- [x] Verified JavaScript syntax with `node --check`
- [x] Confirmed no `console.*` statements remain in `cacheService.js`

### Verification

```bash
node --check server/services/cacheService.js