### PR TITLE
feat(admin): add table pagination utilities

### DIFF
--- a/admin-dashboard/src/__tests__/utils/tablePagination.test.js
+++ b/admin-dashboard/src/__tests__/utils/tablePagination.test.js
@@ -1,0 +1,182 @@
+import { describe, expect, test } from 'vitest';
+import {
+  sortData,
+  filterData,
+  paginateData,
+  applyTableState,
+} from '../../utils/tablePagination';
+
+const users = [
+  { id: 1, name: 'Alice', role: 'Developer', age: 25 },
+  { id: 2, name: 'Bob', role: 'Designer', age: 30 },
+  { id: 3, name: 'Charlie', role: 'Developer', age: 22 },
+  { id: 4, name: 'David', role: 'Manager', age: 35 },
+];
+
+describe('sortData', () => {
+  test('sorts numbers in ascending order', () => {
+    const result = sortData(users, 'age', 'asc');
+
+    expect(result.map((user) => user.age)).toEqual([22, 25, 30, 35]);
+  });
+
+  test('sorts numbers in descending order', () => {
+    const result = sortData(users, 'age', 'desc');
+
+    expect(result.map((user) => user.age)).toEqual([35, 30, 25, 22]);
+  });
+
+  test('sorts strings case-insensitively', () => {
+    const result = sortData(users, 'name', 'asc');
+
+    expect(result.map((user) => user.name)).toEqual([
+      'Alice',
+      'Bob',
+      'Charlie',
+      'David',
+    ]);
+  });
+
+  test('does not mutate the original array', () => {
+    const original = [...users];
+
+    sortData(users, 'age', 'desc');
+
+    expect(users).toEqual(original);
+  });
+
+  test('handles empty and null input', () => {
+    expect(sortData([], 'name')).toEqual([]);
+    expect(sortData(null, 'name')).toEqual([]);
+  });
+});
+
+describe('filterData', () => {
+  test('matches search across multiple columns', () => {
+    const result = filterData(users, 'developer', ['name', 'role']);
+
+    expect(result.map((user) => user.name)).toEqual([
+      'Alice',
+      'Charlie',
+    ]);
+  });
+
+  test('is case-insensitive', () => {
+    const result = filterData(users, 'ALICE', ['name']);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('Alice');
+  });
+
+  test('returns all data when search term is empty', () => {
+    const result = filterData(users, '', ['name']);
+
+    expect(result).toEqual(users);
+  });
+
+  test('returns empty array when no columns are supplied for a search', () => {
+    expect(filterData(users, 'alice', [])).toEqual([]);
+  });
+
+  test('handles null input', () => {
+    expect(filterData(null, 'alice', ['name'])).toEqual([]);
+  });
+});
+
+describe('paginateData', () => {
+  test('returns the correct page', () => {
+    const result = paginateData(users, 2, 2);
+
+    expect(result.items.map((user) => user.name)).toEqual([
+      'Charlie',
+      'David',
+    ]);
+
+    expect(result.totalPages).toBe(2);
+    expect(result.hasPrev).toBe(true);
+    expect(result.hasNext).toBe(false);
+  });
+
+  test('handles the first page correctly', () => {
+    const result = paginateData(users, 1, 2);
+
+    expect(result.items.map((user) => user.name)).toEqual([
+      'Alice',
+      'Bob',
+    ]);
+
+    expect(result.hasPrev).toBe(false);
+    expect(result.hasNext).toBe(true);
+  });
+
+  test('handles a page beyond the last page', () => {
+    const result = paginateData(users, 10, 2);
+
+    expect(result.items).toEqual([users[2], users[3]]);
+    expect(result.totalPages).toBe(2);
+    expect(result.hasPrev).toBe(true);
+    expect(result.hasNext).toBe(false);
+  });
+
+  test('handles empty data', () => {
+    expect(paginateData([], 1, 10)).toEqual({
+      items: [],
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+
+  test('handles null data', () => {
+    expect(paginateData(null, 1, 10)).toEqual({
+      items: [],
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+});
+
+describe('applyTableState', () => {
+  test('filters, sorts, and paginates in one call', () => {
+    const result = applyTableState(users, {
+      sortKey: 'age',
+      sortDir: 'desc',
+      search: 'developer',
+      columns: ['role'],
+      page: 1,
+      pageSize: 1,
+    });
+
+    expect(result.items).toEqual([
+      {
+        id: 1,
+        name: 'Alice',
+        role: 'Developer',
+        age: 25,
+      },
+    ]);
+
+    expect(result.totalPages).toBe(2);
+    expect(result.hasNext).toBe(true);
+    expect(result.hasPrev).toBe(false);
+  });
+
+  test('handles empty state', () => {
+    expect(
+      applyTableState([], {
+        sortKey: 'name',
+        sortDir: 'asc',
+        search: 'test',
+        columns: ['name'],
+        page: 1,
+        pageSize: 10,
+      })
+    ).toEqual({
+      items: [],
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    });
+  });
+});

--- a/admin-dashboard/src/utils/tablePagination.js
+++ b/admin-dashboard/src/utils/tablePagination.js
@@ -1,0 +1,149 @@
+/**
+ * Sort an array of objects by a given key.
+ *
+ * @param {Array} data
+ * @param {string} key
+ * @param {'asc'|'desc'} direction
+ * @returns {Array}
+ */
+export function sortData(data, key, direction = 'asc') {
+  if (!Array.isArray(data) || data.length === 0 || !key) {
+    return Array.isArray(data) ? [...data] : [];
+  }
+
+  const multiplier = direction === 'desc' ? -1 : 1;
+
+  return [...data].sort((a, b) => {
+    const aValue = a?.[key];
+    const bValue = b?.[key];
+
+    if (aValue == null && bValue == null) return 0;
+    if (aValue == null) return 1;
+    if (bValue == null) return -1;
+
+    if (typeof aValue === 'number' && typeof bValue === 'number') {
+      return (aValue - bValue) * multiplier;
+    }
+
+    return (
+      String(aValue).localeCompare(String(bValue), undefined, {
+        numeric: true,
+        sensitivity: 'base',
+      }) * multiplier
+    );
+  });
+}
+
+/**
+ * Filter an array of objects by searching across specified columns.
+ *
+ * @param {Array} data
+ * @param {string} searchTerm
+ * @param {Array<string>} columns
+ * @returns {Array}
+ */
+export function filterData(data, searchTerm = '', columns = []) {
+  if (!Array.isArray(data) || data.length === 0) {
+    return [];
+  }
+
+  const term = String(searchTerm ?? '').trim().toLowerCase();
+
+  if (!term) {
+    return [...data];
+  }
+
+  if (!Array.isArray(columns) || columns.length === 0) {
+    return [];
+  }
+
+  return data.filter((item) =>
+    columns.some((column) =>
+      String(item?.[column] ?? '')
+        .toLowerCase()
+        .includes(term)
+    )
+  );
+}
+
+/**
+ * Paginate an array of data.
+ *
+ * @param {Array} data
+ * @param {number} page - 1-based page number
+ * @param {number} pageSize
+ * @returns {{items: Array, totalPages: number, hasNext: boolean, hasPrev: boolean}}
+ */
+export function paginateData(data, page = 1, pageSize = 10) {
+  const safeData = Array.isArray(data) ? data : [];
+
+  const safePageSize =
+    Number.isFinite(Number(pageSize)) && Number(pageSize) > 0
+      ? Math.floor(Number(pageSize))
+      : 10;
+
+  const totalPages =
+    safeData.length === 0 ? 0 : Math.ceil(safeData.length / safePageSize);
+
+  const safePage =
+    Number.isFinite(Number(page)) && Number(page) > 0
+      ? Math.floor(Number(page))
+      : 1;
+
+  if (totalPages === 0) {
+    return {
+      items: [],
+      totalPages: 0,
+      hasNext: false,
+      hasPrev: false,
+    };
+  }
+
+  const currentPage = Math.min(safePage, totalPages);
+  const startIndex = (currentPage - 1) * safePageSize;
+
+  return {
+    items: safeData.slice(startIndex, startIndex + safePageSize),
+    totalPages,
+    hasNext: currentPage < totalPages,
+    hasPrev: currentPage > 1,
+  };
+}
+
+/**
+ * Apply filtering, sorting, and pagination to table data.
+ *
+ * @param {Array} data
+ * @param {Object} state
+ * @returns {{
+ *   items: Array,
+ *   totalPages: number,
+ *   hasNext: boolean,
+ *   hasPrev: boolean
+ * }}
+ */
+export function applyTableState(
+  data,
+  {
+    sortKey = '',
+    sortDir = 'asc',
+    search = '',
+    columns = [],
+    page = 1,
+    pageSize = 10,
+  } = {}
+) {
+  const filtered = filterData(data, search, columns);
+  const sorted = sortKey
+    ? sortData(filtered, sortKey, sortDir)
+    : filtered;
+
+  return paginateData(sorted, page, pageSize);
+}
+
+export default {
+  sortData,
+  filterData,
+  paginateData,
+  applyTableState,
+};


### PR DESCRIPTION
## Description

Adds reusable client-side table utilities for the admin dashboard to handle sorting, filtering, and pagination.

## Related Issue

Fixes #4306

## Changes Implemented

- Added reusable `sortData` utility for ascending and descending sorting.
- Added reusable `filterData` utility with case-insensitive multi-column search.
- Added reusable `paginateData` utility with pagination metadata.
- Added `applyTableState` utility to combine filtering, sorting, and pagination.
- Added Vitest test coverage for all table utilities.
- Functions are pure and handle null/empty inputs gracefully.
- Added named exports and a default aggregate export.

## Testing

- `npm test -- src/__tests__/utils/tablePagination.test.js` ✅
- 17 tests passed
- `git diff --check` ✅

## Checklist

- [x] Code follows project standards
- [x] Changes are limited to the issue scope
- [x] `git diff --check` passes
- [x] Tests pass
- [x] Unit tests added or updated
- [ ] Documentation updated
- [x] No backend/database changes required
- [x] Ready for review

## Notes

Changes are limited to reusable frontend utilities and their tests in the `admin-dashboard` workspace.