### PR TITLE
feat: add venue seating layout APIs

### DIFF
--- a/server/controllers/venueLayoutsController.js
+++ b/server/controllers/venueLayoutsController.js
@@ -1,0 +1,100 @@
+import { sendSuccess, sendError } from "../utils/responseHelper.js";
+import { eventsRepository } from "../repositories/eventsRepository.js";
+import { registrationsRepository } from "../repositories/registrationsRepository.js";
+import { venueLayoutsRepository } from "../repositories/venueLayoutsRepository.js";
+
+function wrapAsync(fn) {
+  return (req, res) =>
+    Promise.resolve(fn(req, res)).catch((e) => {
+      console.error("[venueLayoutsController]", e);
+      res
+        .status(e.status || 500)
+        .json({ error: e?.message || "Internal server error" });
+    });
+}
+
+function normalizeGridData(value) {
+  const gridData = value && typeof value === "object" ? value : {};
+  const rows = Number(gridData.rows);
+  const cols = Number(gridData.cols);
+  const cells = Array.isArray(gridData.cells) ? gridData.cells : [];
+
+  if (!Number.isInteger(rows) || rows < 1 || rows > 50) {
+    const err = new Error("rows must be an integer between 1 and 50");
+    err.status = 400;
+    throw err;
+  }
+  if (!Number.isInteger(cols) || cols < 1 || cols > 50) {
+    const err = new Error("cols must be an integer between 1 and 50");
+    err.status = 400;
+    throw err;
+  }
+
+  const allowedTypes = new Set(["SEAT", "VIP", "AISLE", "BLOCKED"]);
+  const normalizedCells = cells.map((cell) => ({
+    row: Number(cell.row),
+    col: Number(cell.col),
+    code: String(cell.code || "")
+      .trim()
+      .toUpperCase(),
+    type: allowedTypes.has(cell.type) ? cell.type : "SEAT",
+  }));
+
+  if (
+    normalizedCells.some(
+      (cell) =>
+        !cell.code ||
+        cell.row < 1 ||
+        cell.col < 1 ||
+        cell.row > rows ||
+        cell.col > cols
+    )
+  ) {
+    const err = new Error("cells must include valid row, col, and code values");
+    err.status = 400;
+    throw err;
+  }
+
+  return { rows, cols, cells: normalizedCells };
+}
+
+export const listVenueLayouts = wrapAsync(async (_req, res) => {
+  const layouts = await venueLayoutsRepository.list();
+  return sendSuccess(res, { layouts });
+});
+
+export const createVenueLayout = wrapAsync(async (req, res) => {
+  const name = String(req.body.name || "")
+    .trim()
+    .slice(0, 120);
+  if (!name) {
+    return sendError(
+      req,
+      res,
+      "Layout name is required",
+      400,
+      "VALIDATION_ERROR"
+    );
+  }
+  const gridData = normalizeGridData(req.body.gridData);
+  const layout = await venueLayoutsRepository.create({ name, gridData });
+  return sendSuccess(res, { layout }, 201);
+});
+
+export const getEventSeatMap = wrapAsync(async (req, res) => {
+  const eventId = String(req.params.eventId || "").trim();
+  const event = await eventsRepository.getById(eventId);
+  if (!event) {
+    return sendError(req, res, "Event not found", 404, "EVENT_NOT_FOUND");
+  }
+  if (!event.venueLayoutId) {
+    return sendSuccess(res, { layout: null, occupiedSeats: [] });
+  }
+
+  const [layout, occupiedSeats] = await Promise.all([
+    venueLayoutsRepository.getById(event.venueLayoutId),
+    registrationsRepository.findOccupiedSeats(eventId),
+  ]);
+
+  return sendSuccess(res, { layout, occupiedSeats });
+});

--- a/server/migrations/1811_add_venue_layouts_and_seats.js
+++ b/server/migrations/1811_add_venue_layouts_and_seats.js
@@ -1,0 +1,31 @@
+exports.up = (pgm) => {
+  pgm.sql(`
+    create table if not exists venue_layouts (
+      id uuid primary key default gen_random_uuid(),
+      name text not null,
+      grid_data jsonb not null default '{}'::jsonb,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    );
+
+    alter table events
+      add column if not exists venue_layout_id uuid references venue_layouts(id) on delete set null;
+
+    alter table event_registrations
+      add column if not exists seat_code text;
+
+    create unique index if not exists event_registrations_event_seat_unique
+      on event_registrations (event_id, seat_code)
+      where seat_code is not null and status = 'confirmed';
+  `);
+};
+
+exports.down = (pgm) => {
+  pgm.dropIndex("event_registrations", ["event_id", "seat_code"], {
+    name: "event_registrations_event_seat_unique",
+    ifExists: true,
+  });
+  pgm.dropColumns("event_registrations", ["seat_code"], { ifExists: true });
+  pgm.dropColumns("events", ["venue_layout_id"], { ifExists: true });
+  pgm.dropTable("venue_layouts", { ifExists: true });
+};

--- a/server/repositories/eventsRepository.js
+++ b/server/repositories/eventsRepository.js
@@ -31,6 +31,7 @@ function mapRow(row) {
       typeof row.restricted_groups === "string"
         ? JSON.parse(row.restricted_groups)
         : (row.restricted_groups ?? []),
+    venueLayoutId: row.venue_layout_id || null,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
   };
@@ -159,8 +160,8 @@ export const eventsRepository = {
   async create(event) {
     return withDb(async (client) => {
       const { rows } = await client.query(
-        `insert into events (id, name, short_name, date_text, description, status, icon, tags, restricted_groups, capacity)
-         values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+        `insert into events (id, name, short_name, date_text, description, status, icon, tags, restricted_groups, capacity, venue_layout_id)
+         values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)
          on conflict (id) do update set
            name=excluded.name,
            short_name=excluded.short_name,
@@ -171,6 +172,7 @@ export const eventsRepository = {
            tags=excluded.tags,
            restricted_groups=excluded.restricted_groups,
            capacity=excluded.capacity,
+           venue_layout_id=excluded.venue_layout_id,
 
            updated_at=now()
          returning *`,
@@ -185,6 +187,7 @@ export const eventsRepository = {
           event.tags,
           JSON.stringify(event.restrictedGroups || []),
           event.capacity || null,
+          event.venueLayoutId || null,
         ]
       );
       const mapped = mapRow(rows[0]);
@@ -224,6 +227,7 @@ export const eventsRepository = {
         icon: "icon",
         tags: "tags",
         capacity: "capacity",
+        venueLayoutId: "venue_layout_id",
       };
 
       const setClauses = [];

--- a/server/repositories/registrationsRepository.js
+++ b/server/repositories/registrationsRepository.js
@@ -46,12 +46,13 @@ export const registrationsRepository = {
     customFields,
     waitlist,
     attendanceMode,
+    seatCode,
   }) {
     if (!HAS_SUPABASE) return null;
     return withDb(async (client) => {
       const { rows } = await client.query(
-        `INSERT INTO event_registrations (event_id, full_name, email, department, year, team_name, team_size, custom_fields, waitlist, status, attendance_mode)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+        `INSERT INTO event_registrations (event_id, full_name, email, department, year, team_name, team_size, custom_fields, waitlist, status, attendance_mode, seat_code)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
          ON CONFLICT (event_id, email) DO UPDATE SET
            full_name = EXCLUDED.full_name,
            department = EXCLUDED.department,
@@ -61,7 +62,8 @@ export const registrationsRepository = {
            custom_fields = EXCLUDED.custom_fields,
            waitlist = EXCLUDED.waitlist,
            status = EXCLUDED.status,
-           attendance_mode = EXCLUDED.attendance_mode
+           attendance_mode = EXCLUDED.attendance_mode,
+           seat_code = EXCLUDED.seat_code
          RETURNING *`,
         [
           eventId,
@@ -75,9 +77,36 @@ export const registrationsRepository = {
           waitlist || false,
           waitlist ? "waitlisted" : "confirmed",
           attendanceMode || "in_person",
+          seatCode || null,
         ]
       );
       return rows[0];
+    });
+  },
+
+  async isSeatTaken(eventId, seatCode) {
+    if (!HAS_SUPABASE || !seatCode) return false;
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `SELECT 1 FROM event_registrations
+         WHERE event_id = $1 AND seat_code = $2 AND status = 'confirmed'
+         LIMIT 1`,
+        [eventId, seatCode]
+      );
+      return rows.length > 0;
+    });
+  },
+
+  async findOccupiedSeats(eventId) {
+    if (!HAS_SUPABASE) return [];
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `SELECT seat_code FROM event_registrations
+         WHERE event_id = $1 AND seat_code IS NOT NULL AND status = 'confirmed'
+         ORDER BY seat_code ASC`,
+        [eventId]
+      );
+      return rows.map((row) => row.seat_code);
     });
   },
 

--- a/server/repositories/venueLayoutsRepository.js
+++ b/server/repositories/venueLayoutsRepository.js
@@ -1,0 +1,44 @@
+import { withDb } from "./db.js";
+
+function mapRow(row) {
+  return {
+    id: row.id,
+    name: row.name,
+    gridData: row.grid_data || row.gridData || {},
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export const venueLayoutsRepository = {
+  async list() {
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        "SELECT * FROM venue_layouts ORDER BY updated_at DESC"
+      );
+      return rows.map(mapRow);
+    });
+  },
+
+  async getById(id) {
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        "SELECT * FROM venue_layouts WHERE id = $1 LIMIT 1",
+        [id]
+      );
+      return rows[0] ? mapRow(rows[0]) : null;
+    });
+  },
+
+  async create({ name, gridData }) {
+    return withDb(async (client) => {
+      const { rows } = await client.query(
+        `INSERT INTO venue_layouts (name, grid_data)
+         VALUES ($1, $2::jsonb)
+         RETURNING *`,
+        [name, JSON.stringify(gridData)]
+      );
+      return mapRow(rows[0]);
+    });
+  },
+};

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -11,6 +11,7 @@ import * as activityEventsController from '../controllers/activityEventsControll
 import { adminAuthMiddleware } from '../middleware/adminAuthMiddleware.js';
 import * as coreTeamController from '../controllers/coreTeamController.js';
 import * as eventRegistrationController from '../controllers/eventRegistrationController.js';
+import * as venueLayoutsController from '../controllers/venueLayoutsController.js';
 import * as usersController from '../controllers/usersController.js';
 import { usersRepository } from '../repositories/usersRepository.js';
 import * as attendanceController from '../controllers/attendanceController.js';
@@ -128,6 +129,7 @@ router.post(
 );
 router.get('/api/users', usersController.getPublicUsers);
 router.get('/api/content/events', eventsController.listEvents);
+router.get('/api/content/events/:eventId/seats', venueLayoutsController.getEventSeatMap);
 router.post('/api/content/events/:eventId/register', eventRegistrationController.registerForEvent);
 // (Removed mangled event registration routes)
 router.post('/account-recovery/request', async (req, res) => {
@@ -239,6 +241,17 @@ router.get(
   '/api/admin/events',
   adminAuthMiddleware.requireScope('events:read'),
   eventsController.adminListEvents
+);
+router.get(
+  '/api/admin/venues',
+  adminAuthMiddleware.requireScope('events:read'),
+  venueLayoutsController.listVenueLayouts
+);
+router.post(
+  '/api/admin/venues',
+  adminAuthMiddleware.requireScope('events:write'),
+  adminAuditMiddleware,
+  venueLayoutsController.createVenueLayout
 );
 router.post(
   '/api/admin/events',

--- a/server/services/cacheService.js
+++ b/server/services/cacheService.js
@@ -52,6 +52,17 @@ export const cacheService = {
     }
   },
 
+  async setIfNotExists(key, value, ttl = DEFAULT_TTL) {
+    try {
+      const serialized = JSON.stringify(value);
+      const result = await getClient().set(key, serialized, "EX", ttl, "NX");
+      return result === "OK";
+    } catch (err) {
+      console.error("[cache-service] SetNX error:", err.message);
+      return false;
+    }
+  },
+
   async del(key) {
     try {
       await getClient().del(key);

--- a/server/services/seatLockService.js
+++ b/server/services/seatLockService.js
@@ -5,11 +5,13 @@ const LOCK_TTL = 300; // 5 minutes in seconds
 export const seatLockService = {
   async acquireLock(eventId, seatCode, email) {
     const lockKey = `seatlock:${eventId}:${seatCode}`;
-    const acquired = await cacheService.set(lockKey, email, LOCK_TTL);
-    // Note: cacheService.set returns true if successful.
-    // In a real implementation with ioredis we would use NX (set if not exists)
-    // For now we'll just return true, assuming cacheService handles it or for tests it's enough.
-    return true;
+    if (cacheService.setIfNotExists) {
+      return cacheService.setIfNotExists(lockKey, email, LOCK_TTL);
+    }
+    if (await cacheService.exists(lockKey)) {
+      return false;
+    }
+    return cacheService.set(lockKey, email, LOCK_TTL);
   },
 
   async releaseLock(eventId, seatCode) {


### PR DESCRIPTION
## Description
Implements the backend foundation for dynamic venue seating layouts and visual seat reservation in #3318. This adds venue layout persistence, admin APIs for creating/listing layouts, public event seat-map availability, selected seat persistence during registration, and atomic Redis seat locks so concurrent bookings cannot silently reserve the same seat.

## Related Issue
Closes #3318

## Type of Change
- [x] Feature
- [x] Backend
- [x] Database migration
- [x] Bug fix

## Changes Made
- [x] Added `venue_layouts` migration with `events.venue_layout_id` and `event_registrations.seat_code`
- [x] Added admin `GET/POST /api/admin/venues` endpoints
- [x] Added public `GET /api/content/events/:eventId/seats` endpoint
- [x] Persisted `seatCode` in registration repository and exposed occupied-seat lookup
- [x] Replaced non-atomic seat locking with Redis `SET NX EX`

## Validation
- [x] `node --check server/controllers/venueLayoutsController.js`
- [x] `node --check server/repositories/venueLayoutsRepository.js`
- [x] `node --check server/repositories/registrationsRepository.js`
- [x] `node --check server/repositories/eventsRepository.js`
- [x] `node --check server/services/seatLockService.js`
- [x] `node --check server/services/cacheService.js`
- [x] `node --check server/routes/api.js`
- [x] `node --check server/migrations/1811_add_venue_layouts_and_seats.js`

## Checklist
- [x] My PR is linked to the assigned issue
- [x] My commit includes DCO sign-off
- [x] I kept the PR focused on one issue
- [x] I ran relevant validation locally