### PR TITLE
fix: add error logging to empty catch blocks

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -686,7 +686,9 @@ app.use("/", syncRouter);
 const UPLOADS_DIR = path.join(__dirname, "uploads");
 try {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-} catch (_) {}
+} catch (err) {
+  logger.warn("Failed to create uploads directory", { error: err.message });
+}
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),

--- a/server/middleware/uploadMiddleware.js
+++ b/server/middleware/uploadMiddleware.js
@@ -8,7 +8,9 @@ const __dirname = path.dirname(__filename);
 export const UPLOADS_DIR = path.join(__dirname, 'uploads');
 try {
   fs.mkdirSync(UPLOADS_DIR, { recursive: true });
-} catch (_) {}
+} catch (err) {
+  console.warn('Failed to create uploads directory:', err.message);
+}
 
 const storage = multer.diskStorage({
   destination: (_req, _file, cb) => cb(null, UPLOADS_DIR),

--- a/server/services/bulkOperationsService.js
+++ b/server/services/bulkOperationsService.js
@@ -888,7 +888,12 @@ class BulkOperationsService {
                   dateVal.setDate(dateVal.getDate() + offsetDays);
                   newDateText = dateVal.toISOString().split("T")[0];
                 }
-              } catch (_) {}
+              } catch (err) {
+                logger.warn("Failed to shift event date", {
+                  eventId: event.id,
+                  error: err.message,
+                });
+              }
 
               const { rows: insertedRows } = await client.query(
                 `INSERT INTO events (id, name, short_name, date_text, description, status, icon, tags, location, capacity, created_at, updated_at)

--- a/server/services/schedulerService.js
+++ b/server/services/schedulerService.js
@@ -279,7 +279,13 @@ class SchedulerService extends EventEmitter {
       this._runTask(taskId);
       try {
         task.nextRun = nextCronDate(task.cron);
-      } catch (err) {}
+      } catch (err) {
+        logger.warn('Failed to compute next run for cron task', {
+          taskId: task.id,
+          cron: task.cron,
+          error: err.message,
+        });
+      }
     });
 
     this._timers.set(taskId, job);

--- a/server/services/sseService.js
+++ b/server/services/sseService.js
@@ -142,7 +142,9 @@ export function addSSEClient(res, adminSession = null) {
     });
     try {
       res.status(503).end('Too many SSE connections');
-    } catch (_) {}
+    } catch (err) {
+      logger.warn('Failed to reject excess SSE connection', { error: err.message });
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary
Adds error logging to five empty catch blocks across the server so silent failures (uploads dir, SSE reject, cron scheduling, date shifting) become observable.

## Changes
- `server/index.js`: log when uploads dir creation fails
- `server/middleware/uploadMiddleware.js`: same, using console.warn
- `server/services/sseService.js`: log rejected excess SSE connection
- `server/services/schedulerService.js`: log cron nextRun computation failure
- `server/services/bulkOperationsService.js`: log event date shift failure

## Checklist
- [x] No new dependencies
- [x] Uses existing logger where available