### PR TITLE
Add path-based SPA routing, persistent applicant flows, and enhanced admin event editor

### DIFF
--- a/admin-dashboard/src/components/EventForm.jsx
+++ b/admin-dashboard/src/components/EventForm.jsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import { api } from '../services/api';
 import { AdminIcon } from './AdminIcon';
 
-const STATUSES = ['upcoming', 'ongoing', 'completed', 'cancelled'];
+const STATUSES = ['upcoming', 'completed'];
+const CATEGORIES = ['Hackathon', 'Codathon', 'Ideathon', 'Promptathon', 'Workshop', 'Insight Session', 'Open Source Day', 'Tech Debate'];
+const ICONS = ['Brain', 'Wrench', 'Trophy', 'Terminal', 'Lightbulb', 'Sparkles', 'GitBranch', 'MessageSquare'];
 
-const empty = { name: '', dateText: '', description: '', icon: 'Calendar', status: 'upcoming', location: '', registrationLink: '' };
+const empty = { name: '', dateText: '', time: '', venue: '', category: 'Workshop', description: '', speakerName: '', speakerTitle: '', judges: '', topicsCovered: '', highlights: '', facultyInCharge: '', mediaDriveLink: '', icon: 'Wrench', status: 'upcoming', registrationLink: '' };
 
 export function EventForm({ event, onClose }) {
   const [form, setForm] = useState(event ? { ...event } : empty);
@@ -40,16 +42,24 @@ export function EventForm({ event, onClose }) {
         </div>
         <form onSubmit={handleSubmit} className="form">
           <div className="form-row">
-            <label>Name *</label>
+            <label>Event topic / title *</label>
             <input value={form.name} onChange={e => set('name', e.target.value)} required />
           </div>
           <div className="form-row">
-            <label>Date</label>
-            <input value={form.dateText} onChange={e => set('dateText', e.target.value)} placeholder="e.g. March 15, 2025" />
+            <label>Activity category</label>
+            <select value={form.category} onChange={e => set('category', e.target.value)}>
+              {CATEGORIES.map(category => <option key={category}>{category}</option>)}
+            </select>
           </div>
           <div className="form-row">
-            <label>Icon</label>
-            <input value={form.icon} onChange={e => set('icon', e.target.value)} placeholder="Icon name, e.g. Brain or Calendar" />
+            <label>Date *</label>
+            <input value={form.dateText || form.date || ''} onChange={e => set('dateText', e.target.value)} placeholder="e.g. March 15, 2026" required />
+          </div>
+          <div className="form-row"><label>Time</label><input value={form.time || ''} onChange={e => set('time', e.target.value)} placeholder="e.g. 11:00 AM – 1:00 PM" /></div>
+          <div className="form-row"><label>Venue</label><input value={form.venue || form.location || ''} onChange={e => set('venue', e.target.value)} placeholder="Auditorium / Lab" /></div>
+          <div className="form-row">
+            <label>SVG icon</label>
+            <select value={form.icon} onChange={e => set('icon', e.target.value)}>{ICONS.map(icon => <option key={icon}>{icon}</option>)}</select>
           </div>
           <div className="form-row">
             <label>Status</label>
@@ -57,18 +67,18 @@ export function EventForm({ event, onClose }) {
               {STATUSES.map(s => <option key={s} value={s}>{s}</option>)}
             </select>
           </div>
-          <div className="form-row">
-            <label>Location</label>
-            <input value={form.location} onChange={e => set('location', e.target.value)} />
-          </div>
+          <div className="form-row"><label>Presenter / guest speaker</label><input value={form.speakerName || ''} onChange={e => set('speakerName', e.target.value)} /></div>
+          <div className="form-row"><label>Speaker designation</label><input value={form.speakerTitle || ''} onChange={e => set('speakerTitle', e.target.value)} /></div>
+          <div className="form-row"><label>Jury / judges</label><input value={form.judges || ''} onChange={e => set('judges', e.target.value)} placeholder="Comma-separated names" /></div>
+          <div className="form-row"><label>Faculty in-charge</label><input value={form.facultyInCharge || ''} onChange={e => set('facultyInCharge', e.target.value)} /></div>
+          <div className="form-row"><label>Photos & videos drive link</label><input type="url" value={form.mediaDriveLink || ''} onChange={e => set('mediaDriveLink', e.target.value)} /></div>
           <div className="form-row">
             <label>Registration Link</label>
             <input value={form.registrationLink} onChange={e => set('registrationLink', e.target.value)} type="url" />
           </div>
-          <div className="form-row">
-            <label>Description</label>
-            <textarea value={form.description} onChange={e => set('description', e.target.value)} rows={3} />
-          </div>
+          <div className="form-row"><label>Overview / summary *</label><textarea value={form.description} onChange={e => set('description', e.target.value)} rows={3} required /></div>
+          <div className="form-row"><label>Topics covered</label><textarea value={form.topicsCovered || ''} onChange={e => set('topicsCovered', e.target.value)} rows={2} placeholder="Comma-separated curriculum or discussion points" /></div>
+          <div className="form-row"><label>Event highlights</label><textarea value={form.highlights || ''} onChange={e => set('highlights', e.target.value)} rows={2} /></div>
           {error && <div className="form-error">{error}</div>}
           <div className="form-actions">
             <button type="button" className="btn-secondary" onClick={onClose}>Cancel</button>

--- a/server/index.js
+++ b/server/index.js
@@ -67,6 +67,8 @@ const defaultContent = {
   ],
   activityEvents: {},
   coreTeam: [],
+  membershipApplications: [],
+  coreTeamApplications: [],
 };
 
 const SUPABASE_URL = process.env.SUPABASE_URL || '';
@@ -102,6 +104,63 @@ async function readContent() {
 async function writeContent(content) {
   await ensureContentFile();
   await fs.writeFile(CONTENT_FILE, JSON.stringify(content, null, 2), 'utf8');
+}
+
+const APPLICATION_TYPES = {
+  membership: 'membershipApplications',
+  recruitment: 'coreTeamApplications',
+  core_team: 'coreTeamApplications',
+};
+
+async function saveApplication(type, body) {
+  const key = APPLICATION_TYPES[type];
+  if (!key) throw new Error('Unknown application type');
+  const content = await readContent();
+  content[key] = Array.isArray(content[key]) ? content[key] : [];
+  const email = String(body.collegeEmail || '').trim().toLowerCase();
+  const phone = normalizePhone(body.whatsapp);
+  const duplicate = content[key].some(item =>
+    String(item.collegeEmail || '').toLowerCase() === email || (phone && normalizePhone(item.whatsapp) === phone)
+  );
+  if (duplicate) throw new Error('An application with this email or WhatsApp number already exists');
+  const application = {
+    ...body,
+    id: String(body.id || `${type}-${Date.now()}`),
+    collegeEmail: email,
+    whatsapp: phone,
+    status: 'pending',
+    submittedAt: body.submittedAt || new Date().toISOString(),
+  };
+  content[key].unshift(application);
+  await writeContent(content);
+  return application;
+}
+
+async function listApplications(type) {
+  const content = await readContent();
+  return Array.isArray(content[APPLICATION_TYPES[type]]) ? content[APPLICATION_TYPES[type]] : [];
+}
+
+async function updateApplicationStatus(type, id, status) {
+  if (!['pending', 'accepted', 'rejected', 'blacklisted'].includes(status)) throw new Error('Invalid application status');
+  const content = await readContent();
+  const apps = content[APPLICATION_TYPES[type]] || [];
+  const index = apps.findIndex(item => item.id === id);
+  if (index < 0) return null;
+  apps[index] = { ...apps[index], status, statusUpdatedAt: new Date().toISOString() };
+  await writeContent(content);
+  return apps[index];
+}
+
+async function deleteApplication(type, id) {
+  const content = await readContent();
+  const key = APPLICATION_TYPES[type];
+  const apps = content[key] || [];
+  const exists = apps.some(item => item.id === id);
+  if (!exists) return false;
+  content[key] = apps.filter(item => item.id !== id);
+  await writeContent(content);
+  return true;
 }
 
 async function supabaseRequest(pathname, { method = 'GET', body } = {}) {
@@ -172,8 +231,19 @@ function sanitizeEvent(input = {}) {
       .replace(/^-+|-+$/g, '') || `event-${Date.now()}`,
     name: toSafeString(input.name, 120),
     shortName: toSafeString(input.shortName || input.name, 60),
-    date: toSafeString(input.date, 80),
-    description: toSafeString(input.description, 1200),
+    date: toSafeString(input.date || input.dateText, 80),
+    description: toSafeString(input.description || input.overview, 1200),
+    category: toSafeString(input.category, 60),
+    speakerName: toSafeString(input.speakerName, 120),
+    speakerTitle: toSafeString(input.speakerTitle, 120),
+    judges: toSafeString(input.judges, 500),
+    topicsCovered: toSafeString(input.topicsCovered, 1200),
+    highlights: toSafeString(input.highlights, 1200),
+    facultyInCharge: toSafeString(input.facultyInCharge, 160),
+    mediaDriveLink: toSafeString(input.mediaDriveLink, 500),
+    time: toSafeString(input.time, 80),
+    venue: toSafeString(input.venue || input.location, 160),
+    registrationLink: toSafeString(input.registrationLink, 500),
     status,
     icon: toSafeString(input.icon || 'Pin', 32),
     tags,
@@ -696,17 +766,48 @@ async function handleForm(formType, req, res) {
     if (!isEmail(body.collegeEmail)) return res.status(400).json({ error: 'Invalid email address' });
     if (!isPhoneish(body.whatsapp)) return res.status(400).json({ error: 'Invalid contact number' });
 
-    const savedToSupabase = await appendToSupabaseForms(formType, body);
+    // JSON persistence is always available locally and powers the applicant suite.
+    const application = await saveApplication(formType, body);
+    const savedToSupabase = await appendToSupabaseForms(formType, application);
     try {
-      await appendFormToSheet(formType, body);
+      await appendFormToSheet(formType, application);
     } catch (sheetErr) {
-      if (!savedToSupabase) throw sheetErr;
+      if (!savedToSupabase) console.warn('Application saved locally; sheet mirror unavailable:', sheetErr.message);
     }
-    return res.json({ ok: true });
+    return res.status(201).json({ ok: true, application });
   } catch (e) {
     return res.status(500).json({ error: e?.message || 'Submission failed' });
   }
 }
+
+app.get('/api/admin/membership-apps', adminAuth, async (req, res) => {
+  try { return res.json({ apps: await listApplications('membership') }); }
+  catch (e) { return res.status(500).json({ error: e.message || 'Unable to load membership applications' }); }
+});
+app.put('/api/admin/membership-apps/:id', adminAuth, async (req, res) => {
+  try {
+    const application = await updateApplicationStatus('membership', String(req.params.id), req.body?.status);
+    return application ? res.json({ app: application }) : res.status(404).json({ error: 'Application not found' });
+  } catch (e) { return res.status(400).json({ error: e.message || 'Unable to update application' }); }
+});
+app.delete('/api/admin/membership-apps/:id', adminAuth, async (req, res) => {
+  try { return (await deleteApplication('membership', String(req.params.id))) ? res.json({ ok: true }) : res.status(404).json({ error: 'Application not found' }); }
+  catch (e) { return res.status(500).json({ error: e.message || 'Unable to delete application' }); }
+});
+app.get('/api/admin/coreteam-apps', adminAuth, async (req, res) => {
+  try { return res.json({ apps: await listApplications('core_team') }); }
+  catch (e) { return res.status(500).json({ error: e.message || 'Unable to load core team applications' }); }
+});
+app.put('/api/admin/coreteam-apps/:id', adminAuth, async (req, res) => {
+  try {
+    const application = await updateApplicationStatus('core_team', String(req.params.id), req.body?.status);
+    return application ? res.json({ app: application }) : res.status(404).json({ error: 'Application not found' });
+  } catch (e) { return res.status(400).json({ error: e.message || 'Unable to update application' }); }
+});
+app.delete('/api/admin/coreteam-apps/:id', adminAuth, async (req, res) => {
+  try { return (await deleteApplication('core_team', String(req.params.id))) ? res.json({ ok: true }) : res.status(404).json({ error: 'Application not found' }); }
+  catch (e) { return res.status(500).json({ error: e.message || 'Unable to delete application' }); }
+});
 
 app.post('/api/forms/membership', (req, res) => handleForm('membership', req, res));
 app.post('/api/forms/recruitment', (req, res) => handleForm('recruitment', req, res));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -33,6 +33,7 @@ import TeamPage            from './pages/team/TeamPage';
 import ContactPage         from './pages/contact/ContactPage';
 import RecruitmentPage     from './pages/recruitment/RecruitmentPage';
 import MembershipPage      from './pages/membership/MembershipPage';
+import AdminPage           from './pages/admin/AdminPage';
 
 import { activityPages }   from './data/activities/index';
 import { events as fallbackEvents } from './data/eventsData';
@@ -195,18 +196,56 @@ function Cursor() {
   );
 }
 
+const ROUTES = {
+  home: '/home', activities: '/activities', events: '/events', about: '/about',
+  team: '/team', contact: '/contact', membership: '/membership', recruitment: '/recruitment', admin: '/admin',
+};
+
+function locationToPage(pathname) {
+  const path = pathname.replace(/\/+$/, '') || '/';
+  if (path === '/' || path === ROUTES.home) return { page: null, tab: 'Home' };
+  if (path === ROUTES.activities) return { page: { type: 'section', section: 'Activities' }, tab: 'Activities' };
+  if (path.startsWith('/activities/')) return { page: { type: 'activity', activityKey: decodeURIComponent(path.slice(12)) }, tab: 'Activities' };
+  if (path === ROUTES.events) return { page: { type: 'section', section: 'Events' }, tab: 'Events' };
+  if (path === ROUTES.about) return { page: { type: 'section', section: 'About' }, tab: 'About' };
+  if (path === ROUTES.team) return { page: { type: 'section', section: 'Team' }, tab: 'Team' };
+  if (path === ROUTES.contact) return { page: { type: 'section', section: 'Contact' }, tab: 'Contact' };
+  if (path === ROUTES.membership) return { page: { type: 'join' }, tab: 'Home' };
+  if (path === ROUTES.recruitment || path === '/apply') return { page: { type: 'apply' }, tab: 'Home' };
+  if (path === ROUTES.admin) return { page: { type: 'admin' }, tab: 'Home' };
+  return { page: { type: 'not-found' }, tab: 'Home' };
+}
+
 export default function App() {
   // Skip intro for returning visitors; set flag on first completion
   const [cinDone,  setCinDone]  = useState(() => {
     try { return Boolean(localStorage.getItem('ns_intro_seen')); } catch { return true; }
   });
-  const [activeTab,setActiveTab]= useState('Home');
+  const [activeTab,setActiveTab]= useState(() => locationToPage(window.location.pathname).tab);
   const [mobile,   setMobile]   = useState(window.innerWidth<=768);
   const [wipeOn,   setWipeOn]   = useState(false);
   const [wipePh,   setWipePh]   = useState('out');
-  const [page,     setPage]     = useState(null);
+  const [page,     setPage]     = useState(() => locationToPage(window.location.pathname).page);
   const [theme,    setTheme]    = useState(()=>localStorage.getItem('ns-theme')||'dark');
   const [eventsData,setEventsData]=useState(fallbackEvents);
+
+  const setRoute = useCallback((path, nextPage, tab = 'Home', { replace = false } = {}) => {
+    if (window.location.pathname !== path) window.history[replace ? 'replaceState' : 'pushState']({}, '', path);
+    setPage(nextPage);
+    setActiveTab(tab);
+  }, []);
+
+  useEffect(() => {
+    if (window.location.pathname === '/') window.history.replaceState({}, '', ROUTES.home);
+    const onPopState = () => {
+      const next = locationToPage(window.location.pathname);
+      setPage(next.page);
+      setActiveTab(next.tab);
+      window.scrollTo({ top: 0 });
+    };
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
+  }, []);
   
   useEffect(()=>{
     document.documentElement.setAttribute('data-theme',theme);
@@ -328,65 +367,24 @@ export default function App() {
     },275);
   },[]);
 
-  const onTab=useCallback(tab=>{
-    
-    if(['Activities','Events','About','Team','Contact'].includes(tab)){
-      nav(()=>{setPage({type:'section',section:tab});setActiveTab(tab);});
-      return;
-    }
-    nav(()=>{
-      setPage(null);setActiveTab(tab);
-      setTimeout(()=>{
-        const el=document.getElementById(`section-${tab.toLowerCase()}`);
-        if(!el)return;
-        window.scrollTo({top:el.offsetTop-(mobile?MNH:DNH),behavior:'smooth'});
-      },50);
-    });
-  },[nav,mobile]);
+  const routeForTab = { Home: ROUTES.home, Activities: ROUTES.activities, Events: ROUTES.events, About: ROUTES.about, Team: ROUTES.team, Contact: ROUTES.contact };
+  const onTab = useCallback(tab => nav(() => {
+    const next = locationToPage(routeForTab[tab]);
+    setRoute(routeForTab[tab], next.page, tab);
+  }), [nav, setRoute]);
 
-  const onNavigate=useCallback((type,title)=>{
-    if(type==='activity') nav(()=>setPage({type:'activity',activityKey:title}));
-  },[nav]);
+  const onNavigate = useCallback((type, title) => {
+    if (type === 'activity') nav(() => setRoute(`/activities/${encodeURIComponent(title)}`, { type: 'activity', activityKey: title }, 'Activities'));
+  }, [nav, setRoute]);
 
-  const onEvent=useCallback(ev=>{
-    nav(()=>setPage(p=>({...p,type:'event',event:ev})));
-  },[nav]);
-
-  const onKSSClick=useCallback(ev=>{
-    
-    nav(()=>setPage({type:'event',activityKey:'Insight Session',event:ev}));
-  },[nav]);
-
-  const onBackAct=useCallback(()=>{
-    nav(()=>setPage(p=>({type:'activity',activityKey:p.activityKey})));
-  },[nav]);
-
-  const onBackMain=useCallback(()=>{
-    nav(()=>{
-      setPage(null);
-      setTimeout(()=>{
-        const el=document.getElementById('section-activities');
-        if(!el)return;
-        window.scrollTo({top:el.offsetTop-(mobile?MNH:DNH),behavior:'smooth'});
-      },50);
-    });
-  },[nav,mobile]);
-
-  const onBackToSection=useCallback((section)=>{
-    nav(()=>setPage({type:'section',section}));
-  },[nav]);
-
-  const openApply = useCallback(()=>{
-    nav(()=>setPage({type:'apply'}));
-  },[nav]);
-
-  const openJoin = useCallback(()=>{
-    nav(()=>setPage({type:'join'}));
-  },[nav]);
-
-  const onBackHome=useCallback(()=>{
-    nav(()=>{setPage(null);setActiveTab('Home');window.scrollTo({top:0});});
-  },[nav]);
+  const onEvent = useCallback(ev => nav(() => setRoute(`/events/${encodeURIComponent(ev.id || ev.shortName || ev.name)}`, { type: 'event', event: ev }, 'Events')), [nav, setRoute]);
+  const onKSSClick = onEvent;
+  const onBackAct = useCallback(() => nav(() => setRoute(ROUTES.activities, { type: 'section', section: 'Activities' }, 'Activities')), [nav, setRoute]);
+  const onBackMain = onBackAct;
+  const onBackToSection = useCallback(section => onTab(section), [onTab]);
+  const openApply = useCallback(() => nav(() => setRoute(ROUTES.recruitment, { type: 'apply' })), [nav, setRoute]);
+  const openJoin = useCallback(() => nav(() => setRoute(ROUTES.membership, { type: 'join' })), [nav, setRoute]);
+  const onBackHome = useCallback(() => nav(() => setRoute(ROUTES.home, null, 'Home')), [nav, setRoute]);
 
   const nh=mobile?MNH:DNH;
   const cur=page?.activityKey?activityPages[page.activityKey]:null;
@@ -421,11 +419,13 @@ export default function App() {
              {page.section === 'Team' && <TeamPage onBack={onBackHome} onApply={openApply}/>}
              {page.section === 'Contact' && <ContactPage onBack={onBackHome}/>}
              {page.type === 'activity' && cur && <ActivityDetailPage activity={cur} onBack={onBackMain} onSelectEvent={onEvent}/>}
-             {page.type === 'event' && <EventDetailPage event={page.event} onBack={onBackMain}/>}
+             {page.type === 'event' && page.event && <EventDetailPage event={page.event} onBack={onBackAct}/>}
+             {page.type === 'event' && !page.event && <EventsPage onBack={onBackHome} onEventClick={onKSSClick} events={eventsData}/>}
              {page.type === 'apply' && <RecruitmentPage onBack={onBackHome}/>}
              {page.type === 'join' && <MembershipPage onBack={onBackHome}/>}
+             {page.type === 'admin' && <AdminPage/>}
              {/* 404 fallback for unknown page types */}
-             {page.type && !['section','activity','event','apply','join'].includes(page.type) && <NotFoundPage onGoHome={onBackHome}/>}
+             {page.type && !['section','activity','event','apply','join','admin'].includes(page.type) && <NotFoundPage onGoHome={onBackHome}/>}
            </PageIn>
         ) : (
           <PageIn k="main">
@@ -443,7 +443,7 @@ export default function App() {
         )}
       </main>
 
-      <button id="back-to-top" aria-label="Back to top">↑</button>
+      <button id="back-to-top" aria-label="Back to top">Top</button>
     </>
   );
 }

--- a/src/data/storage.js
+++ b/src/data/storage.js
@@ -121,7 +121,7 @@ export function saveMembershipApplication(data) {
     console.warn('LocalStorage save failed:', e);
   }
   // Also try submitting to backend API if reachable
-  fetch(apiUrl('/api/membership'), {
+  fetch(apiUrl('/api/forms/membership'), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(newApp),

--- a/src/pages/membership/MembershipPage.jsx
+++ b/src/pages/membership/MembershipPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { saveMembershipApplication } from '../../data/storage';
 import { DynamicIcon, IconArrowLeft, IconArrowRight, IconBolt, IconShieldCheck, IconUsers } from '../../shared/Icons';
 import Footer from '../../shared/Footer';
 
@@ -30,17 +31,14 @@ const GROUP_OPTIONS    = [
 
 const MEMBERSHIP_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbyRQOW3Xjv13vXvft8ezD9sJdvjV3kf-VHm1l_mImHRDUAEqsilK0wb5QBD5GOkixwe/exec';
 
-// Helper: store a copy locally so admin dashboard can see applications
+// Persist immediately; server synchronisation is handled by the shared storage service.
 function storeMembershipLocally(payload) {
-  try {
-    const key = 'ns_db_membership_apps';
-    const existing = JSON.parse(localStorage.getItem(key) || '[]');
-    const dup = existing.find(a => a.whatsapp === payload.whatsapp);
-    if (!dup) {
-      const record = { ...payload, id: Date.now().toString(), status: 'pending', statusUpdatedAt: null };
-      localStorage.setItem(key, JSON.stringify([record, ...existing]));
-    }
-  } catch { /* ignore */ }
+  saveMembershipApplication({
+    ...payload,
+    year: payload.semester ? `Semester ${payload.semester}` : '',
+    interests: payload.groups ? payload.groups.split(',').map(value => value.trim()).filter(Boolean) : [],
+    goals: payload.whyJoin,
+  });
 }
 
 function clamp(n, min, max) { return Math.max(min, Math.min(max, n)); }
@@ -313,18 +311,14 @@ export default function MembershipPage({ onBack }) {
         formType:     'membership',
       };
 
-      const res = await fetch(MEMBERSHIP_SCRIPT_URL, {
+      // Save locally and try the platform API before contacting the optional Sheets mirror.
+      // A Sheets outage must never discard a valid application.
+      storeMembershipLocally(payload);
+      fetch(MEMBERSHIP_SCRIPT_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'text/plain;charset=utf-8' },
         body: JSON.stringify(payload),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || (data && data.ok === false)) {
-        throw new Error(data?.error || 'Membership form submission failed');
-      }
-
-      // Dual-write: store locally for admin dashboard
-      storeMembershipLocally(payload);
+      }).catch(() => {});
 
       
       try {

--- a/src/pages/recruitment/RecruitmentPage.jsx
+++ b/src/pages/recruitment/RecruitmentPage.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { saveCoreTeamApplication } from '../../data/storage';
 import { DynamicIcon, IconArrowLeft, IconArrowRight, IconBolt, IconShieldCheck, IconSpark, IconUsers } from '../../shared/Icons';
 import Footer from '../../shared/Footer';
 
@@ -213,18 +214,16 @@ const WHATSAPP_COMMUNITY = 'https://chat.whatsapp.com/FhpJEaod2g419jFMfqrhGZ';
 const LINKEDIN_PAGE      = 'https://www.linkedin.com/showcase/glbajaj-nexasphere/';
 const RECRUITMENT_SCRIPT_URL = 'https://script.google.com/macros/s/AKfycbzo1g6WNiO-f8kySE4Mqbdlh3VxZx9pRGLcjt7qyzRCNB1TMK0kRwjZbDD2UsaJFQ0q/exec';
 
-// Helper: store a copy locally so admin dashboard can see applications
+// Persist immediately; the shared storage service asynchronously syncs with the platform API.
 function storeRecruitmentLocally(payload) {
-  try {
-    const key = 'ns_db_coreteam_apps';
-    const existing = JSON.parse(localStorage.getItem(key) || '[]');
-    const dup = existing.find(a => a.collegeEmail === payload.collegeEmail);
-    if (!dup) {
-      const record = { ...payload, id: Date.now().toString(), status: 'pending', statusUpdatedAt: null };
-      localStorage.setItem(key, JSON.stringify([record, ...existing]));
-    }
-  } catch { /* ignore */ }
+  saveCoreTeamApplication({
+    ...payload,
+    domain: Array.isArray(payload.interests) ? payload.interests[0] : payload.interests,
+    skills: payload.skills || payload.skillset || '',
+    whyJoin: payload.whyJoin || payload.sop || '',
+  });
 }
+
 
 const ROLE_OPTIONS = [
   'Technical Lead',
@@ -987,15 +986,13 @@ export default function RecruitmentPage({ onBack }) {
       // Dual-write: store locally for admin dashboard
       storeRecruitmentLocally(payload);
 
-      const res = await fetch(RECRUITMENT_SCRIPT_URL, {
+      // Google Sheets is a best-effort reporting mirror. The local and API records
+      // are the source of truth, so an unavailable mirror cannot block applicants.
+      fetch(RECRUITMENT_SCRIPT_URL, {
         method: 'POST',
         headers: { 'Content-Type': 'text/plain;charset=utf-8' },
         body: JSON.stringify(payload),
-      });
-      const data = await res.json().catch(() => ({}));
-      if (!res.ok || (data && data.ok === false)) {
-        throw new Error(data?.error || 'Submission failed');
-      }
+      }).catch(() => {});
       try {
         const existing = JSON.parse(localStorage.getItem('ns_submitted_emails') || '[]');
         existing.push(emailKey);

--- a/src/pages/team/TeamMemberModal.jsx
+++ b/src/pages/team/TeamMemberModal.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { DynamicIcon } from '../../shared/Icons';
 
 function CopyPopup({ value, onClose }) {
   const [copied, setCopied] = useState(false);
@@ -23,7 +24,7 @@ function CopyPopup({ value, onClose }) {
     <div className="copy-popup">
       <span className="copy-popup-value">{value}</span>
       <button className="copy-popup-btn" onClick={handleCopy}>
-        {copied ? '✅ Copied!' : '📋 Copy'}
+        <><DynamicIcon name={copied ? 'Check' : 'Copy'} size={14} /> {copied ? 'Copied!' : 'Copy'}</>
       </button>
     </div>
   );
@@ -60,7 +61,7 @@ function ModalContent({ member, onClose }) {
     >
       <div className="modal-box">
         
-        <button className="modal-close" onClick={onClose} aria-label="Close">✕</button>
+        <button className="modal-close" onClick={onClose} aria-label="Close"><DynamicIcon name="X" size={18} /></button>
 
         
         <img src={member.photo} alt={member.name} className="modal-photo" />
@@ -72,15 +73,15 @@ function ModalContent({ member, onClose }) {
         
         <div className="modal-info">
           <div className="modal-info-row">
-            <span className="modal-info-label">🎓 Year</span>
+            <span className="modal-info-label"><DynamicIcon name="GraduationCap" size={15} /> Year</span>
             <span className="modal-info-value">{member.year}</span>
           </div>
           <div className="modal-info-row">
-            <span className="modal-info-label">🔬 Branch</span>
+            <span className="modal-info-label"><DynamicIcon name="FlaskConical" size={15} /> Branch</span>
             <span className="modal-info-value">{member.branch}</span>
           </div>
           <div className="modal-info-row">
-            <span className="modal-info-label">📋 Section</span>
+            <span className="modal-info-label"><DynamicIcon name="FileText" size={15} /> Section</span>
             <span className="modal-info-value">{member.section}</span>
           </div>
         </div>
@@ -88,7 +89,7 @@ function ModalContent({ member, onClose }) {
         
         {member.achievements && member.achievements.length > 0 && (
           <div className="modal-achievements">
-            <div className="modal-achievements-title">🏆 Achievements</div>
+            <div className="modal-achievements-title"><DynamicIcon name="Trophy" size={16} /> Achievements</div>
             <ul className="modal-achievements-list">
               {member.achievements.map((ach, idx) => (
                 <li key={idx} className="modal-achievement-item">{ach}</li>
@@ -100,7 +101,7 @@ function ModalContent({ member, onClose }) {
         
         {member.testimonials && member.testimonials.length > 0 && (
           <div className="modal-testimonials">
-            <div className="modal-testimonials-title">💬 Testimonials</div>
+            <div className="modal-testimonials-title"><DynamicIcon name="MessageSquare" size={16} /> Testimonials</div>
             <ul className="modal-testimonials-list">
               {member.testimonials.map((t, idx) => (
                 <li key={idx} className="modal-testimonial-item">
@@ -122,7 +123,7 @@ function ModalContent({ member, onClose }) {
                 rel="noopener noreferrer"
                 className="modal-social-btn btn-linkedin"
               >
-                🔗 LinkedIn
+                <DynamicIcon name="Link" size={15} /> LinkedIn
               </a>
             )}
 
@@ -135,7 +136,7 @@ function ModalContent({ member, onClose }) {
                     setActivePopup(activePopup === 'whatsapp' ? null : 'whatsapp');
                   }}
                 >
-                  💬 WhatsApp
+                  <DynamicIcon name="MessageCircle" size={15} /> WhatsApp
                 </button>
                 {activePopup === 'whatsapp' && (
                   <CopyPopup value={whatsappValue} onClose={() => setActivePopup(null)} />
@@ -150,7 +151,7 @@ function ModalContent({ member, onClose }) {
                 rel="noopener noreferrer"
                 className="modal-social-btn btn-instagram"
               >
-                📸 Instagram
+                <DynamicIcon name="Camera" size={15} /> Instagram
               </a>
             )}
 
@@ -163,7 +164,7 @@ function ModalContent({ member, onClose }) {
                     setActivePopup(activePopup === 'email' ? null : 'email');
                   }}
                 >
-                  ✉️ Email
+                  <DynamicIcon name="Mail" size={15} /> Email
                 </button>
                 {activePopup === 'email' && (
                   <CopyPopup value={member.email} onClose={() => setActivePopup(null)} />

--- a/src/shared/Chatbot.jsx
+++ b/src/shared/Chatbot.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import '../styles/chatbot.css';
+import { DynamicIcon } from './Icons';
 
 const Chatbot = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -41,7 +42,7 @@ const Chatbot = () => {
       {!isOpen ? (
         <button className="chat-trigger-btn" onClick={() => setIsOpen(true)}>
           <div className="pulse-ring"></div>
-          💬
+          <DynamicIcon name="MessageCircle" size={22} />
         </button>
       ) : (
         <div className="chat-window-glass">
@@ -68,7 +69,7 @@ const Chatbot = () => {
               onKeyDown={(e) => e.key === 'Enter' && handleSend()}
               placeholder="Query system..."
             />
-            <button onClick={handleSend} className="send-btn">🚀</button>
+            <button onClick={handleSend} className="send-btn" aria-label="Send message"><DynamicIcon name="Send" size={18} /></button>
           </div>
         </div>
       )}


### PR DESCRIPTION
### Motivation
- Unify navigation into standard browser paths (e.g. `/home`, `/activities`, `/events`, `/membership`, `/recruitment`, `/admin`) for a predictable SPA UX and deep-linking support.
- Replace ad-hoc emoji usage with the shared SVG icon system and surface richer event metadata for better presentation and discoverability.
- Provide robust dual-write intake for Membership and Core Team applications with local persistence and backend APIs so the Admin dashboard can review and manage applicants reliably.

### Description
- Implemented path-based routing and history handling in `src/App.jsx` with `ROUTES`, `locationToPage`, `setRoute`, and `popstate` handling so pages respond to URL changes and browser back/forward navigation.
- Wired client forms to the shared storage and platform API: `MembershipPage` and `RecruitmentPage` now persist immediately via helpers in `src/data/storage.js` and post to the platform endpoints at `/api/forms/*` while Google Sheets mirrors are treated as non-blocking reporting mirrors.
- Added JSON-backed applicant persistence and admin APIs in `server/index.js` including `saveApplication`, `listApplications`, `updateApplicationStatus`, and `deleteApplication` plus admin routes for `GET/PUT/DELETE /api/admin/membership-apps` and `/api/admin/coreteam-apps` with status values `pending|accepted|rejected|blacklisted`.
- Extended event sanitization and store shape in `server/index.js` to accept additional event metadata (`category`, `time`, `venue`, `speakerName`, `speakerTitle`, `judges`, `topicsCovered`, `highlights`, `facultyInCharge`, `mediaDriveLink`, `registrationLink`) and updated the admin event editor UI in `admin-dashboard/src/components/EventForm.jsx` to expose category, time/venue, speaker/jury, topics/highlights, media link and an SVG icon selector.
- Replaced inline emoji affordances with SVG icons using the shared icon system in `src/pages/team/TeamMemberModal.jsx` and `src/shared/Chatbot.jsx` so UI copy now uses `DynamicIcon` and consistent icon components.

### Testing
- Built the main client with `npm run build` and the admin app with `npm --prefix admin-dashboard run build`, both completed successfully and produced `dist` artifacts.
- Performed static/compile checks with `node --check server/index.js` and `git diff --check`, which succeeded (no syntax or diff-check errors reported).
- Executed the production `vite build` runs as part of the builds and they completed without errors.
- Attempted to run the server process; runtime start failed in this environment because `dotenv` and other server-side dependencies are not installed here (error: missing `dotenv`), so live server smoke-run could not complete in-container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9c33b2cd84832793ce36753832e507)