### PR TITLE
test: add regression coverage for null defaults in createFlag

### DIFF
--- a/server/test/featureFlags.test.js
+++ b/server/test/featureFlags.test.js
@@ -104,6 +104,21 @@ test.beforeEach(() => {
   featureFlagsService.isInitialized = true; // prevent service from trying to fetch all flags on boot
 });
 
+test('createFlag applies defaults when defaulted fields are null', async () => {
+  const flag = await featureFlagsService.createFlag({
+    key: 'test_null_defaults',
+    name: 'Test Null Defaults',
+    type: 'boolean',
+    is_active: null,
+    rollout_percentage: null,
+    fallback_value: null,
+  });
+
+  assert.equal(flag.is_active, true);
+  assert.equal(flag.rollout_percentage, 100);
+  assert.equal(flag.fallback_value, false);
+});
+
 test('Feature flag evaluation - Boolean flag', async () => {
   const flag = {
     key: 'test_boolean',


### PR DESCRIPTION
## Description

Adds regression coverage for issue #3935 by testing `createFlag` with
explicit `null` values for fields that have default values.

The test verifies that:

- `is_active: null` resolves to `true`
- `rollout_percentage: null` resolves to `100`
- `fallback_value: null` resolves to `false`

It also ensures the existing nullish-default behavior is covered by automated tests.

## Testing

- `node --experimental-test-module-mocks --test test/featureFlags.test.js`
- The new regression test passes.
- The existing `Feature flag API Endpoints integration` test currently fails because of an unrelated `scheduleWaitlistExpiryJob` export error in `queueService.js`.

## Checklist

- [ ] I have tested my changes locally.
- [ ] I have added regression coverage for the reported issue.
- [ ] My changes are limited to the scope of this issue.
- [ ] I have reviewed my changes for unnecessary files or modifications.

## Related Issue

Closes #3935