### PR TITLE
fix: restore useSearch import

### DIFF
--- a/website/src/components/SearchBar.jsx
+++ b/website/src/components/SearchBar.jsx
@@ -15,7 +15,7 @@ import {
   MessageSquare,
 } from 'lucide-react';
 // TODO: useSearch hook not implemented yet
-// import { useSearch } from '../hooks/useSearch';
+import { useSearch } from '../hooks/useSearch';
 
 function Highlight({ text, query }) {
   if (!text) return null;


### PR DESCRIPTION
## What does this PR do?

Restores the missing `useSearch` import in `website/src/components/SearchBar.jsx`.

The component was calling `useSearch(activities, events)` without importing the hook, which caused:

`ReferenceError: useSearch is not defined`

This change restores the import from `../hooks/useSearch`.

Closes #4075

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring / optimization

## How Has This Been Tested?

- [ ] Tested locally
- [ ] Verified the application builds successfully
- [ ] Checked for console/runtime errors

### Build verification

`npm run build` completed successfully with Vite.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have checked my code and corrected any misspellings